### PR TITLE
Update the sphinx math for newer sphinx

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.ifconfig',
+              'sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode', 'numpydoc',
               'sphinx.ext.inheritance_diagram',
               'sphinx.ext.autosummary', 'sphinx.ext.extlinks',

--- a/Doc/source/doc_standard.rst
+++ b/Doc/source/doc_standard.rst
@@ -16,7 +16,7 @@ In addition to Sphinx, SpacePy uses the following extensions:
  * 'sphinx.ext.doctest''
  * 'sphinx.ext.intersphinx'
  * 'sphinx.ext.todo'
- * 'sphinx.ext.pngmath'
+ * 'sphinx.ext.imgmath'
  * 'sphinx.ext.ifconfig'
  * 'sphinx.ext.viewcode'
  * 'numpydoc'


### PR DESCRIPTION
 docs: update the sphinx packages to handle the new versions. As of 1.8.0 sphinx.ext.pngmath is gone replaced by sphinx.ext.imgmath. This works back to sphinx==1.4. This is related to #35.

Doing this adds a dependency for sphinx>=1.4.