### PR TITLE
setup: Copy mingw pthread lib to Windows installer.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -802,29 +802,30 @@ class bdist_wininst(_bdist_wininst):
         _bdist_wininst.finalize_options(self)
         finalize_compiler_options(self)
 
-    def copy_fortran_libs(self):
-        """Copy the fortran runtime libraries into the build"""
-        fortdir = None
-        fortnames = None
+    def copy_dlls(self):
+        """Copy the mingw runtime libraries into the build"""
+        libdir = None
+        libnames = None
+        libneeded = ('libgfortran', 'libgcc_s', 'libquadmath', 'libwinpthread')
         for p in os.environ['PATH'].split(';'):
-            fortnames = [f for f in os.listdir(p)
-                         if f[-4:].lower() == '.dll' and
-                         (f[:11] == 'libgfortran' or
-                          f[:8] == 'libgcc_s' or
-                          f[:11] == 'libquadmath')]
-            if len(fortnames) == 3:
-                fortdir = p
+            if not os.path.isdir(p):
+                continue
+            libnames = [
+                f for f in os.listdir(p) if f[-4:].lower() == '.dll'
+                and f.startswith(libneeded)]
+            if len(libnames) == len(libneeded):
+                libdir = p
                 break
-        if fortdir is None:
-            raise RuntimeError("Can't locate fortran libraries.")
+        if libdir is None:
+            raise RuntimeError("Can't locate runtime libraries.")
         outdir = os.path.join(self.bdist_dir, 'PLATLIB', 'spacepy', 'mingw')
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-        for f in fortnames:
-            shutil.copy(os.path.join(fortdir, f), outdir)
+        for f in libnames:
+            shutil.copy(os.path.join(libdir, f), outdir)
 
     def run(self):
-        self.copy_fortran_libs()
+        self.copy_dlls()
         _bdist_wininst.run(self)
 
 

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -70,17 +70,17 @@ __all__ = ["seapy", "toolbox", "poppy", "coordinates", "time", "omni",
            "irbempy", "empiricals", "radbelt", "data_assimilation", "pycdf",
            "datamanager", "datamodel", "ae9ap9"]
 
-# on windows, make sure the Fortran libs are findable
+# on windows, make sure the mingw runtime libs are findable
 if sys.platform == 'win32':
-    fortlibs = os.path.join(os.path.dirname(__file__), 'mingw')
+    minglibs = os.path.join(os.path.dirname(__file__), 'mingw')
     if 'PATH' in os.environ:
-        if not fortlibs in os.environ['PATH']:
+        if not minglibs in os.environ['PATH']:
             if os.environ['PATH']:
-                os.environ['PATH'] += (';' + fortlibs)
+                os.environ['PATH'] += (';' + minglibs)
             else: #empth PATH
-                os.environ['PATH'] = fortlibs
+                os.environ['PATH'] = minglibs
     else:
-        os.environ['PATH'] = fortlibs
+        os.environ['PATH'] = minglibs
 
 def deprecated(version, message):
     """Decorator to deprecate a function/method


### PR DESCRIPTION
This changes the Windows installer creation script to also capture the pthread dll, which seems to be required now.

Originally this machinery was meant to get just the Fortran runtimes from mingw32, so there's also a fair bit of renaming to make clear this is now a general dll-grabber.