### PR TITLE
Support for building binary wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -394,7 +394,7 @@ class build(_build):
         bit = len('%x' % sys.maxsize)*4
         irbemdir = 'irbem-lib-2019-04-04-rev616'
         srcdir = os.path.join('spacepy', 'irbempy', irbemdir, 'source')
-        outdir = os.path.join(os.path.abspath(self.build_lib),
+        outdir = os.path.join(os.path.abspath(self.build_platlib),
                               'spacepy', 'irbempy')
         #Possible names of the output library. Unfortunately this seems
         #to depend on Python version, f2py version, and phase of the moon
@@ -643,7 +643,7 @@ class build(_build):
     def compile_libspacepy(self):
         """Compile the C library, libspacepy. JTN 20110224"""
         srcdir = os.path.join('spacepy', 'libspacepy')
-        outdir = os.path.join(self.build_lib, 'spacepy')
+        outdir = os.path.join(self.build_platlib, 'spacepy')
         try:
             if sys.platform == 'win32':
                 #numpy whacks our C compiler options. We need it for Fortran,
@@ -737,6 +737,7 @@ class build(_build):
         _build.run(self) #need subcommands BEFORE building irbem
         self.compile_irbempy()
         delete_old_files(self.build_lib)
+        delete_old_files(self.build_platlib)
         if self.build_docs:
             self.make_docs()
         else:
@@ -777,15 +778,15 @@ class install(_install):
             distutils.sysconfig.customize_compiler(comp)
         libspacepy = os.path.join(
             'spacepy', comp.library_filename('spacepy', lib_type='shared'))
-        if os.path.exists(os.path.join(self.build_lib, libspacepy)):
-            spacepylibs = [os.path.join(self.install_libbase, libspacepy)]
+        if os.path.exists(os.path.join(self.install_platlib, libspacepy)):
+            spacepylibs = [os.path.join(self.install_platlib, libspacepy)]
         else:
             spacepylibs = []
         irbemlibfiles = [os.path.join('spacepy', 'irbempy', f)
                          for f in get_irbem_libfiles()]
         irbemlibs = [
-            os.path.join(self.install_libbase, f) for f in irbemlibfiles
-            if os.path.exists(os.path.join(self.build_lib, f))]
+            os.path.join(self.install_platlib, f) for f in irbemlibfiles
+            if os.path.exists(os.path.join(self.install_platlib, f))]
         return outputs + docs + spacepylibs + irbemlibs
 
 

--- a/setup.py
+++ b/setup.py
@@ -394,7 +394,7 @@ class build(_build):
         bit = len('%x' % sys.maxsize)*4
         irbemdir = 'irbem-lib-2019-04-04-rev616'
         srcdir = os.path.join('spacepy', 'irbempy', irbemdir, 'source')
-        outdir = os.path.join(os.path.abspath(self.build_platlib),
+        outdir = os.path.join(os.path.abspath(self.build_lib),
                               'spacepy', 'irbempy')
         #Possible names of the output library. Unfortunately this seems
         #to depend on Python version, f2py version, and phase of the moon
@@ -643,7 +643,7 @@ class build(_build):
     def compile_libspacepy(self):
         """Compile the C library, libspacepy. JTN 20110224"""
         srcdir = os.path.join('spacepy', 'libspacepy')
-        outdir = os.path.join(self.build_platlib, 'spacepy')
+        outdir = os.path.join(self.build_lib, 'spacepy')
         try:
             if sys.platform == 'win32':
                 #numpy whacks our C compiler options. We need it for Fortran,
@@ -737,7 +737,6 @@ class build(_build):
         _build.run(self) #need subcommands BEFORE building irbem
         self.compile_irbempy()
         delete_old_files(self.build_lib)
-        delete_old_files(self.build_platlib)
         if self.build_docs:
             self.make_docs()
         else:
@@ -778,15 +777,15 @@ class install(_install):
             distutils.sysconfig.customize_compiler(comp)
         libspacepy = os.path.join(
             'spacepy', comp.library_filename('spacepy', lib_type='shared'))
-        if os.path.exists(os.path.join(self.install_platlib, libspacepy)):
-            spacepylibs = [os.path.join(self.install_platlib, libspacepy)]
+        if os.path.exists(os.path.join(self.build_lib, libspacepy)):
+            spacepylibs = [os.path.join(self.install_libbase, libspacepy)]
         else:
             spacepylibs = []
         irbemlibfiles = [os.path.join('spacepy', 'irbempy', f)
                          for f in get_irbem_libfiles()]
         irbemlibs = [
-            os.path.join(self.install_platlib, f) for f in irbemlibfiles
-            if os.path.exists(os.path.join(self.install_platlib, f))]
+            os.path.join(self.install_libbase, f) for f in irbemlibfiles
+            if os.path.exists(os.path.join(self.build_lib, f))]
         return outputs + docs + spacepylibs + irbemlibs
 
 

--- a/setup.py
+++ b/setup.py
@@ -862,15 +862,6 @@ if 'bdist_wheel' in sys.argv:
             #https://github.com/pypa/pip/issues/3383
             self.root_is_pure = False
 
-        def run(self):
-            #TODO: These aren't actually getting copied
-            #TODO: libspacepy and the irbem pyd aren't, either
-            #This probably requires us to hook the "install" command.
-            if sys.platform == 'win32':
-                copy_dlls(os.path.join(
-                    self.data_dir, 'platlib', 'spacepy', 'mingw'))
-            _bdist_wheel.run(self)
-
 
 class sdist(_sdist):
     """Rebuild the docs before making a source distribution"""

--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,7 @@ def get_irbem_libfiles():
 class build(_build):
     """Extends base distutils build to make pybats, libspacepy, irbem"""
 
-    sub_commands = [('config_fc', lambda *args:True),]
+    sub_commands = [('config_fc', lambda *args:True)] + _build.sub_commands
 
     user_options = _build.user_options + compiler_options + [
         ('build-docs', None,


### PR DESCRIPTION
This PR adds support for buliding binary wheels (bdist_wheel). The installation of the wheel has only been tested on Windows but that's the main goal at this point. It's been tested with pip install <name of wheel> not via pypi (testing for that will be later.)

There's a false start of trying to separate out the arch-specific and Python-only bits of the build. This was reverted but not rebased away because I think it's something we should do in the future. Ultimately this is treating everything (including Python code) as arch-specific but that beats treating the compiled stuff as non-arch specific. This is basically the most direct route to getting everything included in the wheel and there definitely should be some more intelligent sorting out later.