### PR TITLE
pycdf: handle reading empty NRV variables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ pycdf
  - Allow insert, append on gAttrs
  - Properly handle reading from empty variables
  - Fix some type-guessing ordering in Python 3.6
+ - Reading empty NRV variables will now return empty array (not padding)
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================


### PR DESCRIPTION
We had some issues with accidentally reading NRV variables that had never been written to; basically this returned default CDF pad data (not desired). I got this to work more like RV variables with the exception of scalars, which I don't even know what should be the right behavior. I'm going to open an issue for that; in the meantime, this should be a substantial improvement.