### PR TITLE
pycdf: fix typo 'ctype' instead of 'ctypes'

### DIFF
--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -233,7 +233,7 @@ class Library(object):
                         'Try \'os.environ["CDF_LIB"] = library_directory\' '
                         'before import.').format(', '.join(self.libpath)))
             else:
-                self._library = ctype.CDLL(libpath)
+                self._library = ctypes.CDLL(libpath)
                 self.libpath = libpath
         else:
             self._library = library


### PR DESCRIPTION
Found this with mk1 eyeball; it's hit only in very rare circumstances, which is why it hasn't shown up before.