### PR TITLE
Fixed implicit int division in EventClicker

### DIFF
--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -129,7 +129,7 @@ class EventClicker(object):
     True
     >>> troughs = e[:, 1, 0] #x value of event ends
     >>> troughs -= 2 * numpy.pi * numpy.floor(troughs / (2 * numpy.pi))
-    >>> max(numpy.abs(peaks - 3 * numpy.pi / 2)) < 0.2 #troughs near 3pi/2
+    >>> max(numpy.abs(troughs - 3 * numpy.pi / 2)) < 0.2 #troughs near 3pi/2
     True
     >>> d = clicker.get_events_data() #snap-to-data of events
     >>> peakvals = d[:, 0, 1] #y value, snapped near peaks
@@ -355,7 +355,7 @@ class EventClicker(object):
         self.ax.axvline(
             xval,
             color=self._colors[self._curr_phase % len(self._colors)],
-            ls=self._styles[self._curr_phase / len(self._colors) % len(self._styles)])
+            ls=self._styles[self._curr_phase // len(self._colors) % len(self._styles)])
         if not self._xydata is None:
             point_disp = self.ax.transData.transform(
                 numpy.array([[xval, yval]])


### PR DESCRIPTION
Closes #4.

- Changed a divide on an integer to an explicit `//` so it won't fail in Python 3
- Corrected a typo in the docstring example so that it works with a cpaste into the interpreter

As discussed in #4 the only way I could reproduce the remaining issues in the description was to use non-line-based data. Changing that should be a new enhancement request. (Sorry about the ancient commit, but I forgot I had already committed a fix locally!)

