### PR TITLE
documentation: Add how-to-get-help document

### DIFF
--- a/Doc/source/help.rst
+++ b/Doc/source/help.rst
@@ -1,0 +1,30 @@
+************
+SpacePy Help
+************
+
+The best way to get help is to `open an issue
+<https://github.com/spacepy/spacepy/issues>`_. Searching existing
+issues may find other people who have had similar questions. Try
+changing the filters (at the top) to include closed issues, as they
+may have been addressed.
+
+Most modules also have a contact person listed in the docstring. These
+are built into in the main :doc:`index`, or you can view it from
+within Python/IPython::
+
+>>> import spacepy.pycdf
+>>> help(spacepy.pycdf)
+>>> print(spacepy.pycdf.__contact__)
+
+A web version of this documentation is currently hosted at
+`pythonhosted.org <https://pythonhosted.org/SpacePy/>`_.
+
+
+Contributing
+============
+Contributions to SpacePy are welcome! Development is managed via our
+`github <https://github.com/spacepy/spacepy>`_. If you're interesting
+in contributing a new feature or bugfix, it is recommended to open an
+issue to discuss your plans. Once your code is ready, you can `open a
+pull request <https://github.com/spacepy/spacepy/pulls>`_. Thanks for
+helping to improve SpacePy!

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -55,6 +55,7 @@ SpacePy Documents
 .. toctree::
     :maxdepth: 1
 
+    help
     install
     quickstart
     doc_standard


### PR DESCRIPTION
Small documentation update to add links to our github page in the guise of a "how to get help" document. There can be lots of refinements in the future (particularly as we get the website back up on github pages) but this is a start.