### PR TITLE
Scripts to do actual spacepy build in Windows

### DIFF
--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -1,0 +1,36 @@
+:: Build spacepy on windows
+:: Assume win_build_system_setup.cmd has already been run
+@ECHO OFF
+SETLOCAL EnableDelayedExpansion
+
+FOR %%B in (32 64) DO (FOR %%P in (2 3) DO CALL :build %%B %%P)
+
+GOTO :EOF
+
+:build
+IF "%1"=="32" (
+    set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS32
+    set CONDA_SUBDIR=win-32
+    set CONDA_FORCE_32_BIT=1
+) ELSE (
+    set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS64
+    set CONDA_SUBDIR=win-64
+    set CONDA_FORCE_32_BIT=
+)
+IF "%2"=="2" (
+    set PYVER=27
+) ELSE (
+    set PYVER=36
+)
+CALL %USERPROFILE%\Miniconda3\Scripts\activate py%2_%1
+pushd %~dp0\..\..\
+CALL python setup.py bdist_wininst --fcompiler=gnu95
+for %%f in (dist\spacepy-*.*.*.win32.exe dist\spacepy-*.*.*.win-amd64.exe) DO (
+    set OLDNAME=%%f
+    :: Strip off the dist/ on the target...
+    rename !OLDNAME! !OLDNAME:~5,-4!.py%PYVER%.exe
+)
+popd
+::This turns off echo!
+CALL %USERPROFILE%\Miniconda3\Scripts\deactivate
+GOTO :EOF

--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -5,9 +5,9 @@
 
 set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS64
 set CONDA_SUBDIR=win-64
-set CONDA_FORCE_32_BIT=1
+set CONDA_FORCE_32_BIT=
 
-start /wait "" %USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /S /D=%USERPROFILE%\Miniconda3
+start /wait "" %USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%USERPROFILE%\Miniconda3
 %USERPROFILE%\Miniconda3\Scripts\conda update -y conda
 %USERPROFILE%\Miniconda3\Scripts\conda create -y -n py3_64 python=3.6
 %USERPROFILE%\Miniconda3\Scripts\conda create -y -n py2_64 python=2.7
@@ -18,7 +18,7 @@ set CONDA_FORCE_32_BIT=1
 %USERPROFILE%\Miniconda3\Scripts\conda create -y -n py3_32 python=3.6
 %USERPROFILE%\Miniconda3\Scripts\conda create -y -n py2_32 python=2.7
 
-FOR %%B in (32 64) DO (FOR %%P in (2 3) DO CALL :installs %B %P)
+FOR %%B in (32 64) DO (FOR %%P in (2 3) DO CALL :installs %%B %%P)
 
 GOTO :EOF
 
@@ -33,11 +33,11 @@ IF "%1"=="32" (
     set CONDA_FORCE_32_BIT=
 )
 CALL %USERPROFILE%\Miniconda3\Scripts\activate py%2_%1
-CALL conda install -y numpy scipy matplotlib networkx m2w64-gcc-fortran libpython h5py
+CALL %USERPROFILE%\Miniconda3\Scripts\conda install -y numpy scipy matplotlib networkx m2w64-gcc-fortran libpython h5py
 :: libpython sets things up to use ming by default, otherwise try distutils.cfg
 :: note we need libpython or else ffnet requires MSVC to install
 SET FC_VENDOR=gfortran
 CALL pip install ffnet
-CALL deactivate
+CALL %USERPROFILE%\Miniconda3\Scripts\deactivate
 ::This turns off echo!
 GOTO :EOF

--- a/developer/scripts/win_build_system_teardown.cmd
+++ b/developer/scripts/win_build_system_teardown.cmd
@@ -1,0 +1,8 @@
+:: Remove the Windows build system
+@ECHO OFF
+
+%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py2_32
+%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py2_64
+%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py3_32
+%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py3_64
+%USERPROFILE%\Miniconda3\Uninstall-Miniconda3.exe /S  /D=%USERPROFILE%\Miniconda3


### PR DESCRIPTION
Fixes the win_build_system_setup batch script and adds two new ones: one which builds all the versions of SpacePy, and one which tears down the Windows build system. This allows a build of SpacePy Windows installers for all versions (Python 2.7/3.6 and 32-bit/64-bit) without touching any other installations of Python.

I hate batch.