### PR TITLE
toolbox: removed a call to the deprecated matplotlib prctile

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1194,8 +1194,7 @@ def binHisto(data, verbose=False):
     ========
     matplotlib.pyplot.hist
     """
-    from matplotlib.mlab import prctile
-    pul = prctile(data, p=(25,75)) #get confidence interval
+    pul = np.percentile(data, (25, 75)) #get confidence interval
     ql, qu = pul[0], pul[1]
     iqr = qu-ql
     binw = 2.*iqr/(len(data)**(1./3.))


### PR DESCRIPTION
Testing the pull request workflow. There was a deprecated call in toolbox anyway. 
`matplotlib.mlab.prctile` -> `numpy.percentile`
Not really sure why we used the matplotlib version in the first place. Tests all pass with numpy. 