### PR TITLE
Update to toolbox.normalize(), arbitrary range

### DIFF
--- a/spacepy/lib.py
+++ b/spacepy/lib.py
@@ -106,7 +106,10 @@ def load_lib():
     else:
         libnames = ['libspacepy.so']
     if sysconfig:
-        ext = sysconfig.get_config_var('SO')
+        if sys.version_info[0] < 3:
+            ext = sysconfig.get_config_var('SO')
+        else:
+            ext = sysconfig.get_config_var('EXT_SUFFIX')
         if ext:
             libnames.append('libspacepy' + ext)
             libnames.append('spacepy' + ext)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1931,19 +1931,23 @@ def quaternionConjugate(Qin, scalarPos='last'):
 
 # -----------------------------------------------
 
-def normalize(vec):
+def normalize(vec, minmax=(0.0, 1.0)):
     """
-    Given an input vector normalize the vector
+    Given an input vector normalize the vector to a given range
 
     Parameters
     ==========
     vec : array_like
         input vector to normalize
+    minmax : array_like
+        minimum and maximum value to scale to, default (0,1)
 
     Returns
     =======
     out : array_like
         normalized vector
+
+    **Note:** NaN in the input vector does not behave and will return all NaN
 
     Examples
     ========
@@ -1951,14 +1955,9 @@ def normalize(vec):
     >>> tb.normalize([1,2,3])
     [0.0, 0.5, 1.0]
     """
-    # check to see if vec is numpy array, this is fastest
-    if isinstance(vec, np.ndarray):
-        out = (vec - vec.min())/np.ptp(vec)
-    else:
-        vecmin = np.min(vec)
-        ptp = np.ptp(vec)
-        out = [(val -  vecmin)/ptp for val in vec]
-    return out
+    vec = np.asanyarray(vec)
+    return np.interp(vec, (vec.min(), vec.max()), minmax)
+
 
 def intsolve(func, value, start=None, stop=None, maxit=1000):
     """

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1947,16 +1947,13 @@ def normalize(vec, minmax=(0.0, 1.0)):
     out : array_like
         normalized vector
 
-    **Note:** NaN in the input vector does not behave and will return all NaN
-
     Examples
     ========
     >>> import spacepy.toolbox as tb
     >>> tb.normalize([1,2,3])
     [0.0, 0.5, 1.0]
     """
-    vec = np.asanyarray(vec)
-    return np.interp(vec, (vec.min(), vec.max()), minmax)
+    return np.interp(vec, (np.nanmin(vec), np.nanmax(vec)), minmax)
 
 
 def intsolve(func, value, start=None, stop=None, maxit=1000):

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -244,6 +244,10 @@ class SimpleFunctionTests(unittest.TestCase):
         """normalize should give known results"""
         numpy.testing.assert_equal(array([0.0, 0.5, 1.0]), tb.normalize(array([1,2,3])))
         numpy.testing.assert_equal(array([1.0, 6.0, 11.0]), tb.normalize(array([1,2,3]), minmax=(1, 11)))
+        numpy.testing.assert_equal(array([1.0, 6.0, 11.0,numpy.nan]), tb.normalize(array([1,2,3,numpy.nan]),
+                                                                                   minmax=(1, 11)))
+        numpy.testing.assert_equal(array([1.0, 6.0, numpy.nan, 11.0]), tb.normalize(array([1,2,numpy.nan, 3,]),
+                                                                                   minmax=(1, 11)))
 
     def testfeq_equal(self):
         """feq should return true when they are equal"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -242,8 +242,8 @@ class SimpleFunctionTests(unittest.TestCase):
 
     def test_normalize(self):
         """normalize should give known results"""
-        self.assertEqual([0.0, 0.5, 1.0], tb.normalize([1,2,3]))
         numpy.testing.assert_equal(array([0.0, 0.5, 1.0]), tb.normalize(array([1,2,3])))
+        numpy.testing.assert_equal(array([1.0, 6.0, 11.0]), tb.normalize(array([1,2,3]), minmax=(1, 11)))
 
     def testfeq_equal(self):
         """feq should return true when they are equal"""


### PR DESCRIPTION
I needed the ability to normalize to an arbitrary range and some thinking and research led to an elegant solution using numpy.interp. 

This is useful for 0-255 scaling, -1-1, or whatever a user may want. Tests updated and all pass.

 