### PR TITLE
travis.yml: added TravisBuddy webhooks for test failure autonotify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,7 @@ before_script:
 script:
  - python setup.py install
  - cd tests; . /home/travis/bin/definitions.B; python test_spacepy.py
+
+notifications:
+ webhooks: https://www.travisbuddy.com/
+ on_success: never


### PR DESCRIPTION
Added webhooks to Travis CI configuration to have TravisBuddy comment on test failures in PRs.

Syntax following https://www.travisbuddy.com/getting-started.
No comments on tests passing. The comments on test failure *should* say why the test suite failed.

This closes #32