### PR TITLE
Add continuous integration using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install; cd ..
 
 script:
- - sudo python setup.py install
+ - python setup.py install
  - cd tests; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - pip install --upgrade h5py
  - pip install --upgrade networkx
  - pip install --upgrade ffnet
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist-cdf; make OS=linux ENV=gnu all; make install
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install
 
 script:
  - sudo python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+ - "2.7"
+ - "3.5"
+ - "3.6"
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install libhdf5-serial-dev gcc gfortran
+
+install:
+ - pip install --upgrade numpy
+ - pip install --upgrade scipy
+ - pip install --upgrade matplotlib
+ - pip install --upgrade h5py
+ - pip install --upgrade networkx
+ - pip install --upgrade ffnet
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist-cdf; make OS=linux ENV=gnu all; make install
+
+script:
+ - sudo python setup.py install
+ - cd tests; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
- - "2.7"
- - "3.5"
+ - "3.5" #temporarily removed 2.7 as the build was stalling when compiling sources...
  - "3.6"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
 
 script:
  - python setup.py install
- - cd tests; export CDF_LIB=$HOME; python test_spacepy.py
+ - cd tests; . /home/travis/bin/definitions.B; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ install:
  - pip install --upgrade ffnet
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
+before_script:
+ - "export DISPLAY=:99.0" #Travis has no X11, so we dummy this here to allow our graphical tests to run
+ - "sh -e /etc/init.d/xvfb start"
+ - sleep 3 # give xvfb some time to start
+
 script:
  - python setup.py install
  - cd tests; . /home/travis/bin/definitions.B; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
  - pip install --upgrade h5py
  - pip install --upgrade networkx
  - pip install --upgrade ffnet
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install; cd ..
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
 script:
  - python setup.py install
- - cd tests; python test_spacepy.py
+ - cd tests; export CDF_LIB=$HOME; python test_spacepy.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
  - pip install --upgrade h5py
  - pip install --upgrade networkx
  - pip install --upgrade ffnet
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzvf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make install; cd ..
 
 script:
  - sudo python setup.py install

--- a/spacepy/data/tai-utc.dat
+++ b/spacepy/data/tai-utc.dat
@@ -37,3 +37,5 @@
  2006 JAN  1 =JD 2453736.5  TAI-UTC=  33.0       S + (MJD - 41317.) X 0.0      S
  2009 JAN  1 =JD 2454832.5  TAI-UTC=  34.0       S + (MJD - 41317.) X 0.0      S
  2012 JUL  1 =JD 2456109.5  TAI-UTC=  35.0       S + (MJD - 41317.) X 0.0      S
+ 2015 JUL  1 =JD 2457204.5  TAI-UTC=  36.0       S + (MJD - 41317.) X 0.0      S
+ 2017 JAN  1 =JD 2457754.5  TAI-UTC=  37.0       S + (MJD - 41317.) X 0.0      S

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1597,7 +1597,7 @@ class ReadCDF(CDFTests):
             orig = self.cdf[key][...]
             cp = cdfcopy[key]
             self.assertEqual(orig.shape, cp.shape)
-            numpy.testing.assert_array_equal(orig.flat, cp.flat)
+            numpy.testing.assert_array_equal(orig.flatten(), cp.flatten())
             self.assertFalse(self.cdf[key] is cdfcopy[key])
         for key in self.cdf.attrs:
             self.assertEqual(self.cdf.attrs[key][:], cdfcopy.attrs[key])
@@ -2633,8 +2633,8 @@ class ChangezVar(ChangeCDFBase):
             SectorRateScalersCountsCopy[...].shape,
             self.cdf['SectorRateScalersCounts'][...].shape)
         numpy.testing.assert_array_equal(
-            SectorRateScalersCountsCopy[...].flat,
-            self.cdf['SectorRateScalersCounts'][...].flat)
+            SectorRateScalersCountsCopy[...].flatten(),
+            self.cdf['SectorRateScalersCounts'][...].flatten())
 
         oldlen = len(self.cdf['SectorRateScalersCounts'])
         del self.cdf['SectorRateScalersCounts'][-1:-5]

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -202,15 +202,32 @@ class TimeFunctionTests(unittest.TestCase):
                            datetime.datetime(2000, 1, 12, 1, 52, 50, 481431),
                            datetime.datetime(2000, 1, 7, 6, 30, 26, 331312),
                            datetime.datetime(2000, 1, 13, 16, 17, 48, 619577)])
-        numpy.testing.assert_array_equal(ans, t.randomDate(dt1, dt2, 5, sorted=False))
+        ntests = len(ans)
+        res = t.randomDate(dt1, dt2, ntests, sorted=False)
+        #results are different at microsecond level between Python2 and Python3
+        #one likely cause is the difference in behavior of round() between versions
+        #so, we'll round off all the microseconds fields here
+        for ii in range(ntests):
+            ans[ii] = ans[ii].replace(microsecond=100*(ans[ii].microsecond//100))
+            res[ii] = res[ii].replace(microsecond=100*(res[ii].microsecond//100))
+        #TODO: improve testing for randomDate
+        numpy.testing.assert_array_equal(ans, res)
         # check the exception
         dt11 = num2date(date2num(dt1))
         self.assertRaises(ValueError, t.randomDate, dt11, dt2)
         ans.sort()
+
         numpy.random.seed(8675309)
-        numpy.testing.assert_array_equal(ans, t.randomDate(dt1, dt2, 5, sorted=True))
+        res = t.randomDate(dt1, dt2, ntests, sorted=True)
+        for ii in range(ntests):
+            res[ii] = res[ii].replace(microsecond=100*(res[ii].microsecond//100))
+        numpy.testing.assert_array_equal(ans, res)
+
         numpy.random.seed(8675309)
-        numpy.testing.assert_array_equal(ans, t.randomDate(dt1, dt2, 5, sorted=True, tzinfo='MDT'))
+        res = t.randomDate(dt1, dt2, ntests, sorted=True, tzinfo='MDT')
+        for ii in range(ntests):
+            res[ii] = res[ii].replace(microsecond=100*(res[ii].microsecond//100))
+        numpy.testing.assert_array_equal(ans, res)
 
     def test_extract_YYYYMMDD(self):
         """extract_YYYYMMDD() should give known results"""


### PR DESCRIPTION
This PR:
- adds .travis.yml to set up the Travis CI runs. It uses Python 3.5 and 3.6.
- updates the default leapsecond data so that some tests now pass without needing to pull updated leapsecond data using `spacepy.toolbox.update` (tests would pass for local installs with an up-to-date set of leapseconds in the `.spacepy` folder, but not on a clean container)
- `test_time` was updated so that the regression test for `randomDate` passes on Python 2.x and 3.x, which appear to round the microseconds differently (issue is upstream of us, probably in the rounding used by `date2num`)
- resolves issue #7 with the currently listed caveat that the 2.7 build seemed to stall on Travis, so CI only covers 3.5 and 3.6. 

TravisCI results for this branch can be found at [https://travis-ci.com/drsteve/spacepy/builds/81975789](https://travis-ci.com/drsteve/spacepy/builds/81975789)