### PR TITLE
pycdf: Fix crash in tt2000_to_epoch16 (Closes #60)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ pycdf
  - Fix UTC-to-TT2000 conversions on ARM (thanks Rodrigue Piberne for the bug)
  - Speed up many operations by cacheing variable numbers. This is the biggest
    change to pycdf internals in several years; please report any bugs.
+ - Fix TT2000-to-EPOCH16 conversions crashing in very rare cases.
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -349,6 +349,26 @@ class NoCDF(unittest.TestCase):
         for (epoch, tt2000) in zip(epochs, tt2000s):
             self.assertEqual(epoch, list(cdf.lib.tt2000_to_epoch16(tt2000)))
 
+    def testTT2000ToEpoch16Stress(self):
+        """Test TT2000toEpoch16 repeatedly to make sure it doesn't crash"""
+        epochs = [[63366364799.0, 999999999000.0],
+                  [63400665600.0, 100000000.0],
+                  ]
+        tt2000s = [252417665183999999,
+                   286718466184100000,
+                   ]
+        #this is basically 2x what reliably fails in the Win32/py2.7 case,
+        #where this problem was found
+        for i in range(10):
+            for (epoch, tt2000) in zip(epochs, tt2000s):
+                self.assertEqual(epoch, list(cdf.lib.tt2000_to_epoch16(tt2000)))
+
+    def testTT2000ToEpoch16Filled(self):
+        """Test conversion of TT2000 fill value to epoch 16"""
+        self.assertEqual(
+            (-1.e31, -1.e31),
+            cdf.lib.tt2000_to_epoch16(const.FILLED_TT2000_VALUE))
+
     def testEpochtoEpoch16(self):
         """Convert an Epoch to Epoch16"""
         epochs = [63397987200000.0,


### PR DESCRIPTION
This fixes a crash caused by tt2000_to_epoch16; the essence is to fix the return value (misdocumented in the CDF C manual, which has been sent upstream.) There's some additional cleanup while I was at it.
