### PR TITLE
Fix abc imports (closes #42)

### DIFF
--- a/spacepy/irbempy/irbempy.py
+++ b/spacepy/irbempy/irbempy.py
@@ -15,7 +15,10 @@ Copyright 2010 Los Alamos National Security, LLC.
 """
 
 import itertools, numbers
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import sys, os
 import warnings
 

--- a/spacepy/plot/__init__.py
+++ b/spacepy/plot/__init__.py
@@ -70,6 +70,10 @@ several submodules listed below
     utils
 
 """
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 import os
 import numpy as np
 import matplotlib as mpl
@@ -305,8 +309,7 @@ def levelPlot(data, var=None, time=None, levels=(3, 5), target=None, colors=None
             raise KeyError('Key "{1}" not present in data'.format(var))
     else:
         #var is None, so make sure we don't have a dict-like
-        import collections
-        if not isinstance(data, collections.Mapping):
+        if not isinstance(data, Mapping):
             usearr = np.asarray(data)
         else:
             raise TypeError('Data appears to be dict-like without a key being given')

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -49,7 +49,10 @@ Copyright 2010-2015 Los Alamos National Security, LLC.
 
 __contact__ = 'Jon Niehof, Jonathan.Niehof@unh.edu'
 
-import collections
+try:
+    from collections.abc import MutableMapping, MutableSequence
+except ImportError:
+    from collections import MutableMapping, MutableSequence
 import ctypes
 import ctypes.util
 import datetime
@@ -1357,7 +1360,7 @@ def _compress(obj, comptype=None, param=None):
     return (comptype, param)
 
 
-class CDF(collections.MutableMapping):
+class CDF(MutableMapping):
     """
     Python object representing a CDF file.
 
@@ -2561,7 +2564,7 @@ class CDFCopy(spacepy.datamodel.SpaceData):
                                       attrs = cdf.attrs.copy())
 
 
-class Var(collections.MutableSequence):
+class Var(MutableSequence):
     """
     A CDF variable.
 
@@ -4048,7 +4051,7 @@ class _Hyperslice(object):
         return (start, count, step, rev)
 
 
-class Attr(collections.MutableSequence):
+class Attr(MutableSequence):
     """An attribute, g or z, for a CDF
 
     .. warning::
@@ -4850,7 +4853,7 @@ class gAttr(Attr):
     ENTRY_DATASPEC_ = const.gENTRY_DATASPEC_
 
 
-class AttrList(collections.MutableMapping):
+class AttrList(MutableMapping):
     """Object representing a list of attributes.
 
     .. warning::

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -88,7 +88,10 @@ Contact: smorley@lanl.gov,
 Copyright 2010 Los Alamos National Security, LLC.
 """
 import bisect
-import collections
+try:
+    from collections.abc import Callable, MutableSequence
+except ImportError:
+    from collections import Callable, MutableSequence
 import datetime
 
 try:
@@ -120,7 +123,7 @@ an "optimization flag" (-O), but currently this does not actually optimize the b
 # -----------------------------------------------
 # Ticktock class
 # -----------------------------------------------
-class Ticktock(collections.MutableSequence):
+class Ticktock(MutableSequence):
     """
     Ticktock( data, dtype )
 
@@ -225,7 +228,7 @@ class Ticktock(collections.MutableSequence):
             else:
                 self.data = spacepy.datamodel.dmarray(data)
 
-            if not isinstance(dtype, collections.Callable):
+            if not isinstance(dtype, Callable):
                 if isinstance(self.data[0], str):
                     dtype = 'ISO'
                 elif isinstance(self.data[0], datetime.datetime):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -7,7 +7,10 @@ Unit test suite for pycdf
 Copyright 2010-2014 Los Alamos National Security, LLC.
 """
 
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 import ctypes
 import datetime
 import gc
@@ -20,13 +23,6 @@ import sys
 import tempfile
 import unittest
 import warnings
-
-try:
-    type(callable)
-except NameError:
-    import collections
-    def callable(obj):
-        return isinstance(obj, collections.Callable)
 
 import matplotlib.dates
 import numpy
@@ -945,7 +941,7 @@ class ReadCDF(CDFTests):
         #cmp() function'
         testnames = [name for name in dir(self)
                      if name[0:4] == 'test' and
-                     isinstance(getattr(self,name), collections.Callable)]
+                     isinstance(getattr(self,name), Callable)]
         self.last_test = max(testnames)
 
     def setUp(self):
@@ -1905,7 +1901,7 @@ class ReadColCDF(ColCDFTests):
         #cmp() function'
         testnames = [name for name in dir(self)
                      if name[0:4] == 'test' and
-                     isinstance(getattr(self,name), collections.Callable)]
+                     isinstance(getattr(self,name), Callable)]
         self.last_test = max(testnames)
 
     def setUp(self):


### PR DESCRIPTION
This fixes the DeprecationWarning from using the top-level collections for access to abstract base classes, as discussed in #42. Once we drop Python 2 support we can probably go back to properly namespacing.
