### PR TITLE
Pycdf more type guessing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,7 +9,8 @@ pybats
  - Many small changes and bugfixes (thanks John Haiducek)
  - Fix handling of gzipped files under Windows/Python2
 pycdf
- - Proper handling of type guessing for negative integers and numpy scalars
+ - Proper handling of type guessing for negative integers, numpy scalars, and
+   object arrays.
  - Allow ... to get all gEntries
  - Allow insert, append on gAttrs
  - Properly handle reading from empty variables

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -491,6 +491,7 @@ class NoCDF(unittest.TestCase):
                    -1 * 2 ** 31,
                    numpy.array([5, 6, 7], dtype=numpy.uint8),
                    [4611686018427387904],
+                   numpy.array([1], dtype=numpy.object),
                    ]
         type8 = [((4,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
                          const.CDF_INT2, const.CDF_UINT2,
@@ -526,6 +527,11 @@ class NoCDF(unittest.TestCase):
                  ((1,), [const.CDF_INT8,
                        const.CDF_FLOAT, const.CDF_REAL4,
                        const.CDF_DOUBLE, const.CDF_REAL8], 1),
+                 ((1,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
+                         const.CDF_INT2, const.CDF_UINT2,
+                         const.CDF_INT4, const.CDF_UINT4, const.CDF_INT8,
+                         const.CDF_FLOAT, const.CDF_REAL4,
+                         const.CDF_DOUBLE, const.CDF_REAL8], 1),
                  ]
         types = [((4,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
                          const.CDF_INT2, const.CDF_UINT2,
@@ -562,7 +568,13 @@ class NoCDF(unittest.TestCase):
                  ((3,), [const.CDF_UINT1, const.CDF_UCHAR], 1),
                  ((1,), [const.CDF_FLOAT, const.CDF_REAL4,
                        const.CDF_DOUBLE, const.CDF_REAL8], 1),
+                 ((1,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
+                         const.CDF_INT2, const.CDF_UINT2,
+                         const.CDF_INT4, const.CDF_UINT4,
+                         const.CDF_FLOAT, const.CDF_REAL4,
+                         const.CDF_DOUBLE, const.CDF_REAL8], 1),
                  ]
+        self.assertRaises(ValueError, cdf._Hyperslice.types, [object()])
         if cdf.lib.supports_int8: #explicitly test backward-compatible
             cdf.lib.supports_int8 = False
             try:

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -490,6 +490,7 @@ class NoCDF(unittest.TestCase):
                    numpy.int32(-1 * 2 ** 31),
                    -1 * 2 ** 31,
                    numpy.array([5, 6, 7], dtype=numpy.uint8),
+                   [4611686018427387904],
                    ]
         type8 = [((4,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
                          const.CDF_INT2, const.CDF_UINT2,
@@ -522,6 +523,9 @@ class NoCDF(unittest.TestCase):
                        const.CDF_FLOAT, const.CDF_REAL4,
                        const.CDF_DOUBLE, const.CDF_REAL8], 1),
                  ((3,), [const.CDF_UINT1, const.CDF_UCHAR], 1),
+                 ((1,), [const.CDF_INT8,
+                       const.CDF_FLOAT, const.CDF_REAL4,
+                       const.CDF_DOUBLE, const.CDF_REAL8], 1),
                  ]
         types = [((4,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
                          const.CDF_INT2, const.CDF_UINT2,
@@ -556,6 +560,8 @@ class NoCDF(unittest.TestCase):
                  ((), [const.CDF_INT4, const.CDF_FLOAT, const.CDF_REAL4,
                        const.CDF_DOUBLE, const.CDF_REAL8], 1),
                  ((3,), [const.CDF_UINT1, const.CDF_UCHAR], 1),
+                 ((1,), [const.CDF_FLOAT, const.CDF_REAL4,
+                       const.CDF_DOUBLE, const.CDF_REAL8], 1),
                  ]
         if cdf.lib.supports_int8: #explicitly test backward-compatible
             cdf.lib.supports_int8 = False


### PR DESCRIPTION
I found an instance where passing a numpy array of dtype object but that  contained entirely integers resulted in a float variable being created. This PR improves the handling of object arrays, by trying to convert them to numeric and explicitly raising an error if that is not possible.

This doesn't affect the handling of object arrays containing datetimes, as those are handled before this code is hit.
