### PR TITLE
docs: Replace pngmath with imgmath (closes #35)

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -26,11 +26,16 @@ sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
+try: #Sphinx 1.4 and later replaces pngmath with imgmath
+    import sphinx.ext.imgmath
+    imgmath = 'sphinx.ext.imgmath'
+except NameError:
+    imgmath = 'sphinx.ext.pngmath'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx',
-              'sphinx.ext.todo', 'sphinx.ext.pngmath', 'sphinx.ext.ifconfig',
+              'sphinx.ext.todo', imgmath, 'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode', 'numpydoc',
               'sphinx.ext.inheritance_diagram',
               'sphinx.ext.autosummary', 'sphinx.ext.extlinks',

--- a/Doc/source/doc_standard.rst
+++ b/Doc/source/doc_standard.rst
@@ -16,7 +16,7 @@ In addition to Sphinx, SpacePy uses the following extensions:
  * 'sphinx.ext.doctest''
  * 'sphinx.ext.intersphinx'
  * 'sphinx.ext.todo'
- * 'sphinx.ext.imgmath'
+ * 'sphinx.ext.imgmath' (falls back to 'sphinx.ext.pngmath' if imgmath is not available)
  * 'sphinx.ext.ifconfig'
  * 'sphinx.ext.viewcode'
  * 'numpydoc'

--- a/Doc/source/doc_standard.rst
+++ b/Doc/source/doc_standard.rst
@@ -16,7 +16,7 @@ In addition to Sphinx, SpacePy uses the following extensions:
  * 'sphinx.ext.doctest''
  * 'sphinx.ext.intersphinx'
  * 'sphinx.ext.todo'
- * 'sphinx.ext.pngmath'
+ * 'sphinx.ext.imgmath'
  * 'sphinx.ext.ifconfig'
  * 'sphinx.ext.viewcode'
  * 'numpydoc'


### PR DESCRIPTION
Duelling PR here, but I see no reason to pick up a version dependency when we can work around it.