### PR TITLE
Add/update license and copyright info

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,19 @@
+Copyright (c) 2010, Triad National Security, LLC
+All rights reserved.
+
+This software was produced under U.S. Government contract 89233218CNA000001 for
+Los Alamos National Laboratory (LANL), which is operated by Triad National 
+Security, LLC for the U.S. Department of Energy. All rights in the program are
+reserved by Triad National Security, LLC, and the U.S. Department of Energy/
+National Nuclear Security Administration. The Government is granted for itself
+and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+license in this material to reproduce, prepare derivative works, distribute
+copies to the public, perform publicly and display publicly, and to permit
+others to do so.
+
+This is open source software; you can redistribute it and/or modify it under the 
+terms of the Python Software Foundation License. If software is modified to
+produce derivative works, such modified software should be clearly marked, so
+as not to confuse it with the version available from LANL. Full text of the 
+Python Software Foundation License can be found in the LICENSE.md file in the
+main development branch of the repository.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,50 @@
+Copyright 2010 Triad National Security, LLC
+
+1. This LICENSE AGREEMENT is between Triad National Security, LLC ("Triad"),
+   and the Individual or Organization ("Licensee") accessing and otherwise
+   using SpacePy software in source or binary form and its associated
+   documentation.
+
+2. Subject to the terms and conditions of this License Agreement, Triad
+   hereby grants Licensee a nonexclusive, royalty-free, world-wide license
+   to reproduce, analyze, test, perform and/or display publicly, prepare
+   derivative works, distribute, and otherwise use SpacePy alone or in any
+   derivative version, provided, however, that Triad's License Agreement and
+   Triad's notice of copyright, i.e., "Copyright (c) 2010 Triad National
+   Security, LLC; All Rights Reserved" are retained in SpacePy alone or in any
+   derivative version prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on or 
+   incorporates SpacePy or any part thereof, and wants to make the derivative
+   work available to others as provided herein, then Licensee hereby agrees to
+   include in any such work a brief summary of the changes made to SpacePy.
+
+4. Triad is making SpacePy available to Licensee on an "AS IS" basis. TRIAD
+   MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF
+   EXAMPLE, BUT NOT LIMITATION, LANS MAKES NO AND DISCLAIMS ANY REPRESENTATION
+   OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT
+   THE USE OF SPACEPY WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. TRIAD SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF SPACEPY FOR ANY
+   INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+   MODIFYING, DISTRIBUTING, OR OTHERWISE USING SPACEPY, OR ANY DERIVATIVE
+   THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material breach
+   of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any relationship
+   of agency, partnership, or joint venture between LANS and Licensee. This
+   License Agreement does not grant permission to use Triad trademarks or trade
+   name in a trademark sense to endorse or promote products or services of
+   Licensee, or any third party.
+
+8. By copying, installing or otherwise using SpacePy, Licensee agrees to be
+   bound by the terms and conditions of this License Agreement.
+
+
+The modified version of IRBEMlib distributed with SpacePy is covered by the Lesser
+GNU Public License (LGPL).
+
+The LANLstar module depends on the ffnet package which is distributed under the
+GNU Public License (GPL). The use of LANLstar is therefore covered by the GPL.

--- a/METADATA.in
+++ b/METADATA.in
@@ -1,0 +1,3 @@
+include README.md
+include COPYRIGHT.md
+include LICENSE.md

--- a/setup.py
+++ b/setup.py
@@ -874,7 +874,7 @@ setup_kwargs = {
     'author_email': 'spacepy@lanl.gov',
     'maintainer': 'Steve Morley, Josef Koller, Dan Welling, Brian Larsen, Mike Henderson, Jon Niehof',
     'maintainer_email': 'spacepy@lanl.gov',
-    'url': 'http://spacepy.lanl.gov',
+    'url': 'https://github.com/spacepy/spacepy',
 #download_url will override pypi, so leave it out http://stackoverflow.com/questions/17627343/why-is-my-package-not-pulling-download-url
 #    'download_url': 'https://sourceforge.net/projects/spacepy/files/spacepy/',
     'requires': ['numpy (>=1.6)', 'scipy (>=0.10)', 'matplotlib (>=1.5)', 'python_dateutil',

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -140,31 +140,15 @@ __contact__ = 'spacepy@lanl.gov'
 __license__ = """SpacePy: Space Science Tools for Python
 
 
-Copyright 2010-2016 Los Alamos National Security, LLC.
+Copyright 2010 Triad National Security, LLC.
 All Rights Reserved.
 
- This material was produced under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National Laboratory (LANL), which is operated by Los Alamos National Security, LLC for the U.S. Department of Energy. The U.S. Government has rights to use, reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE
-
-
- 1. This LICENSE AGREEMENT is between the Los Alamos National Security, LLC ("LANS"), and the Individual or Organization ("Licensee") accessing and otherwise using SpacePy 0.1.6 software in source or binary form and its associated documentation.
-
- 2. Subject to the terms and conditions of this License Agreement, LANS hereby grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce, analyze, test, perform and/or display publicly, prepare derivative works, distribute, and otherwise use SpacePy 0.1.6 alone or in any derivative version, provided, however, that LANS' License Agreement and LANS' notice of copyright, i.e., "Copyright (c) 2010-2016 Los Alamos National Security, LLC; All Rights Reserved" are retained in SpacePy 0.1.6 alone or in any derivative version prepared by Licensee.
-
- 3. In the event Licensee prepares a derivative work that is based on or incorporates SpacePy 0.1.6 or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to SpacePy 0.1.6.
-
- 4. LANS is making SpacePy 0.1.6 available to Licensee on an "AS IS" basis. LANS MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, LANS MAKES NO AND DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF SPACEPY 0.1.6 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
-
- 5. LANS SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF SPACEPY 0.1.6 FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING SPACEPY 0.1.6, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
-
- 6. This License Agreement will automatically terminate upon a material breach of its terms and conditions.
-
- 7. Nothing in this License Agreement shall be deemed to create any relationship of agency, partnership, or joint venture between LANS and Licensee. This License Agreement does not grant permission to use LANS trademarks or trade name in a trademark sense to endorse or promote products or services of Licensee, or any third party.
-
- 8. By copying, installing or otherwise using SpacePy 0.1.6, Licensee agrees to be bound by the terms and conditions of this License Agreement.
-
- The modified version of IRBEMlib distributed with SpacePy is covered by the Lesser GNU Public License (LGPL).
-
- The LANLstar module depends on the ffnet package which is distributed under the GNU Public License (GPL). The use of LANLstar is therefore covered by the GPL.
+This is open source software; you can redistribute it and/or modify it under the 
+terms of the Python Software Foundation License. If software is modified to
+produce derivative works, such modified software should be clearly marked, so
+as not to confuse it with the version available from LANL. Full text of the 
+Python Software Foundation License can be found in the LICENSE.md file in the
+main development branch of the repository (https://github.com/spacepy/spacepy).
 """
 
 if sys.platform == 'win32':


### PR DESCRIPTION
This PR closes issue #14 

License/copyright information was previously only in the LICENSE attribute in the code. Further LANS, LLC asserted copyright prior to providing open source approval for SpacePy, and that IP was transferred to Triad National Security, LLC with the recent M&O contract change.

This addresses all of these by:
- Providing explicit COPYRIGHT.md and LICENSE.md files
- Abbreviating the LICENSE attribute for maintainability
- Adding a METADATA.in file that should carry the license info with installed wheels
- Updating the URL in the setup to no longer point to the old website, this now points to the github repo.

