### PR TITLE
Do not require ffnet on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Our latest release version is available through PyPI and can be installed using
 pip install spacepy --user
 ```
 
+This will also automatically install most dependencies. To permit binary installations without a compiler, this will not install ffnet on Windows. Users needing the LANLstar module can install ffnet separately (requires Fortran compiler); this can be done before or after the SpacePy install.
+
 The latest "bleeding-edge" source code is available from our github repository at [https://github.com/spacepy/spacepy](https://github.com/spacepy/spacepy) and can be installed using the standard
 
 ```
@@ -47,7 +49,7 @@ Soft dependencies (that are required only for a very limited part of SpacePy's f
  - ffnet
  - NASA CDF
 
-For complete installation SpacePy also requires C and Fortran compilers. We test with GCC compilers but try to maintain support for all major compilers.
+For complete installation, excepting pre-built Windows binaries, SpacePy also requires C and Fortran compilers. We test with GCC compilers but try to maintain support for all major compilers.
 
 #### NASA CDF
 If you wish to use CDF files, download and install the NASA CDF library. The default installation directory is recommended to help SpacePy find the library. Get the package from [https://cdf.gsfc.nasa.gov/html/sw_and_docs.html](https://cdf.gsfc.nasa.gov/html/sw_and_docs.html)

--- a/setup.py
+++ b/setup.py
@@ -985,7 +985,9 @@ if use_setuptools:
         'scipy>=0.10',
         'matplotlib>=1.5',
         'h5py',
-        'ffnet',
+        #Do not install ffnet on Windows since there's no binary
+        #(people must hand-install)
+        'ffnet;platform_system!="Windows"',
         #ffnet needs networkx but not marked as requires, so to get it via pip
         #we need to ask for it ourselves
         'networkx',


### PR DESCRIPTION
This PR removes the requirement for ffnet on Windows so people can install from binary wheel without having a Fortran compiler (for ffnet). This will keep LANLstar from working by default, but explicitly installing ffnet will make that work (without having to reinstall SpacePy.)

This is option 3 on #160 . It it not the only option (or necessarily the one I'm voting for), but it's certainly the _easiest_.

Note this only affects `install_requires` so the metadata still declares an ffnet dependency.