### PR TITLE
Test against specific numpy versions, plus latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ matrix:
  include:
   - python: 2.7
     env: NUMPY_VERSION="==1.15.2"
+  - python: 2.7
     env: NUMPY_VERSION="==1.13.3"
+  - python: 2.7
     env: NUMPY_VERSION="==1.11.3"
   - python: 3.5
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
+  - python: 2.7
     env: NUMPY_VERSION="==1.13.3"
   - python: 3.6
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
+  - python: 2.7
     env: NUMPY_VERSION="==1.13.3"
 
 before_install:
@@ -18,7 +22,7 @@ before_install:
  - sudo apt-get install libhdf5-serial-dev gcc gfortran
 
 install:
- - pip install --force-reinstall numpy$NUMPY_VERSION
+ - pip install --force-reinstall "numpy${NUMPY_VERSION}"
  - pip install scipy
  - pip install matplotlib
  - pip install h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,11 @@ before_install:
 
 install:
  - pip install --force-reinstall numpy==$NUMPY_VERSION
- - pip install --upgrade scipy
- - pip install --upgrade matplotlib
- - pip install --upgrade h5py
- - pip install --upgrade networkx
- - pip install --upgrade ffnet
+ - pip install scipy
+ - pip install matplotlib
+ - pip install h5py
+ - pip install networkx
+ - pip install ffnet
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,28 @@
 language: python
-python:
- - "3.5" #temporarily removed 2.7 as the build was stalling when compiling sources...
- - "3.6"
+
+matrix:
+ include:
+  - python: 2.7
+    env: NUMPY_VERSION=1.15.2
+  - python: 2.7
+    env: NUMPY_VERSION=1.13.3
+  - python: 2.7
+    env: NUMPY_VERSION=1.11.3
+  - python: 3.5
+    env: NUMPY_VERSION=1.15.2
+  - python: 3.5
+    env: NUMPY_VERSION=1.13.3
+  - python: 3.6
+    env: NUMPY_VERSION=1.15.2
+  - python: 3.6
+    env: NUMPY_VERSION=1.13.3
 
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install libhdf5-serial-dev gcc gfortran
 
 install:
- - pip install --upgrade numpy
+ - pip install --force-reinstall numpy==$NUMPY_VERSION
  - pip install --upgrade scipy
  - pip install --upgrade matplotlib
  - pip install --upgrade h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,22 @@ language: python
 matrix:
  include:
   - python: 2.7
-    env: NUMPY_VERSION=1.15.2
-  - python: 2.7
-    env: NUMPY_VERSION=1.13.3
-  - python: 2.7
-    env: NUMPY_VERSION=1.11.3
+    env: NUMPY_VERSION="==1.15.2"
+    env: NUMPY_VERSION="==1.13.3"
+    env: NUMPY_VERSION="==1.11.3"
   - python: 3.5
-    env: NUMPY_VERSION=1.15.2
-  - python: 3.5
-    env: NUMPY_VERSION=1.13.3
+    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+    env: NUMPY_VERSION="==1.13.3"
   - python: 3.6
-    env: NUMPY_VERSION=1.15.2
-  - python: 3.6
-    env: NUMPY_VERSION=1.13.3
+    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+    env: NUMPY_VERSION="==1.13.3"
 
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install libhdf5-serial-dev gcc gfortran
 
 install:
- - pip install --force-reinstall numpy==$NUMPY_VERSION
+ - pip install --force-reinstall numpy$NUMPY_VERSION
  - pip install scipy
  - pip install matplotlib
  - pip install h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
     env: NUMPY_VERSION="==1.11.3"
   - python: 3.5
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
-  - python: 2.7
+  - python: 3.5
     env: NUMPY_VERSION="==1.13.3"
   - python: 3.6
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
-  - python: 2.7
+  - python: 3.6
     env: NUMPY_VERSION="==1.13.3"
 
 before_install:


### PR DESCRIPTION
Updates to the Travis CI configuration.

Specifically, this adds a testing matrix with specified versions of Python and numpy.
 - Python 2.7 is now tested. Closes #30 
 - Specific versions of numpy are tested. Closes #31 
 - The latest release of numpy will also be tested as one matrix member uses constraints, e.g., >=1.6,!=1.15.0

All testing passes. Numpy 1.1.5.0 is specifically excluded from testing due to the issue described in #24 and #30 

For now I've kept the testing matrix relatively small. It can always be expanded as we develop a concrete plan for what needs testing (which I see as a future enhancement, not required to close the issues at hand). This PR provides a blueprint for expanding the testing in the future..