### PR TITLE
Fix windows build of libspacepy

### DIFF
--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -35,6 +35,7 @@ IF "%1"=="32" (
 CALL %USERPROFILE%\Miniconda3\Scripts\activate py%2_%1
 CALL conda install -y numpy scipy matplotlib networkx m2w64-gcc-fortran libpython h5py
 :: libpython sets things up to use ming by default, otherwise try distutils.cfg
+:: note we need libpython or else ffnet requires MSVC to install
 SET FC_VENDOR=gfortran
 CALL pip install ffnet
 CALL deactivate


### PR DESCRIPTION
With this PR, the Windows build works: setup.py build/install work, bdist_wininst work, and pip install from the git commit.

I haven't run all the unit tests (those will result in separate bugs as necessary) and I haven't tested that the bdist_wininst output actually installs (that's actually pretty hard with several parallel Anaconda environments, as it requires registry hacking, but it will be tested in the future). Also this doesn't close the problem of pip install without numpy, that's unrelated to the Windows build setup.