### PR TITLE
DOC: definitions of coordinates 

### DIFF
--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -27,7 +27,7 @@ class Coords(object):
     in units of Re and degrees
 
     Coordinate transforms are based on the IRBEM library; `its manual
-    <http://irbem.svn.sourceforge.net/viewvc/irbem/trunk/manual/user_guide.html>`_
+    <http://svn.code.sf.net/p/irbem/code/tags/IRBEM-4.4.0/manual/user_guide.html>`_
     may prove useful. For a good reference on heliospheric and magnetospheric
     coordinate systems, see Franz & Harper, "Heliospheric Coordinate Systems",
     Planet. Space Sci., 50, pp 217-233, 2002.

--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -27,7 +27,7 @@ class Coords(object):
     in units of Re and degrees
 
     Coordinate transforms are based on the IRBEM library; `its manual
-    <http://svn.code.sf.net/p/irbem/code/tags/IRBEM-4.4.0/manual/user_guide.html>`_
+    <http://svn.code.sf.net/p/irbem/code/trunk/manual/user_guide.html>`_
     may prove useful. For a good reference on heliospheric and magnetospheric
     coordinate systems, see Franz & Harper, "Heliospheric Coordinate Systems",
     Planet. Space Sci., 50, pp 217-233, 2002.
@@ -39,7 +39,7 @@ class Coords(object):
     dtype : string
         coordinate system; possible values are:
 
-        * **GDZ** (Geodetic – WGS84),
+        * **GDZ** (Geodetic),
         * **GEO** (Geographic Coordinate System),
         * **GSM** (Geocentric Solar Magnetospheric),
         * **GSE** (Geocentric Solar Ecliptic),
@@ -170,7 +170,7 @@ class Coords(object):
          [1 2 2]] ), dtype=GEO,car, units=['Re', 'Re', 'Re']
         '''
         rstr = "Coords( {0} , '{1}', '{2}')".format(self.data.tolist(), self.dtype, self.carsph)
-        return rstr 
+        return rstr
     __repr__ = __str__
 
     # -----------------------------------------------

--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -30,7 +30,8 @@ class Coords(object):
     <http://svn.code.sf.net/p/irbem/code/trunk/manual/user_guide.html>`_
     may prove useful. For a good reference on heliospheric and magnetospheric
     coordinate systems, see Franz & Harper, "Heliospheric Coordinate Systems",
-    Planet. Space Sci., 50, pp 217-233, 2002.
+    Planet. Space Sci., 50, pp 217-233, 2002
+    (https://doi.org/10.1016/S0032-0633(01)00119-2).
 
     Parameters
     ==========
@@ -39,15 +40,15 @@ class Coords(object):
     dtype : string
         coordinate system; possible values are:
 
-        * **GDZ** (Geodetic),
+        * **GDZ** (Geodetic; WGS84),
         * **GEO** (Geographic Coordinate System),
         * **GSM** (Geocentric Solar Magnetospheric),
         * **GSE** (Geocentric Solar Ecliptic),
         * **SM** (Solar Magnetic),
-        * **GEI** (Geocentric Equatorial Inertial),
+        * **GEI** (Geocentric Equatorial Inertial; True-of-Date),
         * **MAG** (Geomagnetic Coordinate System),
         * **SPH** (Spherical Coordinate System),
-        * **RLL** (Radius, Latitude, Longitude)
+        * **RLL** (Radius, Latitude, Longitude; Geodetic)
 
     carsph : string
         Cartesian or spherical, 'car' or 'sph'

--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -37,7 +37,18 @@ class Coords(object):
     data : list or ndarray, dim = (n,3)
         coordinate points [X,Y,Z] or [rad, lat, lon]
     dtype : string
-        coordinate system, possible are GDZ, GEO, GSM, GSE, SM, GEI, MAG, SPH, RLL
+        coordinate system; possible values are:
+
+        * **GDZ** (Geodetic – WGS84),
+        * **GEO** (Geographic Coordinate System),
+        * **GSM** (Geocentric Solar Magnetospheric),
+        * **GSE** (Geocentric Solar Ecliptic),
+        * **SM** (Solar Magnetic),
+        * **GEI** (Geocentric Equatorial Inertial),
+        * **MAG** (Geomagnetic Coordinate System),
+        * **SPH** (Spherical Coordinate System),
+        * **RLL** (Radius, Latitude, Longitude)
+
     carsph : string
         Cartesian or spherical, 'car' or 'sph'
     units : list of strings, optional


### PR DESCRIPTION
We're exploring using SpacePy to provide the basis for some coordinate transform operations using the Geomagnetic Coordinate System. Being not an expert in the field, I found it hard to work out whether SpacePy could provide such functionality based on the docs, as the supported coordinate systems are provided as abbreviations only.

As such, to lower the future bar to entry for people such as I, I've added a short definition of each supported coordinate. I've also updated the link to the IRBEM docs, as the current link seems to have stopped working.

Note: my sources for providing the definitions of the coordinates were:
* https://www.spenvis.oma.be/help/background/coortran/coortran.html
* https://www.vdl.afrl.af.mil/programs/ae9ap9/files/package/Ae9_Ap9_SPM_Users_Guide.pdf#page=16 (PDF; at time of writing also has an incorrectly configured security certificate)

As I'm not an expert in the field I'm not _certain_ the definitions are correct (especially as the two sources used slightly different definitions in a few cases), although the contents of the sources seems to relate directly to the subject matter.