### PR TITLE
Explicitly preserve dtypes converting SpaceData to numpy recarray

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ Changes in Version 0.1.7 (2017-xx-xx)
 - Fix writing of configuration file on Windows
 ae9ap9
  - Fix handling of gzipped files under Windows/Python2
+datamodel
+ - Datatypes are now explicitly preserved by function "toRecArray"
 pybats
  - Many small changes and bugfixes (thanks John Haiducek)
  - Fix handling of gzipped files under Windows/Python2

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1774,8 +1774,8 @@ def toRecArray(sdo):
     >>> print(ra, ra.dtype)
     [(2, 1.0) (4, 2.0)] (numpy.record, [('y', '<i8'), ('x', '<f8')])
     '''
-    keys = list(sdo.keys())
-    recarr = numpy.rec.fromarrays( [sdo[k] for k in sdo], names=keys)
+    nametype = numpy.dtype([(k, sdo[k].dtype.str) for k in sdo])
+    recarr = numpy.rec.fromarrays( [sdo[k] for k in sdo], dtype=nametype)
     return recarr
 
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -445,8 +445,8 @@ class dmarrayTests(unittest.TestCase):
         np.testing.assert_equal(tst, ans)
         self.assertEqual(tst.dtype, ans.dtype)
 
-    def test_toRecArray(self):
-        '''a record array can be created from a SpaceData'''
+    def test_toRecArray_contents(self):
+        '''a record array can be created from a SpaceData, keys and values equal'''
         sd = dm.SpaceData()
         sd['x'] = dm.dmarray([1.0, 2.0])
         sd['y'] = dm.dmarray([2,4])
@@ -454,8 +454,27 @@ class dmarrayTests(unittest.TestCase):
         np.testing.assert_equal(ra['x'], [1.0, 2.0])
         np.testing.assert_equal(ra['y'], [2, 4])
         self.assertEqual(['x', 'y'], sorted(ra.dtype.fields))
-        self.assertTrue(ra.dtype in (np.dtype((np.record, [('x', '<f8'), ('y', '<i8'), ])), np.dtype((np.record, [ ('y', '<i8'), ('x', '<f8'), ]))))
 
+    def test_toRecArray_dtypes1(self):
+        '''recarray created from dmarray preserves data types (32-bit)'''
+        sd = dm.SpaceData()
+        sd['x'] = dm.dmarray([1.0, 2.0], dtype=np.float32)
+        sd['y'] = dm.dmarray([2,4], dtype=np.int32)
+        ra = dm.toRecArray(sd)
+        expected = [sd[key].dtype for key in sd]
+        got = [ra.dtype[name] for name in ra.dtype.names]
+        self.assertEqual(expected, got)
+
+    def test_toRecArray_dtypes2(self):
+        '''recarray created from dmarray preserves data types (16-bit+str)'''
+        sd = dm.SpaceData()
+        sd['x'] = dm.dmarray([1.0, 2.0], dtype=np.float16)
+        sd['y'] = dm.dmarray([2,4], dtype=np.int16)
+        sd['str'] = dm.dmarray(['spam', 'eggs'], dtype='|S5')
+        ra = dm.toRecArray(sd)
+        expected = [sd[key].dtype for key in sd]
+        got = [ra.dtype[name] for name in ra.dtype.names]
+        self.assertEqual(expected, got)
         
 class converterTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes #62 

A test failure on Windows highlighted that dtypes were not guaranteed to be consistent across platforms (e.g., numpy might assign `numpy.array([4])` a dtype of int32 or int64). Also, dtypes were not guaranteed to be preserved on creating a recarray from a SpaceData (the default dtype-guessing was being used on creating the recarray, so specified dtypes may not be honoured).

This PR:
- Changes the failing test so that it doesn't check types, just equality of contents
- Adds new tests to check for type-preservation
- Updates `toRecArray` so that it uses the names/dtypes from the SpaceData contents to set the names/dtypes in the numpy record array
- Notes the change in CHANGELOG

Tested on Python 2.7 (64-bit) on Windows, plus everything in the CI.