### PR TITLE
Fixed gzip read on Windows/Py2.7 (pybats, ae9ap9)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,11 @@
 Changes in Version 0.1.7 (2017-xx-xx)
 =====================================
 - Fix writing of configuration file on Windows
+ae9ap9
+ - Fix handling of gzipped files under Windows/Python2
 pybats
  - Many small changes and bugfixes (thanks John Haiducek)
+ - Fix handling of gzipped files under Windows/Python2
 pycdf
  - Proper handling of type guessing for negative integers and numpy scalars
  - Allow ... to get all gEntries

--- a/spacepy/ae9ap9.py
+++ b/spacepy/ae9ap9.py
@@ -541,7 +541,10 @@ def _readHeader(fname):
     """
     dat = []
     if fname.endswith('.gz'):
-        fp = gzip.open(fname, 'rt')
+        try:
+            fp = gzip.open(fname, 'rt')
+        except ValueError: #Python 2.7 (Windows) compatibility
+            fp = gzip.open(fname)
     else:
         fp = open(fname, 'rt')
     while True:

--- a/spacepy/pybats/rim.py
+++ b/spacepy/pybats/rim.py
@@ -188,7 +188,10 @@ class Iono(PbData):
 
         # slurp entire file.
         if self.attrs['file'][-3:]=='.gz':
-            infile=gzip.open(self.attrs['file'],'rt')
+            try:
+                infile = gzip.open(self.attrs['file'],'rt')
+            except ValueError: #Python2.7 (Windows) compatibility
+                infile = gzip.open(self.attrs['file'])
         else:
             infile = open(self.attrs['file'], 'r')
         raw = infile.readlines()


### PR DESCRIPTION
Closes issue #59 

Resolves incorrect read mode in Python 2 on Windows. The discussion in #59 includes a reference to a bug report for Python where this was discussed. Using the io.TextIOWrapper as discussed is not a solution as it forces the failure under Python 2.7 to a different spot.

This fix simply tries the original read, and if it fails with a ValueError then it tries to read using the default mode (which gives the desired results on Windows with Python 2). No additional tests are needed as the unit tests that were failing under Windows now pass (Windows 10, Python 2.7.16 (Anaconda)).