### PR TITLE
Update testWriteWrongSizeData (Closes #66)

### DIFF
--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2770,8 +2770,10 @@ class ChangezVar(ChangeCDFBase):
 
     def testWriteWrongSizeData(self):
         """Write with data sized or shaped differently from expected"""
-        message = 'attempt to assign data of dimensions (3,) ' + \
-                  'to slice of dimensions (5,)'
+        #This is a bit odd but numpy "shape" is sometimes Long...
+        message = ('attempt to assign data of dimensions {} '
+                  'to slice of dimensions (5,)').format(
+                      str(numpy.array([1, 2, 3]).shape))
         try:
             self.cdf['SpinNumbers'][0:5] = [b'99', b'98', b'97']
         except ValueError:
@@ -2780,8 +2782,10 @@ class ChangezVar(ChangeCDFBase):
         else:
             self.fail('Should have raised ValueError: ' + message)
 
-        message = 'attempt to assign data of dimensions (2, 6, 2) ' + \
-                  'to slice of dimensions (3, 6, 2)'
+        message = ('attempt to assign data of dimensions {} '
+                  'to slice of dimensions (3, 6, 2)').format(
+                      str(numpy.empty((2, 6, 2)).shape))
+
         try:
             self.cdf['SpinRateScalersCounts'][0:3, 12:, 0:4:2] = \
                 [[[0, 1], [2, 3], [4, 5], [6, 7], [8, 9], [0, 1]],


### PR DESCRIPTION
numpy shapes are "long" on 64-bit python 2 (probably because of the 32-bit long issue that's been biting us.) So the string representation has a bunch of "L". This PR makes the check for the error message match whatever representation numpy gives us.

This isn't a functionality issue, just a test.