### PR TITLE
Pycdf attrs speedup (closes #89)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,9 +12,8 @@ pycdf
  - Reading empty NRV variables will now return empty array (not padding)
  - Fix more cases of BAD_ENTRY_NUM when reading attribute entries
  - Fix UTC-to-TT2000 conversions on ARM (thanks Rodrigue Piberne for the bug)
- - Speed up many operations by referencing variables by number instead of
-   name. This is the biggest change to pycdf internals in several years; please
-   report any bugs.
+ - Speed up many operations by cacheing variable numbers. This is the biggest
+   change to pycdf internals in several years; please report any bugs.
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,9 @@ pycdf
  - Reading empty NRV variables will now return empty array (not padding)
  - Fix more cases of BAD_ENTRY_NUM when reading attribute entries
  - Fix UTC-to-TT2000 conversions on ARM (thanks Rodrigue Piberne for the bug)
+ - Speed up many operations by referencing variables by number instead of
+   name. This is the biggest change to pycdf internals in several years; please
+   report any bugs.
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================

--- a/developer/benchmarks/pycdf/entry_writing.py
+++ b/developer/benchmarks/pycdf/entry_writing.py
@@ -6,7 +6,7 @@ The actual test case was for CHAR entries on FLOAT vars with types
 specified, so that's why that's used here. That has 1492 variables with
 18 attrs each.
 
-32s initially
+32s initially. Down to 17.4 at this point.
 """
 
 import os

--- a/developer/benchmarks/pycdf/entry_writing.py
+++ b/developer/benchmarks/pycdf/entry_writing.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+"""Write a bunch of zEntries to test for speed
+
+The actual test case was for CHAR entries on FLOAT vars with types
+specified, so that's why that's used here. That has 1492 variables with
+18 attrs each.
+
+32s initially
+"""
+
+import os
+
+import spacepy.pycdf
+
+
+with spacepy.pycdf.CDF('foo.cdf', create=True) as f:
+    for i in range(1500):
+        f.new('VAR_{:03d}'.format(i), type=spacepy.pycdf.const.CDF_FLOAT)
+    for i in range(1500):
+        var = f['VAR_{:03d}'.format(i)]
+        for j in range(20):
+            var.attrs.new('ATTR_{:02d}'.format(j), 'foo',
+                          type=spacepy.pycdf.const.CDF_CHAR)
+
+os.remove('foo.cdf')

--- a/developer/benchmarks/pycdf/entry_writing.py
+++ b/developer/benchmarks/pycdf/entry_writing.py
@@ -6,7 +6,7 @@ The actual test case was for CHAR entries on FLOAT vars with types
 specified, so that's why that's used here. That has 1492 variables with
 18 attrs each.
 
-32s initially. Down to 17.4 at this point.
+32s initially. Down to 11.3 at this point.
 """
 
 import os

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4508,19 +4508,15 @@ class zAttr(Attr):
     ========
     :class:`Attr`
     """
-
-    def __init__(self, *args, **kwargs):
-        """Initialize this attribute"""
-        self.ENTRY_ = const.zENTRY_
-        self.ENTRY_DATA_ = const.zENTRY_DATA_
-        self.SCOPE = const.VARIABLE_SCOPE
-        self.ENTRY_EXISTENCE_ = const.zENTRY_EXISTENCE_
-        self.ATTR_NUMENTRIES_ = const.ATTR_NUMzENTRIES_
-        self.ATTR_MAXENTRY_ = const.ATTR_MAXzENTRY_
-        self.ENTRY_NUMELEMS_ = const.zENTRY_NUMELEMS_
-        self.ENTRY_DATATYPE_ = const.zENTRY_DATATYPE_
-        self.ENTRY_DATASPEC_ = const.zENTRY_DATASPEC_
-        super(zAttr, self).__init__(*args, **kwargs)
+    ENTRY_ = const.zENTRY_
+    ENTRY_DATA_ = const.zENTRY_DATA_
+    SCOPE = const.VARIABLE_SCOPE
+    ENTRY_EXISTENCE_ = const.zENTRY_EXISTENCE_
+    ATTR_NUMENTRIES_ = const.ATTR_NUMzENTRIES_
+    ATTR_MAXENTRY_ = const.ATTR_MAXzENTRY_
+    ENTRY_NUMELEMS_ = const.zENTRY_NUMELEMS_
+    ENTRY_DATATYPE_ = const.zENTRY_DATATYPE_
+    ENTRY_DATASPEC_ = const.zENTRY_DATASPEC_
 
     def insert(self, index, data):
         """Insert entry at particular index number
@@ -4614,19 +4610,15 @@ class gAttr(Attr):
     ========
     :class:`Attr`
     """
-
-    def __init__(self, *args, **kwargs):
-        """Initialize this attribute"""
-        self.ENTRY_ = const.gENTRY_
-        self.ENTRY_DATA_ = const.gENTRY_DATA_
-        self.SCOPE = const.GLOBAL_SCOPE
-        self.ENTRY_EXISTENCE_ = const.gENTRY_EXISTENCE_
-        self.ATTR_NUMENTRIES_ = const.ATTR_NUMgENTRIES_
-        self.ATTR_MAXENTRY_ = const.ATTR_MAXgENTRY_
-        self.ENTRY_NUMELEMS_ = const.gENTRY_NUMELEMS_
-        self.ENTRY_DATATYPE_ = const.gENTRY_DATATYPE_
-        self.ENTRY_DATASPEC_ = const.gENTRY_DATASPEC_
-        super(gAttr, self).__init__(*args, **kwargs)
+    ENTRY_ = const.gENTRY_
+    ENTRY_DATA_ = const.gENTRY_DATA_
+    SCOPE = const.GLOBAL_SCOPE
+    ENTRY_EXISTENCE_ = const.gENTRY_EXISTENCE_
+    ATTR_NUMENTRIES_ = const.ATTR_NUMgENTRIES_
+    ATTR_MAXENTRY_ = const.ATTR_MAXgENTRY_
+    ENTRY_NUMELEMS_ = const.gENTRY_NUMELEMS_
+    ENTRY_DATATYPE_ = const.gENTRY_DATATYPE_
+    ENTRY_DATASPEC_ = const.gENTRY_DATASPEC_
 
 
 class AttrList(collections.MutableMapping):
@@ -4850,6 +4842,7 @@ class AttrList(collections.MutableMapping):
         """
         if name in self:
             raise KeyError(name + ' already exists.')
+        #A zAttr without an Entry in this zVar will be a "get" not "create"
         attr = self._get_or_create(name)
         if data is not None:
             if self.special_entry is None:

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1513,6 +1513,41 @@ class CDF(collections.MutableMapping):
     or, if more control is needed over the type and dimensions, use
     :py:meth:`new`.
 
+    Although it is supported to assign Var objects to Python variables for
+    convenience, there are some minor pitfalls that can arise when changing
+    a CDF that will not affect most users. This is only a concern when
+    assigning a zVar object to a Python variable, and then deleting or
+    renaming the variable via a *different* Python variable.
+
+    Deleting a variable and then trying to access it via a different Python
+    object:
+
+        >>> var = cdffile['Var1']
+        >>> del cdffile['Var1']
+        >>> var[0] #fail
+
+    Renaming a variable and trying to access it via a different Python object:
+
+        >>> var = cdffile['Var1']
+        >>> cdffile['Var1'].rename('Var2')
+        >>> var[0] #fail
+
+    Renaming a variable through the same object will work:
+
+        >>> var = cdffile['Var1']
+        >>> var.rename('Var2')
+        >>> var[0] #fine
+
+    Deleting a variable and then creating another variable with the same name
+    may lead to some surprises:
+
+        >>> var = cdffile['Var1']
+        >>> var[...] = [1, 2, 3, 4]
+        >>> del cdffile['Var1']
+        >>> cdffile.new('Var1', data=[5, 6, 7, 8]
+        >>> var[...]
+        [5, 6, 7, 8]
+
     .. autosummary::
 
         ~CDF.attrs

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1530,6 +1530,7 @@ class CDF(collections.MutableMapping):
         ~CDF.attrs
         ~CDF.backward
         ~CDF.checksum
+        ~CDF.clear_from_cache
         ~CDF.clone
         ~CDF.close
         ~CDF.col_major
@@ -1554,6 +1555,7 @@ class CDF(collections.MutableMapping):
        (for opening with CDF library before 3.x)
 
     .. automethod:: checksum
+    .. automethod:: clear_from_cache
     .. automethod:: clone
     .. automethod:: close
     .. automethod:: col_major
@@ -2366,6 +2368,29 @@ class CDF(collections.MutableMapping):
             num = varNum.value
             self._var_nums[varname] = num
         return num
+
+    def clear_from_cache(self, varname):
+        """Mark a variable deleted in the name-to-number cache
+
+        Will remove a variable, and all variables with higher numbers,
+        from the variable cache.
+
+        Does NOT delete the variable!
+
+        This maintains a cache of name-to-number mappings for zVariables
+        to keep from having to query the CDF library constantly. It's mostly
+        an internal function.
+
+        Parameters
+        ==========
+        varname : bytes
+            name of the zVariable. Not this is NOT a string in Python 3!
+        """
+        num = self.var_num(varname)
+        #All numbers higher than this are renumbered
+        for v, n in list(self._var_nums.items()):
+            if n >= num:
+                del self._var_nums[v]
 
 
 class CDFCopy(spacepy.datamodel.SpaceData):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1851,6 +1851,18 @@ class ReadCDF(CDFTests):
         self.assertEqual(0, self.cdf._var_nums['ATC'])
         self.assertRaises(cdf.CDFError, self.cdf.var_num, b'foobar')
 
+    def testDeleteCachezVarNum(self):
+        """Test deleting something from the zvar cache"""
+        #This is a bit backwards, but easiest way to fill the cache
+        _ = [self.cdf.var_num(self.cdf[i].name()) for i in range(len(self.cdf))]
+        #This is variable #8
+        self.cdf.clear_from_cache('SpinRateScalersCounts')
+        self.assertFalse('SpinRateScalersCounts' in self.cdf._var_nums)
+        self.assertFalse('SpinRateScalersCountSigma' in self.cdf._var_nums) #9
+        self.assertFalse('MajorNumbers' in self.cdf._var_nums) #10
+        self.assertTrue('SectorRateScalersCountsSigma' in self.cdf._var_nums) #8
+        self.assertEqual(10, self.cdf.var_num(b'MajorNumbers')) #Repopulated
+
 
 class ReadColCDF(ColCDFTests):
     """Tests that read a column-major CDF, but do not modify it."""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1856,12 +1856,37 @@ class ReadCDF(CDFTests):
         #This is a bit backwards, but easiest way to fill the cache
         _ = [self.cdf.var_num(self.cdf[i].name()) for i in range(len(self.cdf))]
         #This is variable #8
-        self.cdf.clear_from_cache('SpinRateScalersCounts')
-        self.assertFalse('SpinRateScalersCounts' in self.cdf._var_nums)
-        self.assertFalse('SpinRateScalersCountSigma' in self.cdf._var_nums) #9
-        self.assertFalse('MajorNumbers' in self.cdf._var_nums) #10
-        self.assertTrue('SectorRateScalersCountsSigma' in self.cdf._var_nums) #8
+        self.cdf.clear_from_cache(b'SpinRateScalersCounts')
+        self.assertFalse(b'SpinRateScalersCounts' in self.cdf._var_nums)
+        self.assertFalse(b'SpinRateScalersCountSigma' in self.cdf._var_nums) #9
+        self.assertFalse(b'MajorNumbers' in self.cdf._var_nums) #10
+        #7
+        self.assertTrue(b'SectorRateScalersCountsSigma' in self.cdf._var_nums)
         self.assertEqual(10, self.cdf.var_num(b'MajorNumbers')) #Repopulated
+
+    def testCachezAttrNum(self):
+        """Test basic reads of the attr number cache"""
+        self.assertFalse(b'Project' in self.cdf._attr_info)
+        self.assertEqual((0, True), self.cdf.attr_num(b'Project'))
+        self.assertTrue(b'Project' in self.cdf._attr_info)
+        self.assertEqual((0, True), self.cdf._attr_info[b'Project'])
+        self.assertRaises(cdf.CDFError, self.cdf.attr_num, b'foobar')
+        #zAttr?
+        self.assertEqual((41, False), self.cdf.attr_num(b'VALIDMIN'))
+
+    def testDeleteCacheAttrNum(self):
+        """Test deleting something from the attr cache"""
+        #This is a bit backwards, but easiest way to fill the cache
+        _ = [self.cdf.attr_num(self.cdf.attrs[i]._name)
+             for i in range(len(self.cdf.attrs))]
+        #This is attr #8
+        self.cdf.clear_attr_from_cache(b'PI_affiliation')
+        self.assertFalse(b'PI_affiliation' in self.cdf._attr_info)
+        self.assertFalse(b'TEXT' in self.cdf._attr_info) #9
+        self.assertFalse(b'Instrument_type' in self.cdf._attr_info) #10
+        self.assertTrue(b'PI_name' in self.cdf._attr_info) #7
+        #Repopulated
+        self.assertEqual((10, True), self.cdf.attr_num(b'Instrument_type'))
 
 
 class ReadColCDF(ColCDFTests):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1848,13 +1848,18 @@ class ReadCDF(CDFTests):
         self.assertFalse(b'ATC' in self.cdf._var_nums)
         self.assertEqual(0, self.cdf.var_num(b'ATC'))
         self.assertTrue(b'ATC' in self.cdf._var_nums)
-        self.assertEqual(0, self.cdf._var_nums['ATC'])
+        self.assertEqual(0, self.cdf._var_nums[b'ATC'])
         self.assertRaises(cdf.CDFError, self.cdf.var_num, b'foobar')
 
     def testDeleteCachezVarNum(self):
         """Test deleting something from the zvar cache"""
         #This is a bit backwards, but easiest way to fill the cache
-        _ = [self.cdf.var_num(self.cdf[i].name()) for i in range(len(self.cdf))]
+        #without assuming it's being used
+        for i in range(len(self.cdf)):
+            n = self.cdf[i].name()
+            if str is not bytes:
+                n = n.encode('ascii')
+            _ = self.cdf.var_num(n)
         #This is variable #8
         self.cdf.clear_from_cache(b'SpinRateScalersCounts')
         self.assertFalse(b'SpinRateScalersCounts' in self.cdf._var_nums)

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2112,6 +2112,15 @@ class ChangeCDF(ChangeCDFBase):
         del self.cdf['ATC']
         numpy.testing.assert_array_equal(
             zvardata, zvar[...])
+
+    def testDeleteAttrWithRef(self):
+        """Delete a gAttr while having reference to another one"""
+        #This is #19
+        ack = self.cdf.attrs['Acknowledgement']
+        ackdata = ack[...]
+        #This is #3
+        del self.cdf.attrs['Data_type']
+        numpy.testing.assert_array_equal(ackdata, ack[...])
         
     def testNewVar(self):
         """Create a new variable"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1843,6 +1843,14 @@ class ReadCDF(CDFTests):
         self.assertEqual('6', str(self.cdf['StringUnpadded'].dtype)[-1])
         self.assertEqual('6', str(self.cdf['StringUnpadded'][...].dtype)[-1])
 
+    def testCachezVarNum(self):
+        """Test basic reads of the zVar number cache"""
+        self.assertFalse(b'ATC' in self.cdf._var_nums)
+        self.assertEqual(0, self.cdf.var_num(b'ATC'))
+        self.assertTrue(b'ATC' in self.cdf._var_nums)
+        self.assertEqual(0, self.cdf._var_nums['ATC'])
+        self.assertRaises(cdf.CDFError, self.cdf.var_num, b'foobar')
+
 
 class ReadColCDF(ColCDFTests):
     """Tests that read a column-major CDF, but do not modify it."""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -985,7 +985,7 @@ class ReadCDF(CDFTests):
         self.assertEqual(expectedNames, names)
 
     def testGetVarNum(self):
-        self.assertEqual(0, self.cdf['ATC']._num)
+        self.assertEqual(0, self.cdf['ATC']._num())
 
     def testCDFIterator(self):
         expected = self.varnames
@@ -2102,25 +2102,26 @@ class ChangeCDF(ChangeCDFBase):
         else:
             self.fail('Should have raised CDFError')
 
+    @unittest.expectedFailure
     def testRenameSameVar(self):
         """Rename a variable while keeping a reference to it"""
         zvar = self.cdf['PhysRecNo']
         self.cdf['PhysRecNo'].rename('foobar')
-        #This works because the reference is by var num not name
         numpy.testing.assert_array_equal(
             zvar[...], self.cdf['foobar'][...])
 
+    @unittest.expectedFailure
     def testDeleteSameName(self):
         """Delete a variable and re-make with same name"""
         zvar = self.cdf['PhysRecNo']
-        number = zvar._num
+        number = zvar._num()
         del self.cdf['PhysRecNo']
         self.cdf['PhysRecNo'] = [1, 2, 3, 4]
         #Verify we have different variable numbers between two things
         #with the same name
-        self.assertNotEqual(number, self.cdf['PhysRecNo']._num)
-        #And since they're referring to different numbers, the
-        #variables will be different
+        self.assertNotEqual(number, self.cdf['PhysRecNo']._num())
+        #And since they're referring to different variables, the
+        #contents should be different.
         #https://stackoverflow.com/questions/38506044/numpy-testing-assert-array-not-equal
         self.assertRaises(AssertionError, numpy.testing.assert_array_equal,
                           zvar[...], self.cdf['PhysRecNo'][...])
@@ -2762,13 +2763,13 @@ class ChangeAttr(ChangeCDFBase):
         self.assertEqual('foobar', zvar.attrs['DEPEND_0'])
         self.assertEqual(const.CDF_CHAR.value,
                          cdf.zAttr(self.cdf,
-                                   'DEPEND_0').type(zvar._num))
+                                   'DEPEND_0').type(zvar._num()))
 
         zvar.attrs['FILLVAL'] = [0, 1]
         numpy.testing.assert_array_equal([0,1], zvar.attrs['FILLVAL'])
         self.assertEqual(const.CDF_INT4.value,
                          cdf.zAttr(self.cdf,
-                                   'FILLVAL').type(zvar._num))
+                                   'FILLVAL').type(zvar._num()))
 
         message = 'Entry strings must be scalar.'
         try:
@@ -2796,20 +2797,20 @@ class ChangeAttr(ChangeCDFBase):
         self.assertEqual(1, zvar.attrs['NEW_ATTRIBUTE'])
         self.assertEqual(const.CDF_INT4.value,
                          cdf.zAttr(self.cdf,
-                                   'NEW_ATTRIBUTE').type(zvar._num))
+                                   'NEW_ATTRIBUTE').type(zvar._num()))
 
         zvar.attrs['NEW_ATTRIBUTE2'] = [1, 2]
         numpy.testing.assert_array_equal([1, 2], zvar.attrs['NEW_ATTRIBUTE2'])
         self.assertEqual(const.CDF_INT4.value,
                          cdf.zAttr(self.cdf,
-                                   'NEW_ATTRIBUTE2').type(zvar._num))
+                                   'NEW_ATTRIBUTE2').type(zvar._num()))
 
         zvar = self.cdf['SpinNumbers']
         zvar.attrs['NEW_ATTRIBUTE3'] = 1
         self.assertEqual(1, zvar.attrs['NEW_ATTRIBUTE3'])
         self.assertEqual(const.CDF_BYTE.value,
                          cdf.zAttr(self.cdf,
-                                   'NEW_ATTRIBUTE3').type(zvar._num))
+                                   'NEW_ATTRIBUTE3').type(zvar._num()))
 
     def testDelzAttr(self):
         """Delete a zEntry"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2105,6 +2105,14 @@ class ChangeCDF(ChangeCDFBase):
         self.assertRaises(AssertionError, numpy.testing.assert_array_equal,
                           zvar[...], self.cdf['PhysRecNo'][...])
 
+    def testDeleteWithRef(self):
+        """Delete a variable while have a reference to another one"""
+        zvar = self.cdf['PhysRecNo']
+        zvardata = zvar[...]
+        del self.cdf['ATC']
+        numpy.testing.assert_array_equal(
+            zvardata, zvar[...])
+        
     def testNewVar(self):
         """Create a new variable"""
         self.cdf.new('newzVar', [[1, 2, 3], [4, 5, 6]],

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -985,7 +985,7 @@ class ReadCDF(CDFTests):
         self.assertEqual(expectedNames, names)
 
     def testGetVarNum(self):
-        self.assertEqual(0, self.cdf['ATC']._num())
+        self.assertEqual(0, self.cdf['ATC']._num)
 
     def testCDFIterator(self):
         expected = self.varnames
@@ -2082,25 +2082,28 @@ class ChangeCDF(ChangeCDFBase):
         else:
             self.fail('Should have raised CDFError')
 
-    @unittest.expectedFailure
     def testRenameSameVar(self):
         """Rename a variable while keeping a reference to it"""
         zvar = self.cdf['PhysRecNo']
         self.cdf['PhysRecNo'].rename('foobar')
+        #This works because the reference is by var num not name
         numpy.testing.assert_array_equal(
             zvar[...], self.cdf['foobar'][...])
 
     def testDeleteSameName(self):
         """Delete a variable and re-make with same name"""
         zvar = self.cdf['PhysRecNo']
-        number = zvar._num()
+        number = zvar._num
         del self.cdf['PhysRecNo']
         self.cdf['PhysRecNo'] = [1, 2, 3, 4]
-        #Verify we have different record numbers between two things
+        #Verify we have different variable numbers between two things
         #with the same name
-        self.assertNotEqual(number, self.cdf['PhysRecNo']._num())
-        numpy.testing.assert_array_equal(
-            zvar[...], self.cdf['PhysRecNo'][...])
+        self.assertNotEqual(number, self.cdf['PhysRecNo']._num)
+        #And since they're referring to different numbers, the
+        #variables will be different
+        #https://stackoverflow.com/questions/38506044/numpy-testing-assert-array-not-equal
+        self.assertRaises(AssertionError, numpy.testing.assert_array_equal,
+                          zvar[...], self.cdf['PhysRecNo'][...])
 
     def testNewVar(self):
         """Create a new variable"""
@@ -2722,13 +2725,13 @@ class ChangeAttr(ChangeCDFBase):
         self.assertEqual('foobar', zvar.attrs['DEPEND_0'])
         self.assertEqual(const.CDF_CHAR.value,
                          cdf.zAttr(self.cdf,
-                                   'DEPEND_0').type(zvar._num()))
+                                   'DEPEND_0').type(zvar._num))
 
         zvar.attrs['FILLVAL'] = [0, 1]
         numpy.testing.assert_array_equal([0,1], zvar.attrs['FILLVAL'])
         self.assertEqual(const.CDF_INT4.value,
                          cdf.zAttr(self.cdf,
-                                   'FILLVAL').type(zvar._num()))
+                                   'FILLVAL').type(zvar._num))
 
         message = 'Entry strings must be scalar.'
         try:
@@ -2756,20 +2759,20 @@ class ChangeAttr(ChangeCDFBase):
         self.assertEqual(1, zvar.attrs['NEW_ATTRIBUTE'])
         self.assertEqual(const.CDF_INT4.value,
                          cdf.zAttr(self.cdf,
-                                   'NEW_ATTRIBUTE').type(zvar._num()))
+                                   'NEW_ATTRIBUTE').type(zvar._num))
 
         zvar.attrs['NEW_ATTRIBUTE2'] = [1, 2]
         numpy.testing.assert_array_equal([1, 2], zvar.attrs['NEW_ATTRIBUTE2'])
         self.assertEqual(const.CDF_INT4.value,
                          cdf.zAttr(self.cdf,
-                                   'NEW_ATTRIBUTE2').type(zvar._num()))
+                                   'NEW_ATTRIBUTE2').type(zvar._num))
 
         zvar = self.cdf['SpinNumbers']
         zvar.attrs['NEW_ATTRIBUTE3'] = 1
         self.assertEqual(1, zvar.attrs['NEW_ATTRIBUTE3'])
         self.assertEqual(const.CDF_BYTE.value,
                          cdf.zAttr(self.cdf,
-                                   'NEW_ATTRIBUTE3').type(zvar._num()))
+                                   'NEW_ATTRIBUTE3').type(zvar._num))
 
     def testDelzAttr(self):
         """Delete a zEntry"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2102,6 +2102,8 @@ class ChangeCDF(ChangeCDFBase):
         else:
             self.fail('Should have raised CDFError')
 
+    #This is renamed via a *different* reference, so the original
+    #reference still has the old name, and referenced by name.
     @unittest.expectedFailure
     def testRenameSameVar(self):
         """Rename a variable while keeping a reference to it"""
@@ -2110,6 +2112,20 @@ class ChangeCDF(ChangeCDFBase):
         numpy.testing.assert_array_equal(
             zvar[...], self.cdf['foobar'][...])
 
+    #A variable is deleted but we still have a reference to it
+    #I'm not sure what would be expected behavior here, but
+    #there's a NO_SUCH_VAR error raised.
+    @unittest.expectedFailure
+    def testDeleteAndAccess(self):
+        """Delete a variable and then try to access it again"""
+        zvar = self.cdf['PhysRecNo']
+        number = zvar._num()
+        del self.cdf['PhysRecNo']
+        foo = zvar[...]
+
+    #A completely different variable is made with the same name,
+    #so the old reference will point to the new variable
+    #(referenced by name)
     @unittest.expectedFailure
     def testDeleteSameName(self):
         """Delete a variable and re-make with same name"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2065,6 +2065,8 @@ class ChangeCDF(ChangeCDFBase):
         zvar.rename('foobar')
         numpy.testing.assert_array_equal(
             zvardata, self.cdf['foobar'][...])
+        numpy.testing.assert_array_equal(
+            zvardata, zvar[...])
         try:
             zvar = self.cdf['PhysRecNo']
         except KeyError:
@@ -2079,6 +2081,26 @@ class ChangeCDF(ChangeCDFBase):
             self.assertEqual(v.status, cdf.const.BAD_VAR_NAME)
         else:
             self.fail('Should have raised CDFError')
+
+    @unittest.expectedFailure
+    def testRenameSameVar(self):
+        """Rename a variable while keeping a reference to it"""
+        zvar = self.cdf['PhysRecNo']
+        self.cdf['PhysRecNo'].rename('foobar')
+        numpy.testing.assert_array_equal(
+            zvar[...], self.cdf['foobar'][...])
+
+    def testDeleteSameName(self):
+        """Delete a variable and re-make with same name"""
+        zvar = self.cdf['PhysRecNo']
+        number = zvar._num()
+        del self.cdf['PhysRecNo']
+        self.cdf['PhysRecNo'] = [1, 2, 3, 4]
+        #Verify we have different record numbers between two things
+        #with the same name
+        self.assertNotEqual(number, self.cdf['PhysRecNo']._num())
+        numpy.testing.assert_array_equal(
+            zvar[...], self.cdf['PhysRecNo'][...])
 
     def testNewVar(self):
         """Create a new variable"""


### PR DESCRIPTION
This speeds up code that writes a lot of attributes by about a factor of 3, and would also substantially help out anything that's just hitting a lot of variables. It switches from checking the CDF for a variable/attribute number every time a variable/attribute is referenced to cacheing the number (and expiring the cache when things happen that might change it.)
