### PR TITLE
Reimplement dmarray and add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install; cd ..
 
 script:
- - sudo python setup.py install
+ - python setup.py install
  - cd tests; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - pip install --upgrade h5py
  - pip install --upgrade networkx
  - pip install --upgrade ffnet
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist-cdf; make OS=linux ENV=gnu all; make install
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install
 
 script:
  - sudo python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+ - "2.7"
+ - "3.5"
+ - "3.6"
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install libhdf5-serial-dev gcc gfortran
+
+install:
+ - pip install --upgrade numpy
+ - pip install --upgrade scipy
+ - pip install --upgrade matplotlib
+ - pip install --upgrade h5py
+ - pip install --upgrade networkx
+ - pip install --upgrade ffnet
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist-cdf; make OS=linux ENV=gnu all; make install
+
+script:
+ - sudo python setup.py install
+ - cd tests; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
- - "2.7"
- - "3.5"
+ - "3.5" #temporarily removed 2.7 as the build was stalling when compiling sources...
  - "3.6"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
  - python setup.py install
- - cd tests; export CDF_LIB=$HOME; python test_spacepy.py
+ - cd tests; . /home/travis/bin/definitions.B; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ install:
  - pip install --upgrade ffnet
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
+before_script:
+ - "export DISPLAY=:99.0" #Travis has no X11, so we dummy this here to allow our graphical tests to run
+ - "sh -e /etc/init.d/xvfb start"
+ - sleep 3 # give xvfb some time to start
+
 script:
  - python setup.py install
  - cd tests; . /home/travis/bin/definitions.B; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
  - pip install --upgrade h5py
  - pip install --upgrade networkx
  - pip install --upgrade ffnet
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install; cd ..
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
 script:
  - python setup.py install
- - cd tests; python test_spacepy.py
+ - cd tests; export CDF_LIB=$HOME; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - pip install --upgrade h5py
  - pip install --upgrade networkx
  - pip install --upgrade ffnet
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install; cd ..
 
 script:
  - sudo python setup.py install

--- a/developer/benchmarks/pycdf/entry_typing.py
+++ b/developer/benchmarks/pycdf/entry_typing.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+"""Test assigning to zEntries and type guessing...hoping to speed this up"""
+
+import itertools
+import os
+import os.path
+import time
+
+from spacepy import pycdf
+
+if os.path.exists('foo.cdf'):
+    os.remove('foo.cdf')
+
+with pycdf.CDF('foo.cdf', '') as f:
+    for i in range(100):
+        f.new('DOUBLE_{0}'.format(i), type=pycdf.const.CDF_DOUBLE)
+        f.new('INT_{0}'.format(i), type=pycdf.const.CDF_INT4)
+        f.new('STR_{0}'.format(i), type=pycdf.const.CDF_CHAR,
+                      n_elements=10)
+    for i in range(100):
+        for aname in ['{0}_{1}'.format(*p) for p in itertools.product(
+                ('VALIDMIN', 'VALIDMAX', 'SCALEMIN', 'SCALEMAX', 'FILLVAL'),
+                range(10))]:
+            f['DOUBLE_{0}'.format(i)].attrs.new(
+                aname, type=pycdf.const.CDF_DOUBLE)
+            f['INT_{0}'.format(i)].attrs.new(
+                aname, type=pycdf.const.CDF_INT4)
+            f['STR_{0}'.format(i)].attrs.new(
+                aname, type=pycdf.const.CDF_CHAR)
+        for aname in ('DEPEND_0', 'DEPEND_1', 'DEPEND_2'):
+            for varname in ('DOUBLE', 'INT', 'STR'):
+                f['{0}_{1}'.format(varname, i)].attrs.new(
+                    aname, type=pycdf.const.CDF_CHAR)
+    t = time.time()
+    f['STR_0'].attrs['stuff'] = 1
+    print(time.time() - t)

--- a/spacepy/data/tai-utc.dat
+++ b/spacepy/data/tai-utc.dat
@@ -37,3 +37,5 @@
  2006 JAN  1 =JD 2453736.5  TAI-UTC=  33.0       S + (MJD - 41317.) X 0.0      S
  2009 JAN  1 =JD 2454832.5  TAI-UTC=  34.0       S + (MJD - 41317.) X 0.0      S
  2012 JUL  1 =JD 2456109.5  TAI-UTC=  35.0       S + (MJD - 41317.) X 0.0      S
+ 2015 JUL  1 =JD 2457204.5  TAI-UTC=  36.0       S + (MJD - 41317.) X 0.0      S
+ 2017 JAN  1 =JD 2457754.5  TAI-UTC=  37.0       S + (MJD - 41317.) X 0.0      S

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3522,7 +3522,7 @@ class _Hyperslice(object):
         d = numpy.asanyarray(data)
         if d.dtype == numpy.object: #this is probably going to be bad
             try:
-                len(d.flat[0])
+                len(d.flatten()[0])
             except TypeError: #at least it's not a list
                 pass
             else:

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -364,7 +364,8 @@ class dmarrayTests(unittest.TestCase):
         tmp = pickle.dumps(self.dat)
         for i, val in enumerate(self.dat):
             self.assertEqual(pickle.loads(tmp)[i], val)
-        self.assertEqual(pickle.loads(tmp).attrs, self.dat.attrs)
+        reloaded = pickle.loads(tmp)
+        self.assertEqual(reloaded.attrs, self.dat.attrs)
 
     def test_pickle_dump(self):
         """things should pickle and unpickle to a file"""
@@ -381,55 +382,12 @@ class dmarrayTests(unittest.TestCase):
         np.testing.assert_almost_equal(self.dat, dat2)
         self.assertEqual(self.dat.attrs, dat2.attrs)
 
-    def test_attrs_only(self):
-        """dmarray can only have .attrs"""
-        self.assertRaises(TypeError, dm.dmarray, [1,2,3], setme = 123 )
-
-    def test_more_attrs(self):
-        """more attrs are allowed if they are predefined"""
-        a = dm.dmarray([1,2,3])
-        a.Allowed_Attributes = a.Allowed_Attributes + ['blabla']
-        a.blabla = {}
-        a.blabla['foo'] = 'you'
-        self.assertEqual(a.blabla['foo'], 'you')
-
     def test_extra_pickle(self):
-        """Extra attrs are pickled and unpicked"""
-        self.dat.addAttribute('blabla', {'foo':'you'})
+        """Unsupported attributes are lost on pickle/unpickle"""
+        self.dat.blabla = {'foo':'you'}
         val = pickle.dumps(self.dat)
         b = pickle.loads(val)
-        self.assertTrue('blabla' in b.Allowed_Attributes)
-        self.assertEqual(b.blabla['foo'], 'you')
-
-    def test_extra_pickle2(self):
-        """Order should not matter of Allowed_Attributes"""
-        # added new one to the front
-        self.dat.Allowed_Attributes = ['foo'] + self.dat.Allowed_Attributes
-        self.dat.foo = 'bar'
-        val = pickle.dumps(self.dat)
-        b = pickle.loads(val)
-        self.assertTrue('foo' in b.Allowed_Attributes)
-        self.assertEqual(b.foo, 'bar')
-
-    def test_addAttribute(self):
-        """addAttribute should work"""
-        a = dm.dmarray([1,2,3])
-        a.addAttribute('bla')
-        self.assertEqual(a.bla, None)
-        a.addAttribute('bla2', {'foo': 'bar'})
-        self.assertEqual(a.bla2['foo'], 'bar')
-        self.assertRaises(NameError, a.addAttribute, 'bla2')
-
-    def test_attrs(self):
-        """The only attribute the can be set is attrs"""
-        self.assertRaises(TypeError, dm.dmarray, [1,2,3], bbb=23)
-        try:
-            self.dat.bbb = 'someval'
-        except TypeError:
-            pass
-        else:
-            self.fail(
-                'Assigning to arbitrary Python attribute should raise TypeError')
+        self.assertRaises(AttributeError, b.__getattribute__, 'blabla')
 
     def test_dmfilled(self):
         """dmfilled should fill an array"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1584,7 +1584,7 @@ class ReadCDF(CDFTests):
             orig = self.cdf[key][...]
             cp = cdfcopy[key]
             self.assertEqual(orig.shape, cp.shape)
-            numpy.testing.assert_array_equal(orig.flat, cp.flat)
+            numpy.testing.assert_array_equal(orig.flatten(), cp.flatten())
             self.assertFalse(self.cdf[key] is cdfcopy[key])
         for key in self.cdf.attrs:
             self.assertEqual(self.cdf.attrs[key][:], cdfcopy.attrs[key])
@@ -2620,8 +2620,8 @@ class ChangezVar(ChangeCDFBase):
             SectorRateScalersCountsCopy[...].shape,
             self.cdf['SectorRateScalersCounts'][...].shape)
         numpy.testing.assert_array_equal(
-            SectorRateScalersCountsCopy[...].flat,
-            self.cdf['SectorRateScalersCounts'][...].flat)
+            SectorRateScalersCountsCopy[...].flatten(),
+            self.cdf['SectorRateScalersCounts'][...].flatten())
 
         oldlen = len(self.cdf['SectorRateScalersCounts'])
         del self.cdf['SectorRateScalersCounts'][-1:-5]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -202,15 +202,32 @@ class TimeFunctionTests(unittest.TestCase):
                            datetime.datetime(2000, 1, 12, 1, 52, 50, 481431),
                            datetime.datetime(2000, 1, 7, 6, 30, 26, 331312),
                            datetime.datetime(2000, 1, 13, 16, 17, 48, 619577)])
-        numpy.testing.assert_array_equal(ans, t.randomDate(dt1, dt2, 5, sorted=False))
+        ntests = len(ans)
+        res = t.randomDate(dt1, dt2, ntests, sorted=False)
+        #results are different at microsecond level between Python2 and Python3
+        #one likely cause is the difference in behavior of round() between versions
+        #so, we'll round off all the microseconds fields here
+        for ii in range(ntests):
+            ans[ii] = ans[ii].replace(microsecond=100*(ans[ii].microsecond//100))
+            res[ii] = res[ii].replace(microsecond=100*(res[ii].microsecond//100))
+        #TODO: improve testing for randomDate
+        numpy.testing.assert_array_equal(ans, res)
         # check the exception
         dt11 = num2date(date2num(dt1))
         self.assertRaises(ValueError, t.randomDate, dt11, dt2)
         ans.sort()
+
         numpy.random.seed(8675309)
-        numpy.testing.assert_array_equal(ans, t.randomDate(dt1, dt2, 5, sorted=True))
+        res = t.randomDate(dt1, dt2, ntests, sorted=True)
+        for ii in range(ntests):
+            res[ii] = res[ii].replace(microsecond=100*(res[ii].microsecond//100))
+        numpy.testing.assert_array_equal(ans, res)
+
         numpy.random.seed(8675309)
-        numpy.testing.assert_array_equal(ans, t.randomDate(dt1, dt2, 5, sorted=True, tzinfo='MDT'))
+        res = t.randomDate(dt1, dt2, ntests, sorted=True, tzinfo='MDT')
+        for ii in range(ntests):
+            res[ii] = res[ii].replace(microsecond=100*(res[ii].microsecond//100))
+        numpy.testing.assert_array_equal(ans, res)
 
     def test_extract_YYYYMMDD(self):
         """extract_YYYYMMDD() should give known results"""


### PR DESCRIPTION
Major changes:
- Added .travis.yml file to set up Travis CI and build/run test suite
- Reimplemented dmarray so it's a subclass of numpy.ma.MaskedArray, not of numpy.ndarray
- pycdf update to not compare or slice iterators in testing and check_well_formed method
- Updated included leapsecond file
- fix to test_time.py: test_randomDate regression test as expected result differs between 2.7 and 3.6

dmarray modifications fix issue #12  

[Test results for my branch](https://travis-ci.com/drsteve/spacepy)
Only 3.5 and 3.6 are currently tested here as the 2.7 build was freezing (on Travis) on compiling C sources. All tests on 2.7 pass on my local machine.