### PR TITLE
Replace defunct calls to matplotlib.mlab in data_assimilation

### DIFF
--- a/spacepy/data_assimilation.py
+++ b/spacepy/data_assimilation.py
@@ -7,7 +7,6 @@ import numpy as np
 from numpy.linalg import svd
 import pdb
 from spacepy.toolbox import feq
-from matplotlib.mlab import find
 
 __contact__ = 'Josef Koller, jkoller@lanl.gov'
 
@@ -627,10 +626,10 @@ def getobs4window(dd, Tnow):
 
     Lmean = np.mean(Lmean)
     # move to actual grid point
-    print(Lmeana)
-    idx = find(Lgrid>Lmean)[0]
+    print(Lmean)
+    idx,  = np.where(Lgrid>Lmean)
 
-    Lmean = Lgrid[idx]
+    Lmean = Lgrid[idx[0]]
     ymean = np.mean(ymean)
     return dd, np.array([Lmean]), np.array([ymean])
 


### PR DESCRIPTION
`matplotlib.mlab` used to supply a number of functions to replicate MatLab functionality and syntax. These were deprecated some time ago. `spacepy.data_assimilation` used `matplotlib.mlab.find`: this was deprecated in matplotlib 2.2 and removed in the latest version.

The removal in the latest version means we're now failing continuous integration.

This PR replaces the call to `find` with `numpy.where` so that the mlab dependence is gone and the fix is compatible even with very old versions of numpy.

This PR closes issue #133 