### PR TITLE
Fixing matplotlib deprecated/removed features

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -855,8 +855,8 @@ setup_kwargs = {
     'url': 'http://spacepy.lanl.gov',
 #download_url will override pypi, so leave it out http://stackoverflow.com/questions/17627343/why-is-my-package-not-pulling-download-url
 #    'download_url': 'https://sourceforge.net/projects/spacepy/files/spacepy/',
-    'requires': ['numpy', 'scipy', 'matplotlib (>=0.99)', 'python_dateutil',
-                 'h5py', 'python (>=2.6, !=3.0)'],
+    'requires': ['numpy (>=1.6)', 'scipy (>=0.10)', 'matplotlib (>=1.5)', 'python_dateutil',
+                 'h5py', 'python (>=2.7, !=3.0)'],
     'packages': packages,
     'package_data': {'spacepy': package_data},
     'classifiers': [
@@ -891,10 +891,9 @@ setup_kwargs = {
 if use_setuptools:
 #Sadly the format here is DIFFERENT than the distutils format
     setup_kwargs['install_requires'] = [
-        'numpy>=1.4',
-        #Probably pessimistic, but I KNOW 0.7 works
-        'scipy>=0.7',
-        'matplotlib>=0.99',
+        'numpy>=1.6',
+        'scipy>=0.10',
+        'matplotlib>=1.5',
         'h5py',
         'ffnet',
         #ffnet needs networkx but not marked as requires, so to get it via pip

--- a/spacepy/data/spacepy.mplstyle
+++ b/spacepy/data/spacepy.mplstyle
@@ -14,7 +14,7 @@ lines.linewidth: 1.2
 
 font.size: 13.0
 
-axes.color_cycle: royalblue, seagreen, crimson, gold, saddlebrown, black, cyan, magenta
+axes.prop_cycle: cycler(color=['royalblue', 'seagreen', 'crimson', 'gold', 'saddlebrown', 'black', 'cyan', 'magenta'])
 axes.facecolor: ECECEC     #a little bit darker than 'whitesmoke'
 axes.edgecolor: 0.45
 axes.linewidth: 1.25

--- a/spacepy/data/spacepy_altgrid.mplstyle
+++ b/spacepy/data/spacepy_altgrid.mplstyle
@@ -14,7 +14,7 @@ lines.linewidth: 1.2
 
 font.size: 13.0
 
-axes.color_cycle: royalblue, seagreen, crimson, gold, saddlebrown, black, cyan, magenta
+axes.prop_cycle: cycler(color=['royalblue', 'seagreen', 'crimson', 'gold', 'saddlebrown', 'black', 'cyan', 'magenta'])
 axes.facecolor: white
 axes.edgecolor: 0.45
 axes.linewidth: 1.25

--- a/spacepy/data/spacepy_polar.mplstyle
+++ b/spacepy/data/spacepy_polar.mplstyle
@@ -14,7 +14,7 @@ lines.linewidth: 1.2
 
 font.size: 13.0
 
-axes.color_cycle: royalblue, seagreen, crimson, gold, saddlebrown, black, cyan, magenta
+axes.prop_cycle: cycler(color=['royalblue', 'seagreen', 'crimson', 'gold', 'saddlebrown', 'black', 'cyan', 'magenta'])
 axes.facecolor: ECECEC     #a little bit darker than 'whitesmoke'
 axes.edgecolor: 0.45
 axes.linewidth: 1.25

--- a/spacepy/poppy.py
+++ b/spacepy/poppy.py
@@ -65,7 +65,6 @@ import warnings
 import datetime as dt
 
 import numpy as np
-import matplotlib.mlab
 
 from spacepy import help
 #Try to pull in the C version. Assumption is that if you import this module,
@@ -217,7 +216,6 @@ class PPro(object):
                 first_idx = [bisect.bisect_left(p2, starts[nss] + self.lags[ilag])
                              for nss in nss_list]
                 self.n_assoc[ilag, :] = [last_idx[i] - first_idx[i] for i in nss_list]
-            pul = matplotlib.mlab.prctile_rank(lags, p=(20,80))
         else:
             def fracday(dd):
                 '''turn a timedelta into a fractional day'''
@@ -244,10 +242,11 @@ class PPro(object):
             n_assoc = self.n_assoc.ctypes.data_as(lib.lptr)
             lib.assoc(p2, p1, lags.ctypes.data_as(lib.dptr), n_assoc,
                       winhalf, len(p2), len(p1), len(self.lags))
-            pul = matplotlib.mlab.prctile_rank(lags, p=(20,80))
+        left20perc = int(np.round((len(lags)*0.2)))
+        right20perc = int(np.round((len(lags)*0.8)))
         self.assoc_total = np.sum(self.n_assoc, axis=1)
-        valsL = self.assoc_total[pul==0]
-        valsR = self.assoc_total[pul==2]
+        valsL = self.assoc_total[:left20perc]
+        valsR = self.assoc_total[right20perc:]
         self.asympt_assoc = np.mean([np.mean(valsL), np.mean(valsR)])
 
         self.expected = np.empty([len(self.lags)], dtype='float64')

--- a/spacepy/seapy.py
+++ b/spacepy/seapy.py
@@ -528,7 +528,6 @@ class Sea(SeaBase):
         else:
             ax0.fill_between(self.x, self.bound_low.ravel(), self.bound_high.ravel(),
                              edgecolor='none', facecolor=color, interpolate=True)
-        plt.hold(True)
         ax0.plot(self.x, self.semedian, 'k-', lw=2.0)
         ax0.plot(self.x, self.semean, 'r--', lw=1.25)
         plt.xlabel(xlstr)
@@ -1018,7 +1017,6 @@ def sea_signif(obj1, obj2, test='KS', show=True, xquan = 'Time Since Epoch',
     ax1 = fig.add_subplot(212, position=[pos.bounds[0], 0.1, pos.bounds[2], 0.25])
     #overlay superposed epochs
     ax0.plot(obj1.x, obj1.semedian, lw=1.5)
-    plt.hold(True)
     ax0.plot(obj1.x, obj1.bound_high, color='royalblue', ls='--')
     ax0.plot(obj1.x, obj1.bound_low, color='royalblue', ls='--')
     ax0.plot(obj2.x, obj2.semedian, color='crimson', lw=1.5)

--- a/spacepy/seapy.py
+++ b/spacepy/seapy.py
@@ -322,10 +322,9 @@ class Sea(SeaBase):
         self.bound_high = np.zeros((m,1))
 
         if kwargs['quartiles']:
-            from matplotlib.mlab import prctile
             for i in range(m):
                 dum = np.sort(y_sea_m[:,i].compressed())
-                qul = prctile(dum,p=(25,75))
+                qul = np.percentile(dum, (25,75))
                 self.bound_low[i], self.bound_high[i] = qul[0], qul[1]
                 self.bound_type = 'quartiles'
         elif kwargs['ci']: #bootstrapped confidence intervals (95%)
@@ -440,10 +439,9 @@ class Sea(SeaBase):
         #outobj.bound_high = np.zeros((m,1))
 
         #if quartiles:
-            #from matplotlib.mlab import prctile
             #for i in range(m):
                 #dum = np.sort(y_sea_m[:,i].compressed())
-                #qul = prctile(dum,p=(25,75))
+                #qul = np.percentile(dum, (25,75))
                 #outobj.bound_low[i], outobj.bound_high[i] = qul[0], qul[1]
         #elif ci: #bootstrapped confidence intervals (95%)
             #from spacepy.poppy import boots_ci

--- a/tests/test_poppy.py
+++ b/tests/test_poppy.py
@@ -15,7 +15,6 @@ except ImportError:
 import sys
 import unittest
 
-import matplotlib.mlab
 import numpy
 import numpy.random
 import scipy.special
@@ -287,7 +286,7 @@ class ValuePercentileTests(unittest.TestCase):
         for sequence, target in zip(sequences, targets):
             for t in target:
                 result = poppy.value_percentile(sequence, t)
-                rt_target = matplotlib.mlab.prctile(sequence, result)
+                rt_target = numpy.percentile(sequence, result)
                 if result == 0.0:
                     self.assertTrue(t <= rt_target)
                 elif result == 100.0:

--- a/tests/test_spacepy.py
+++ b/tests/test_spacepy.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     import unittest as ut
 
+from test_pybats import *
 from test_time import *
 from test_empiricals import *
 from test_toolbox import *
@@ -34,7 +35,6 @@ from test_base import *
 from test_plot_utils import *
 from test_rst import *
 from test_lib import *
-from test_pybats import *
 from test_ae9ap9 import *
 # add others here as they are written
 


### PR DESCRIPTION
SpacePy had a few matplotlib calls that were deprecated a while back, as well as using a color_cycler object in the plot styles. The color_cycler has been replaced with a properties cycler requiring a different syntax in the style file.

The commits in this PR remove or replace all of the deprecated/removed calls to matplotlib keeping us compatible with the latest matplotlib and removing all of the matplotlib warnings that I've hit... This PR resolves #22 
As discussed in issue #8, this also requires bumping the required versions of dependencies, and I've updated the setup.py accordingly.