### PR TITLE
pycdf: Compatibility with CDF library 3.7.1 (Closes #142)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@ pycdf
    change to pycdf internals in several years; please report any bugs.
  - Fix TT2000-to-EPOCH16 conversions crashing in very rare cases.
  - Minimize setting/unsetting readonly mode, as this can be very slow.
+ - Update for API changes in CDF library 3.7.1 (compatibility maintained
+   with earlier versions)
 
 Changes in Version 0.1.6 (2016-09-08)
 =====================================

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -228,9 +228,14 @@ class NoCDF(unittest.TestCase):
                   0.0,
                   ]
         dts = [datetime.datetime(2009, 1, 1),
-               datetime.datetime(9999, 12, 13, 23, 59, 59, 999000),
+               datetime.datetime(9999, 12, 31, 23, 59, 59, 999000),
                datetime.datetime(9999, 12, 13, 23, 59, 59, 999000),
                ]
+        #3.7.1 updated the "invalid" value to 12/31, but only in one
+        #case; rest remain 12/13.
+        if cdf.lib.version[0:3] < (3, 7, 1):
+            dts[1] = datetime.datetime(
+                9999, 12, 13, 23, 59, 59, 999000)
         for (epoch, dt) in zip(epochs, dts):
             self.assertEqual(dt, cdf.lib.epoch_to_datetime(epoch))
         result = cdf.lib.v_epoch_to_datetime(numpy.array(epochs))


### PR DESCRIPTION
CDF library API changed from 3.7.1 to 3.7.0 (new names for CDF_TT2000_from_UTC_parts and CDF_TT2000_to_UTC_parts). Also in a lot of cases the library was returning 9999/12/13 for invalid dates; one of those cases (but not others) has been changed to 9999/12/31 so the test needed to be updated.