### PR TITLE
omni: open the database readonly to accommodate multiprocessing scenarios (Closes #128)

### DIFF
--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -245,7 +245,7 @@ def get_omni(ticks, dbase='QDhourly', **kwargs):
         else:
             ldb = 'Test'
             fln = testfln
-        with h5.File(fln) as hfile:
+        with h5.File(fln, 'r') as hfile:
             QDkeylist = [kk for kk in hfile if kk not in ['Qbits', 'UTC']]
             st, en = ticks[0].RDT, ticks[-1].RDT
             ##check that requested requested times are within range of data


### PR DESCRIPTION
When reading the omni database, open the file so another process can also read from it.

Doing a proper unit test for this got ridiculous, because it would require inserting locking into get_omni to resolve the race condition between the two processes (or just spawning a zillion and hoping.) Opening the file outside of read_omni doesn't work: if opened r/w, then the omni readonly open still fails. If opened ro, then a rw open later on in omni still succeeds. So there's no way to "prepare" the omni read for failure if omni opens rw.

(Open RO, then RO: fine.
RW, then RO: RO fails.
RO, then RW: fine.
RW, then RW: second RW fails.)
