### PR TITLE
irbem: moved inline comments on statement lines (for f2py)

### DIFF
--- a/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/AE8_AP8.f
+++ b/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/AE8_AP8.f
@@ -152,7 +152,8 @@ c
       UT_dip=0.d0
       DO isat = 1,ntime
          ! need to reinitialize sun for GEI to GEO coordinate transforms
-         CALL INIT_GSM(iyear(isat),idoy(isat),UT(isat),psi) ! compute sun among other things
+         ! INIT_GSM: compute sun among other things
+         CALL INIT_GSM(iyear(isat),idoy(isat),UT(isat),psi)
          tilt = psi/rad ! in common block dip_ang
 
 	    call get_coordinates ( sysaxes, 
@@ -226,8 +227,10 @@ c  minimum and maximum Lshell to calculate electron fluxes
       PARAMETER   (xMAXE_L = 12.0)
 
       INTEGER*4   ntmax,i,nene,ieny
-      INTEGER*4   whichm  !1=AE8min 2=AE8max 3=AP8min 4=AP8max
-      INTEGER*4   whatf  !1=diff 2=E range 3=int
+      !model flags: 1=AE8min 2=AE8max 3=AP8min 4=AP8max
+      INTEGER*4   whichm
+      !flux flags: 1=diff 2=E range 3=int
+      INTEGER*4   whatf
       INTEGER*4 MAPPMIN(16582), MAPPMAX(16291),
      &           MAPEMIN(13168), MAPEMAX(13548)
       REAL*8      energy(2,25)

--- a/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/CoordTrans.f
+++ b/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/CoordTrans.f
@@ -2820,7 +2820,8 @@ C
       INTEGER*4 nmax,i,ntime, sysaxesIN, sysaxesOUT
       INTEGER*4 iyear(ntime_max),idoy(ntime_max),y,d
       REAL*8 secs(ntime_max),xINV(3,ntime_max),xOUTV(3,ntime_max)
-      REAL*8 xIN(3),xOUT(3),s   ! local vars
+      ! local vars
+      REAL*8 xIN(3),xOUT(3),s
 
       ! Loop over the number of points specified, calling
       !  coord_trans1 each iteration

--- a/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/drift_bounce_orbit.f
+++ b/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/drift_bounce_orbit.f
@@ -20,7 +20,8 @@
 C-----------------------------------------------------------------------------
 C     Wrappers and procedures for ONERA_DESP_LIB
 C-----------------------------------------------------------------------------
-      REAL*4 FUNCTION drift_bounce_orbit(argc, argv) ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION drift_bounce_orbit(argc, argv)
       INCLUDE 'wrappers.inc'
 c     INTEGER*4 argc, argv(*)                      ! Argc and Argv are integers
       
@@ -42,7 +43,8 @@ c
       RETURN
       END
 
-      REAL*4 FUNCTION drift_bounce_orbit2(argc, argv) ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION drift_bounce_orbit2(argc, argv)
       INCLUDE 'wrappers.inc'
 c     INTEGER*4 argc, argv(*)                      ! Argc and Argv are integers
       
@@ -263,7 +265,8 @@ C     Internal Variables
       
       INTEGER*4  I,J,K,Iflag,Iflag_I,Ilflag,Ifail
       INTEGER*4  Ibounce_flag
-      INTEGER*4  istore         ! azimuth cursor
+      !istore is azimuth cursor
+      INTEGER*4  istore
       REAL*8     Lb
       REAL*8     leI,leI1
       REAL*8     XY,YY
@@ -686,13 +689,15 @@ C
       IMPLICIT NONE
 
 c     Declare input variables
-      REAL*8 xstart(3) ! GEO
-      REAL*8 Bmirror  ! particles mirror field strength
-      INTEGER*4 istore ! where to store bounce orbit
+      !xstart in GEO, Bmirror is particle mirror field strength
+      !istore stores bounce orbit
+      REAL*8 xstart(3)
+      REAL*8 Bmirror
+      INTEGER*4 istore
       ! hmin,hmin_lon are also inputs
 
 c     Declare output variables
-      INTEGER*4  Nposit(25),Iflag ! Iflag=1 means success
+      INTEGER*4  Nposit(25),Iflag
       REAL*8     posit(3,1000,25)
       REAL*8     Bposit(1000,25),R0,hmin,hmin_lon
 
@@ -702,8 +707,10 @@ c     Declare internal variables
       REAL*8 xmir(3)
       REAL*8 alpha
       REAL*8 dsreb0,dsreb,x1(3),x2(3),B1,B2,Bvec(3)
-      INTEGER*4 store ! store or not?
+      ! store or not?
+      INTEGER*4 store
 
+      ! Iflag=1 means success, set to fail until succeeded
       Iflag = 0
 
       if ((istore.gt.25).or.(istore.lt.1)) then

--- a/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/find_foot.f
+++ b/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/find_foot.f
@@ -24,8 +24,8 @@ c
 C Routine to find foot point of field line at specified altitude and hemi
 C finds foot point at specified altitude to within 1 km
 C
-
-      REAL*4 FUNCTION find_foot_point(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION find_foot_point(argc, argv)
       INCLUDE 'wrappers.inc'
 c      INTEGER*4 argc, argv(*)                      ! Argc and Argv are integers
 
@@ -204,8 +204,8 @@ C
 
        INTEGER*4  I,J
        REAL*8     Lb
-C
-       integer*4  IFOUND ! dummy loop result variable
+C      IFOUND is a dummy loop result variable
+       integer*4  IFOUND
 C
 C
        CALL GEO_SM(xx0,xx)
@@ -219,7 +219,8 @@ C
           goto 999
        ENDIF
 
-       call geo_gdz(xx0(1),xx0(2),xx0(3),XFOOT(2),XFOOT(3),XFOOT(1)) ! provides lat/lon/alt at x2
+       !geo_gdz provides lat/lon/alt at x2
+       call geo_gdz(xx0(1),xx0(2),xx0(3),XFOOT(2),XFOOT(3),XFOOT(1))
        if (XFOOT(1).LE.stop_alt) then
             goto 999 ! fail altitude of starting point to low
        endif
@@ -243,13 +244,14 @@ C
        ENDIF
 
 C calcul du sens du depart 
-C
-       CALL sksyst(-dsreb,xx0,x1,Bl,Ifail) ! southward step
+C sksyst call takes southward step
+       CALL sksyst(-dsreb,xx0,x1,Bl,Ifail)
        IF (Ifail.LT.0) THEN
           goto 999
        ENDIF
        B1 = Bl
-       CALL sksyst(dsreb,xx0,x2,Bl,Ifail)! northward step
+C sksyst call takes northward step
+       CALL sksyst(dsreb,xx0,x2,Bl,Ifail)
        IF (Ifail.LT.0) THEN
           goto 999
        ENDIF
@@ -290,7 +292,8 @@ C
 c
 c test for completion
 c need to check: alt < stop_alt, and moving to lower alt (higher B)
-         call geo_gdz(x2(1),x2(2),x2(3),XFOOT(2),XFOOT(3),XFOOT(1)) ! provides lat/lon/alt at x2
+         ! geo_gdz provides lat/lon/alt at x2
+         call geo_gdz(x2(1),x2(2),x2(3),XFOOT(2),XFOOT(3),XFOOT(1))
          if (XFOOT(1).LE.stop_alt) then
             IFOUND = 1
             goto 20 ! done with loop
@@ -305,7 +308,8 @@ C
        if (IFOUND.EQ.1) then
           ! footpoint is between x1 and x2
           if (abs(XFOOT(1)-stop_alt).le.1.0) then
-             call champ(x2,BFOOT,BFOOTMAG,Ifail) ! get field at x2
+             !get B field at x2
+             call champ(x2,BFOOT,BFOOTMAG,Ifail)
              if (Ifail.LT.0) then
                 goto 999
              endif

--- a/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/onera_desp_lib.f
+++ b/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/onera_desp_lib.f
@@ -22,8 +22,8 @@ C-----------------------------------------------------------------------------
 
 
 c function returns version of fortran source code
-
-      REAL*4 FUNCTION IRBEM_FORTRAN_VERSION(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION IRBEM_FORTRAN_VERSION(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -44,8 +44,8 @@ c function returns version of fortran source code
 
 
 c function returns release of fortran source code
-
-      REAL*4 FUNCTION IRBEM_FORTRAN_RELEASE(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION IRBEM_FORTRAN_RELEASE(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -66,8 +66,8 @@ c function returns release of fortran source code
 
 
 c function returns maximum size of variables
-
-      REAL*4 FUNCTION GET_IRBEM_NTIME_MAX(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION GET_IRBEM_NTIME_MAX(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -85,8 +85,8 @@ c function returns maximum size of variables
         INTEGER*4 ntime_max1
         ntime_max1 = ntime_max
       END
-
-      REAL*4 FUNCTION make_lstar(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION make_lstar(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -224,8 +224,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION make_lstar_shell_splitting(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION make_lstar_shell_splitting(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -366,8 +366,8 @@ c Compute Bmin assuming 90� PA at S/C
       END
 c
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION Lstar_Phi(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION Lstar_Phi(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -438,8 +438,8 @@ c
       end
 c
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION drift_shell(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION drift_shell(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -524,8 +524,8 @@ c
       END
 
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION trace_field_line(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION trace_field_line(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -548,8 +548,8 @@ c  subroutine make_Lstar: 17 arguments
       END
 c
 c --------------------------------------------------------------------
-c
-      REAL*4 FUNCTION trace_field_line2(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION trace_field_line2(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -656,8 +656,8 @@ c
       END
 c
 c --------------------------------------------------------------------
-c
-      REAL*4 FUNCTION trace_field_line_towards_earth(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION trace_field_line_towards_earth(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -743,8 +743,8 @@ c
       END
 
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION find_mirror_point(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION find_mirror_point(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -850,8 +850,8 @@ c
 
 
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION find_MAGequator(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION find_MAGequator(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -929,8 +929,8 @@ c
         CALL loc_equator_opt(xGeo,BMIN,posit)
       END
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION GET_FIELD(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION GET_FIELD(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1014,8 +1014,8 @@ c
       END
 C-----------------------------------------------------------------------------
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION GET_FIELD_MULTI_IDL(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION GET_FIELD_MULTI_IDL(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1078,8 +1078,8 @@ c      endif
       end
 c
 c --------------------------------------------------------------------
-c
-      REAL*4 FUNCTION GET_MLT(argc, argv) ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION GET_MLT(argc, argv)
       INCLUDE 'wrappers.inc'
 
       j = loc(argc)             ! Obtains the number of arguments (argc)
@@ -1138,7 +1138,8 @@ C
 C-----------------------------------------------------------------------------
 c******************************************************************************
 c *****************************************************************************
-      REAL*4 FUNCTION GET_HEMI(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION GET_HEMI(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1159,7 +1160,8 @@ c
 C-----------------------------------------------------------------------------
 c******************************************************************************
 c *****************************************************************************
-      REAL*4 FUNCTION GET_HEMI_MULTI_IDL(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION GET_HEMI_MULTI_IDL(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1734,8 +1736,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION coord_trans(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION coord_trans(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1757,8 +1759,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION coord_trans_vec(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION coord_trans_vec(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1781,8 +1783,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION geo2gsm(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION geo2gsm(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1817,8 +1819,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION gsm2geo(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION gsm2geo(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1855,8 +1857,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION geo2gse(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION geo2gse(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1892,8 +1894,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION gse2geo(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION gse2geo(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1932,8 +1934,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION gdz2geo(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION gdz2geo(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1954,8 +1956,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION geo2gdz(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION geo2gdz(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -1976,8 +1978,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION geo2gei(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION geo2gei(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2014,8 +2016,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION gei2geo(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION gei2geo(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2052,8 +2054,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION geo2sm(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION geo2sm(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2090,8 +2092,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION sm2geo(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION sm2geo(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2128,8 +2130,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION gsm2sm(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION gsm2sm(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2161,8 +2163,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION sm2gsm(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION sm2gsm(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2198,8 +2200,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION geo2mag(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION geo2mag(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2231,8 +2233,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION mag2geo(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION mag2geo(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2263,8 +2265,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION sph2car(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION sph2car(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2285,8 +2287,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION car2sph(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION car2sph(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2307,8 +2309,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION rll2gdz(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION rll2gdz(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2328,8 +2330,8 @@ c  subroutine geo2gsm: 6 arguments
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION gse2hee(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION gse2hee(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2350,8 +2352,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION hee2gse(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION hee2gse(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2372,8 +2374,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION hae2hee(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION hae2hee(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2394,8 +2396,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION hee2hae(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION hee2hae(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2416,8 +2418,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION hae2heeq(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION hae2heeq(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2438,8 +2440,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure for ONERA library
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION heeq2hae(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION heeq2hae(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2472,7 +2474,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'fly_in_nasa_aeap_', ntime,sysaxes,whichm,whatf,energy,xIN1,xIN2,xIN3,flux, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION fly_in_nasa_aeap(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION fly_in_nasa_aeap(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2502,7 +2504,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'get_AE8_AP8_flux_idl_', ntime,whichm,whatf,nene,energy,BBo,L,flux, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION get_ae8_ap8_flux_idl(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION get_ae8_ap8_flux_idl(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2532,7 +2534,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'fly_in_afrl_crres_', ntime,sysaxes,whichm,whatf,energy,xIN1,xIN2,xIN3,flux, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION fly_in_afrl_crres(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION fly_in_afrl_crres(argc, argv)
 !
       INTEGER*4   CHAR_SIZE
       PARAMETER      (CHAR_SIZE=500)
@@ -2568,7 +2570,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'get_crres_flux_idl_', ntime,whichm,whatf,Nene,energy,BBo,L,Ap15,flux,afrl_crres_path,strlen, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION get_crres_flux_idl(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION get_crres_flux_idl(argc, argv)
 !
       INTEGER*4   CHAR_SIZE
       PARAMETER      (CHAR_SIZE=500)
@@ -2604,7 +2606,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'fly_in_ige1_', launch_year,duration,whichm,whatf,Nene,energy,Lower_flux,Mean_flux,Upper_flux, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION fly_in_ige(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION fly_in_ige(argc, argv)
 !
       INTEGER*4   CHAR_SIZE
       PARAMETER      (CHAR_SIZE=500)
@@ -2638,7 +2640,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'fly_in_meo_gnss1_', launch_year,duration,whichm,whatf,Nene,energy,Lower_flux,Mean_flux,Upper_flux, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION fly_in_meo_gnss(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION fly_in_meo_gnss(argc, argv)
 !
       INTEGER*4   CHAR_SIZE
       PARAMETER      (CHAR_SIZE=500)
@@ -2672,7 +2674,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'SGP4_TLE_', runtype,startsfe,stopsfe,deltasec,InFileByte,strlenIn,OutFileByte,strlenOut, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION SGP4_TLE(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION SGP4_TLE(argc, argv)
 !
       INTEGER*4   CHAR_SIZE
       PARAMETER      (CHAR_SIZE=500)
@@ -2707,7 +2709,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'SGP4_ORB_', runtype,startsfe,stopsfe,deltasec,InFileByte,strlenIn,OutFileByte,strlenOut, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION SGP4_ELE(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION SGP4_ELE(argc, argv)
 !
       INCLUDE 'wrappers.inc'
 !
@@ -2741,7 +2743,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'RV2COE_IDL_', R, V, P, A, Ecc, Incl, Omega, Argp, Nu, M, ArgLat, TrueLon, LonPer, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION RV2COE_IDL(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION RV2COE_IDL(argc, argv)
 !
       INCLUDE 'wrappers.inc'
 !
@@ -2773,7 +2775,7 @@ c
 !
 ! CALLING SEQUENCE: result=call_external(lib_name, 'DATE_AND_TIME2DECY_IDL_', Year,Month,Day,hour,minute,second,decy, /f_value)
 !---------------------------------------------------------------------------------------------------
-      REAL*4 FUNCTION DATE_AND_TIME2DECY_IDL(argc, argv)   ! Called by IDL
+      REAL*4 FUNCTION DATE_AND_TIME2DECY_IDL(argc, argv)
 !
       INCLUDE 'wrappers.inc'
 !
@@ -2793,8 +2795,8 @@ c
 C-----------------------------------------------------------------------------
 C IDL Wrappers
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION msis86_idl(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION msis86_idl(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2857,8 +2859,8 @@ c
 C-----------------------------------------------------------------------------
 C IDL Wrappers
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION msise90_idl(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION msise90_idl(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2911,8 +2913,8 @@ c
 C-----------------------------------------------------------------------------
 C IDL Wrappers
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION nrlmsise00_idl(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION nrlmsise00_idl(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                    ! Obtains the number of arguments (argc)
@@ -2967,8 +2969,8 @@ c
 C-----------------------------------------------------------------------------
 C Wrapper and procedure
 C-----------------------------------------------------------------------------
-
-      REAL*4 FUNCTION make_lstar_shell_splitting2_idl(argc, argv)   ! Called by IDL
+      ! Called by IDL
+      REAL*4 FUNCTION make_lstar_shell_splitting2_idl(argc, argv)
       INCLUDE 'wrappers.inc'
 
        j = loc(argc)                   ! Obtains the number of arguments (argc)


### PR DESCRIPTION
f2py doesn't like exclamation marks on lines with a declaration e.g. INTEGER or a function call (CALL ...).
These _in-line_ comments have now been moved to adjacent lines, so it quiets down a number of the f2py complaints on compilation. There are still a bunch of warnings from the implied do-loops when constructing the data statements in AE8/AP8, but I don't think that should afect functionality. (It'd still be nice to restructure the Fortran to quiet that down too). I've already pushed this change back up to the IRBEM repo on SF. Most of the changes were in functions we don't use (IDL wrapper functions).

This doesn't touch any code _per se_, but may make f2py's job a little easier. In that sense, it might affect test failures like #68 (although it seems unlikely).