### PR TITLE
Fixes for datamanager under Windows

### DIFF
--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -243,7 +243,7 @@ class RePath(object):
         return res
 
     @staticmethod
-    def path_slice(path, start, stop=None, step=None):
+    def path_slice(path, start, stop=None, step=None, native=False):
         """
         Slice a path by elements, as in getitem or []
 
@@ -262,6 +262,8 @@ class RePath(object):
             If ``stop`` is not specified but ``step`` is, return to end.
         step : int
             Increment between each.
+        native : bool
+            Is this a native path or UNIX-style? (default False, UNIX)
 
         Returns
         =======
@@ -279,9 +281,11 @@ class RePath(object):
         "bar/baz"
         """
         if stop is None and step is None:
-            return RePath.path_split(path)[start]
+            return RePath.path_split(path, native=native)[start]
         else:
-            return os.path.join(*RePath.path_split(path)[start:stop:step])
+            join = (os.path if native else posixpath).join
+            return join(*RePath.path_split(path, native=native)
+                        [start:stop:step])
 
 
 def insert_fill(times, data, fillval=numpy.nan, tol=1.5, absolute=None, doTimes=True):

--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -422,7 +422,7 @@ def insert_fill(times, data, fillval=numpy.nan, tol=1.5, absolute=None, doTimes=
                 "Unable to uniquely match shape of data to count of times.")
         timeaxis = matches[0]
     fillshape = numpy.delete(data.shape, timeaxis) #shape of data w/o time axis
-    if numpy.shape(fillval) != fillshape:
+    if (numpy.shape(fillval) != fillshape).any():
         if numpy.shape(fillval) == ():
             fillval = numpy.tile(fillval, fillshape)
         else:

--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -50,6 +50,7 @@ __all__ = ["DataManager", "apply_index", "array_interleave", "axis_index",
 import datetime
 import operator
 import os.path
+import posixpath
 import re
 
 import numpy
@@ -214,7 +215,7 @@ class RePath(object):
         return re.match('^' + pat + '$', string)
 
     @staticmethod
-    def path_split(path):
+    def path_split(path, native=False):
         """
         Break a path apart into a list for each path element.
 
@@ -222,19 +223,23 @@ class RePath(object):
         ==========
         path : str
             Path to split
+        native : bool
+            Is this a native path or UNIX-style? (default False, UNIX)
 
         Returns
         =======
         out : list of str
             One path element (directory or file) per item
         """
+        split = os.path.split if native else posixpath.split
         res = []
         while path:
-            path, tail = os.path.split(path)
-            res.insert(0, tail)
-            if path == '/':
-                res.insert(0, '/')
+            base, tail = split(path)
+            if base == path: #No further splitting
+                res.insert(0, path)
                 break
+            res.insert(0, tail)
+            path = base
         return res
 
     @staticmethod

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -8,7 +8,9 @@ Copyright 2015 University System of New Hampshire
 
 import datetime
 import itertools
+import ntpath
 import os
+import os.path
 import shutil
 import tempfile
 import unittest
@@ -74,6 +76,22 @@ class RePathTests(unittest.TestCase):
         self.assertEqual(
             ["/", "foo", "rbspa_ect-hope-sci-L2_20150409_v5.0.0.cdf"],
             spacepy.datamanager.RePath.path_split(path))
+
+    def test_path_split_win(self):
+        """Simple splitting on Windows paths"""
+        oldpath = os.path
+        os.path = ntpath #Pretend we're on Windows
+        try:
+            path = "foo\\bar\\baz"
+            self.assertEqual(
+                ["foo", "bar", "baz"],
+                spacepy.datamanager.RePath.path_split(path, native=True))
+            path = "C:\\foo\\rbspa_ect-hope-sci-L2_20150409_v5.0.0.cdf"
+            self.assertEqual(
+                ["C:\\", "foo", "rbspa_ect-hope-sci-L2_20150409_v5.0.0.cdf"],
+                spacepy.datamanager.RePath.path_split(path, native=True))
+        finally:
+            os.path = oldpath
 
     def test_path_slice(self):
         """Verify slicing on a path"""

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -11,6 +11,7 @@ import itertools
 import ntpath
 import os
 import os.path
+import posixpath
 import shutil
 import sys
 import tempfile
@@ -62,6 +63,9 @@ class DataManagerClassTests(unittest.TestCase):
                                                  c['descend'])
             expected = [os.path.join(dirlist[0], f) for f in c['files1']]
             expected.extend([os.path.join(dirlist[1], f) for f in c['files2']])
+            #We're not going to be crazy and put slashes in the tests....
+            expected = [e.replace(posixpath.sep, os.path.sep)
+                        for e in expected]
             output = list(dm.files_matching(c['dt']))
             numpy.testing.assert_array_equal(
                 sorted(expected), sorted(output), 'Case:' + str(c))
@@ -161,6 +165,14 @@ class RePathTests(unittest.TestCase):
         self.assertTrue(r.match(
             '2015/rbspa_ect-hope-sci-L2_20150410_v4.0.0.cdf',
             where='end'))
+
+    def test_path_match_toplevel(self):
+        """Single toplevel dir"""
+        #This is the reduced case of Case 3 in test_files_matching,
+        #which fails on Windows
+        r = spacepy.datamanager.RePath(
+            r'%Y/rbspa_ect-hope-sci-L2_%Y%m%d_v(\d\.){3}cdf')
+        self.assertTrue(r.match('2015', None, 'start'))
 
 
 class DataManagerFunctionTests(unittest.TestCase):

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -12,6 +12,7 @@ import ntpath
 import os
 import os.path
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -79,8 +80,9 @@ class RePathTests(unittest.TestCase):
 
     def test_path_split_win(self):
         """Simple splitting on Windows paths"""
-        oldpath = os.path
-        os.path = ntpath #Pretend we're on Windows
+        if sys.platform != 'win32':
+            oldpath = os.path
+            os.path = ntpath #Pretend we're on Windows
         try:
             path = "foo\\bar\\baz"
             self.assertEqual(
@@ -91,7 +93,8 @@ class RePathTests(unittest.TestCase):
                 ["C:\\", "foo", "rbspa_ect-hope-sci-L2_20150409_v5.0.0.cdf"],
                 spacepy.datamanager.RePath.path_split(path, native=True))
         finally:
-            os.path = oldpath
+            if sys.platform != 'win32':
+                os.path = oldpath
 
     def test_path_slice(self):
         """Verify slicing on a path"""
@@ -104,6 +107,27 @@ class RePathTests(unittest.TestCase):
         self.assertEqual("bar/baz",
                          spacepy.datamanager.RePath.path_slice(
                              path, 1, 3))
+
+    def test_path_slice_win(self):
+        """Verify slicing on a path, Windows"""
+        if sys.platform != 'win32':
+            oldpath = os.path
+            os.path = ntpath #Pretend we're on Windows
+        try:
+            path = "foo\\bar\\baz"
+            self.assertEqual(
+                "bar",
+                spacepy.datamanager.RePath.path_slice(path, 1, native=True))
+            self.assertEqual(
+                "foo\\baz",
+                spacepy.datamanager.RePath.path_slice(
+                    path, 0, step=2, native=True))
+            self.assertEqual(
+                "bar\\baz",
+                spacepy.datamanager.RePath.path_slice(path, 1, 3, native=True))
+        finally:
+            if sys.platform != 'win32':
+                os.path = oldpath
 
     def test_path_match(self):
         """Verify matching a path regex"""


### PR DESCRIPTION
Basically just expiicitly uses POSIX paths (as is the design for RePath), although adds an option for native paths in some low-level utility functions where it might be handy.
