### PR TITLE
pycdf: fix more BAD_ENTRY_NUM (closes #25)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ pycdf
  - Properly handle reading from empty variables
  - Fix some type-guessing ordering in Python 3.6
  - Reading empty NRV variables will now return empty array (not padding)
+ - Fix more cases of BAD_ENTRY_NUM when reading attribute entries
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4131,7 +4131,7 @@ class Attr(collections.MutableSequence):
             raise IndexError('list index ' + str(number) + ' out of range.')
         count = ctypes.c_long(0)
         self._call(
-            const.SELECT_, self.ENTRY_, number,
+            const.SELECT_, self.ENTRY_, ctypes.c_long(number),
             const.GET_, self.ENTRY_NUMELEMS_, ctypes.byref(count))
         return count.value
 
@@ -4315,7 +4315,7 @@ class Attr(collections.MutableSequence):
             buff = numpy.empty((length,), lib.numpytypedict[cdftype],
                                order='C')
         buff = numpy.require(buff, requirements=('C', 'A', 'W'))
-        self._call(const.SELECT_, self.ENTRY_, number,
+        self._call(const.SELECT_, self.ENTRY_, ctypes.c_long(number),
                    const.GET_, self.ENTRY_DATA_,
                    buff.ctypes.data_as(ctypes.c_void_p))
 


### PR DESCRIPTION
I couldn't actually reproduce this but that might have been from having to comment a bunch of stuff out to make the triggering script run, or maybe it was just bad luck. This just cleans up a few places that are likely the trigger.