### PR TITLE
Pycdf slow ro again

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ pycdf
  - Speed up many operations by cacheing variable numbers. This is the biggest
    change to pycdf internals in several years; please report any bugs.
  - Fix TT2000-to-EPOCH16 conversions crashing in very rare cases.
+ - Minimize setting/unsetting readonly mode, as this can be very slow.
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1838,7 +1838,8 @@ class CDF(MutableMapping):
 
         lib.call(const.OPEN_, const.CDF_, self.pathname, ctypes.byref(self._handle))
         self._opened = True
-        self.readonly(readonly)
+        if readonly: #Default is RW
+            self.readonly(readonly)
 
     def _create(self):
         """Creates (and opens) a new CDF file
@@ -1883,9 +1884,7 @@ class CDF(MutableMapping):
         if os.path.exists(self.pathname):
             raise CDFError(const.CDF_EXISTS)
         shutil.copy2(master_path, self.pathname)
-        self._open()
-        self._opened = True
-        self.readonly(False)
+        self._open(False)
 
     @classmethod
     def from_data(cls, filename, sd):

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -2019,8 +2019,10 @@ class CDF(MutableMapping):
         .. note::
             Closing a CDF that has been opened readonly, or setting readonly
             False, may take a substantial amount of time if there are many
-            variables in the CDF. Consider specifying ``readonly=False``
-            when opening the file if this is an issue.
+            variables in the CDF, as a (potentially large) cache needs to
+            be cleared. Consider specifying ``readonly=False`` when opening
+            the file if this is an issue. However, this may make some reading
+            operations slower.
 
         Other Parameters
         ================


### PR DESCRIPTION
I found a case where opening a CDF from master meant it was opened read-only and then read-write, which was needlessly slow.

Also put in a documentation note of the ups and downs of readonly; some benchmarking indicates the cache does help things out in some cases, so always opening read-write doesn't seem like a good idea.

