### PR TITLE
lib: non-version-specific SO deprecation fix

### DIFF
--- a/spacepy/lib.py
+++ b/spacepy/lib.py
@@ -106,10 +106,9 @@ def load_lib():
     else:
         libnames = ['libspacepy.so']
     if sysconfig:
-        if sys.version_info[0] < 3:
+        ext = sysconfig.get_config_var('EXT_SUFFIX')
+        if ext is None:
             ext = sysconfig.get_config_var('SO')
-        else:
-            ext = sysconfig.get_config_var('EXT_SUFFIX')
         if ext:
             libnames.append('libspacepy' + ext)
             libnames.append('spacepy' + ext)


### PR DESCRIPTION
Alternative to #77 (although assumes it's applied) and fixes #75. This is the way it was fixed in setup.py and avoids being version-specific. I could probably one-liner it with `ext = sysconfig.get_config_var('EXT_SUFFIX') or sysconfig.get_config_var('SO')` but that seems needlessly opaque.