### PR TITLE
install docs: separate out the simple stuff and all the complications

### DIFF
--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -2,8 +2,23 @@
 Installing SpacePy
 ******************
 
-SpacePy uses the standard Python distutils and setuptools to compile and install.
-For detailed, platform-specific installation instructions, see:
+The simplest way from zero to a working SpacePy setup is:
+
+  1. Install the `Anaconda <https://docs.anaconda.com/anaconda/>`_ Python
+     environment. Python 3 is recommended (as is, usually, 64-bit).
+  2. ``pip install --upgrade spacepy``
+
+If you are familiar with installing Python packages, have particular
+preferences for managing an installation, or if the above doesn't
+work, refer to platform-specific instructions and the details
+below. (In particular, if you will use :mod:`~spacepy.LANLstar` on
+Windows, see :doc:`install_windows`.)
+
+For installing the NASA CDF library to support :mod:`~spacepy.pycdf`,
+see the platform-specific instructions linked below.
+
+If you need further assistance, you can `open an issue
+<https://github.com/spacepy/spacepy/issues>`_.
 
 .. toctree::
     :maxdepth: 1
@@ -13,20 +28,23 @@ For detailed, platform-specific installation instructions, see:
     install_mac
     install_windows
 
-For a list of dependencies, see :doc:`dependencies`.
+SpacePy installs with the common Python distutils and pip.
 
-Following are generic instructions.
-
-The latest stable release is provided via the Python Package Index (PyPI).
-To install from PyPI, make sure you have pip installed::
+The latest stable release is provided via `PyPI
+<https://pypi.org/project/SpacePy/>`_ To install from PyPI, make sure
+you have pip installed::
 
     pip install --upgrade spacepy
 
-If you are installing for a single user, and are not working in a virtual environment,
-add the --user flag when installing with pip.
+If you are installing for a single user, and are not working in a
+virtual environment, add the ``--user`` flag when installing with pip.
 
-To build from source (available at `our github <https://github.com/spacepy/spacepy>`_
-just run (from a virtual environment, such as a conda environment)::
+Source releases are available from `PyPI
+<https://pypi.org/project/SpacePy/#files>`__; releases and current
+development are available from `our github
+<https://github.com/spacepy/spacepy>`_. After downloading and
+unpacking, run (a virtual environment, such as a conda environment, is
+recommended)::
 
     python setup.py install
 
@@ -38,18 +56,12 @@ or, to install for a single user (not in a virtual environment)::
 
     python setup.py install --user
 
-If you do not have administrative privileges, or you will be developing for SpacePy,
-we strongly recommend using virtual environments.
+If you do not have administrative privileges, or you will be
+developing for SpacePy, we strongly recommend using virtual
+environments.
 
 To install in custom location, e.g.::
 
     python setup.py install --home=/n/packages/lib/python
 
-It is also possible to select a specific compiler for installing the IRBEM-LIB library as part
-of SpacePy. Currently the
-following flags are supported: gnu95, gnu, pg. You can invoke these by using one of the
-following commands below but not all of them are supported on all platforms:
-
-* ``python setup.py install --fcompiler=pg``      #(will use pgi compiler suite)
-* ``python setup.py install --fcompiler=gnu``    #(will use g77)
-* ``python setup.py install --fcompiler=gnu95``   #(default option for using gfortran)
+Installs using ``setup.py`` do not require setuptools.

--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -2,68 +2,61 @@
 Linux Installation
 ******************
 
-Dependencies
-============
-Installing SpacePy on linux using pip should automatically install the core
-dependencies. Installing numpy prior to SpacePy should make the installation
-process a little smoother.
+Installation on Linux requires both a C and a Fortran compiler; a
+recent GCC is recommended (the C compiler is likely included with your
+distribution). On Debian and Ubuntu::
+  
+      sudo apt-get install gfortran
 
-The first is to download a single software suite that installs a
-comprehensive set of Python libraries; the second is to install the core 
-dependencies yourself.
+Once this is set up, ``pip install spacepy`` should Just Work. If
+you're installing as a single user (not in a virtual environment) then
+add the ``--user`` flag.
 
-The Easy Way
-------------
-Both `Anaconda <https://www/anaconda.com>`_ and 
-`Enthought Canopy <https://www.enthought.com/>`_
-will provide Python, numpy, scipy, matplotlib and a host of other useful
-3rd-party libraries. In both cases you will still need to install 
-:ref:`CDF <linux_CDF>` by hand.
+You will also need the :ref:`NASA CDF library <linux_CDF>` to use
+:mod:`~spacepy.pycdf`.
 
-Assuming you have a fortran compiler installed, you should be able to install
-Spacepy using pip::
+Our recommended (but not required) Python distribution is `Anaconda
+<https://docs.anaconda.com/anaconda/>`_ running 64-bit
+Python 3. Anaconda includes much of the scientific Python
+stack. Another excellent distribution is `Canopy
+<https://www.enthought.com/product/canopy/>`_.
 
-    pip install spacepy
+.. contents::
+   :local:
 
-If you're installing as a single user (not in a virtual environment)
-then add the --user flag.
+Dependencies via conda
+======================
 
-If you are installing by hand, follow the instructions for your linux
-distribution below.
+Installation via ``pip`` will automatically install most Python
+dependencies (but not the :ref:`NASA CDF library <linux_CDF>`). They
+can also be installed from conda::
 
-Debian and Ubuntu
------------------
-Installation on the Python distribution and scientific stack via the
-system package manager is no longer recommended. Use of pip or conda
-is recommended so that packages updates can be obtained in a timely
-manner. However, your system may not come with some of the required
-packages, like gfortran.
+  conda install numpy scipy matplotlib networkx h5py
 
-The following command should install gfortran on Ubuntu and Debian::
+Dependencies via system packages
+================================
 
-    sudo apt install gfortran
+SpacePy usually works with the system Python on Linux. To install dependencies via the package manager on Debian or Ubuntu::
 
-To make installing the NASA CDF library easier, and to enable the CDF
-command line tools to be built::
+  sudo apt-get install python-dev python-h5py python-matplotlib python-networkx python-numpy python-scipy
 
-    sudo apt install ncurses-dev
+For Python 3, use::
 
-You can also, of course, install the same packages via synaptic or
-other package manager of your choice.
+  sudo apt-get install python3-dev python3-h5py python3-matplotlib python3-networkx python3-numpy python3-scipy
 
-Since no packages are available that provide it, install 
-:ref:`CDF <linux_CDF>` by hand.
-
-Other distributions
--------------------
 For other distributions, check :doc:`dependencies` and install by hand
 or via your package manager. 
-
 
 .. _linux_CDF:
 
 CDF
----
+===
+
+It is recommended to install the ncurses library; on Ubuntu and Debian::
+
+    sudo apt-get install ncurses-dev
+
+
 Download the latest `CDF library <http://cdf.gsfc.nasa.gov/>`_. Choose
 the file ending in ``-dist-all.tar.gz`` from the ``linux``
 directory. Untar and cd into the resulting directory. Then build::
@@ -86,11 +79,18 @@ SpacePy uses these variables to find the library.
 .. _linux_ffnet:
 
 ffnet
------
-Download the latest `ffnet module
-<http://ffnet.sourceforge.net/install.html>`_. Compilation requires
-f2py (from numpy), installed in the distribution-specific directions
-above. Untar and cd into the resulting directory. Then build::
+=====
+
+ffnet can be installed from ``pip``; if the wrong Fortran compiler is
+found try::
+
+  FC_VENDOR=gfortran pip install ffnet
+
+It can also be installed from 
+`sourcea <http://ffnet.sourceforge.net/install.html>`_.
+Compilation requires f2py (from numpy), installed per the
+distribution-specific directions above. Untar and cd into the
+resulting directory. Then build::
 
     python setup.py build
 
@@ -107,12 +107,14 @@ fails, try specifying the older GNU compiler at the build step::
 
     python setup.py build --fcompiler=gnu
 
-SpacePy
-=======
-With the dependencies installed, SpacePy is ready to build and install.
+Compiling
+=========
+
+With the dependencies installed, SpacePy can be built from source.
 This uses the same basic setup as ffnet (standard Python distutils).
-You can always get the latest source code for SpacePy from our
-`github repository <https://github.com/spacepy/spacepy>`_.
+You can always get the latest source code for SpacePy from our `github
+repository <https://github.com/spacepy/spacepy>`_ and the latest
+release from `PyPI <https://pypi.org/project/SpacePy/#files>`_
 
 Build::
 
@@ -136,3 +138,21 @@ If you're using conda, installation as user isn't recommended::
 Or install for all users on the system::
 
     sudo python setup.py install
+
+If you want to build the documentation yourself (rather than using the
+documentation shipped with SpacePy), install sphinx and numpydoc. The
+easiest way is via pip::
+
+  pip install sphinx numpydoc
+
+They are also available via conda::
+
+  conda install sphinx numpydoc
+
+Or the package manager:
+
+  sudo apt-get install python-sphinx python-numpydoc
+
+For Python 3:
+
+  sudo apt-get install python3-sphinx python3-numpydoc

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -55,8 +55,10 @@ If this fails, specify a FORTRAN compiler::
 
     python setup.py build --fcompiler=gnu
 
-(``python setup.py build --help-fcompiler`` will list options for
-FORTRAN compilers.)
+``python setup.py build --help-fcompiler`` will list options for
+FORTRAN compilers. Currently available compilers are ``pg``,
+``gnu95``, ``gnu``, ``intelem``, ``intel`` or ``none`` (to skip all
+Fortran); ``gnu95`` (the GNU gfortran compiler) is recommended.
 
 Install for one user::
 

--- a/Doc/source/install_windows.rst
+++ b/Doc/source/install_windows.rst
@@ -2,116 +2,121 @@
 Windows Installation
 ********************
 
-Although the SpacePy team makes every effort to keep code portable, and has
-expended considerable effort on Windows specifically, Windows is not a
-primary development platform for any of the developers. There may be some
-limitations and/or bugs under Windows which are not present in OSX or Linux.
-Bug reports and patches are always welcome.
+The SpacePy team currently provides binary "wheels" via PyPI so it can
+be installed on Windows without a compiler. Binaries are provided for
+Python 2.7, 3.6, and 3.7 in 64-bit and 32-bit variants for each. ``pip
+install spacepy`` should find and install these binaries.
 
-The Easy Way
-============
+Our recommended (but not required) Python distribution is `Anaconda
+<https://docs.anaconda.com/anaconda/>`_ running 64-bit
+Python 3. Anaconda includes much of the scientific Python
+stack. Another excellent distribution is `Canopy
+<https://www.enthought.com/product/canopy/>`_.
 
-Download the `Python(x,y) distribution 
-<http://code.google.com/p/pythonxy/>`_. The standard plugins include
-most of the dependencies required for SpacePy. Like SpacePy, this currently
-only supports 32-bit code, but will run on 64-bit machines.
+.. contents::
+   :local:
 
-If you wish to use the lanlstar module, you will need `ffnet-0.7.1.win32-py2.7.exe <https://sourceforge.net/projects/ffnet/files/ffnet/ffnet-0.7.1/>`_.
+.. _windows_fortran:
 
-If you wish to use CDF files, download and install the `NASA CDF library
-<http://cdf.gsfc.nasa.gov/>`_. Again, the 32-bit installer is required, e.g.
-CDF34_1_0-SETUP-32.EXE. The default installation directory is recommended to
-help SpacePy find the library.
+Fortran and ffnet
+=================
 
-Finally, install SpacePy using the installer EXE. Be sure to choose the
-installer that matches your version of Python, either 2.6 or 2.7.
+`ffnet <http://ffnet.sourceforge.net/download.html>`_ is required for
+:mod:`~spacepy.LANLstar`. It can be installed either before or after
+SpacePy. Binary wheels are not provided, so a Fortran compiler is
+required
 
+With Anaconda, the compiler and ffnet can be installed with::
 
-The Hard Way
-============
+  conda install m2w64-gcc-fortran libpython
+  SET FC_VENDOR=gfortran
+  pip install ffnet
 
-Installing dependencies
------------------------
+The `FC_VENDOR` line is necessary because ffnet defaults to the
+Microsoft compiler.
 
-This is a step-by-step guide to installing all of the spacepy dependencies
-individiually. This is the easiest way to install all dependencies by hand;
-if you are comfortable downloading, compiling, and installing Python modules
-yourself, that will also work.
+Some standalone binary installers (no ``pip`` support) are also
+available on the `ffnet site
+<http://ffnet.sourceforge.net/download.html>`_. These do not require a
+compiler but support only a limited set of Python versions.
 
-Download and install the 32-bit `Python Windows installer
-<http://python.org/download/>`_ .  The 2.7 version is recommended since
-most dependencies are now built against 2.7.
+Compiling
+=========
 
-The following filenames are given for Python 2.7 and were the latest
-as of this writing; download the appropriate file for your version of
-Python and the latest version available of the required package. 
+If a binary wheel is not available for your version of Python, ``pip``
+will try to compile SpacePy. The only supported compiler is
+``mingw32``. Install it with::
 
-Download and install `numpy-1.7.1-win32-superpack-python2.7.exe
-<http://sourceforge.net/projects/numpy/files/>`_.
+  conda install m2w64-gcc-fortran libpython
 
-Download and install `scipy-0.12.0-win32-superpack-python2.7.exe
-<http://sourceforge.net/projects/scipy/files/>`_.
+This is also required if installing from a source distribution or git checkout.
 
-Download and install `matplotlib-1.2.1.win32-py2.7.exe
-<http://matplotlib.org/downloads.html>`_.
+:mod:`~spacepy.irbempy` requires Fortran to compile and the only
+supported compiler is ``gnu95``; this is the default and provided
+by ``m2w64-gcc-fortran``.
 
-Download and install `h5py-2.1.3.win32-py2.7.msi
-<http://code.google.com/p/h5py/downloads/list>`_.
+If you have difficulties, it may be useful to reference the `build
+scripts
+<https://github.com/spacepy/spacepy/tree/master/developer/scripts>`
+the SpacePy developers use.
 
-Download and install `networkx-1.7_py27.exe
-<http://code.google.com/p/pythonxy/wiki/StandardPlugins>`_.
+.. _windows_CDF:
 
-Download and install `ffnet-0.7.1.win32-py2.7.exe
-<https://sourceforge.net/projects/ffnet/files/ffnet/ffnet-0.7.1/>`_.
+NASA CDF
+========
 
-If you wish to use CDF files, download and install the `NASA CDF library
-<http://cdf.gsfc.nasa.gov/>`_. Again, the 32-bit installer is required, e.g.
-CDF34_1_0-SETUP-32.EXE. The default installation directory is recommended to
-help SpacePy find the library.
+:mod:`~spacepy.pycdf` requires the `NASA CDF library
+<https://cdf.gsfc.nasa.gov/html/sw_and_docs.html>`_ . Binary
+installers are available for Windows; be sure to pick the version
+that matches your Python installation. The current 32-bit version
+is `cdf37_1_0-setup-32.exe
+<https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/windows/cdf37_1_0-setup-32.exe>`_;
+for 64-bit, `cdf37_1_0-setup-64.exe
+<https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/windows/cdf37_1_0-setup-64.exe>`_.
 
-At this point, you can install SpacePy from the installer EXE, or continue
-to build SpacePy from source.
+This is a simple self-extracting installer that can be installed either before or after installing SpacePy.
 
+Standalone installers
+=====================
 
-Building and installing SpacePy
--------------------------------
+Self-extracting and self-installing executables are also available for
+download direct from `PyPI
+<https://pypi.org/project/SpacePy/#files>`_. Be sure to choose the
+file that matches your Python installation, both in Python version and
+word size (64-bit vs. 32-bit.)
+E.g. ``spacepy-0.2.0.win-amd64.py36.exe`` is the installer for Python
+3.6 on 64-bit Windows and ``spacepy-0.2.0.win32.py27.exe`` is the
+installer for Python 2.7 on 32-bit Windows.
 
-Edit your Windows path: Right-click my computer, choose properties,
-advanced, environment variables.  Edit the path variable: append
-``;c:\python27;c:\python27\Scripts;c:\MinGW\bin`` (`more information
-<http://docs.python.org/using/windows.html#finding-the-python-executable>`_).
+Once downloaded, these can be installed without an internet connection.
 
-Download the latest `mingwget <http://sourceforge.net/projects/mingw/files/Automated%20MinGW%20Installer/mingw-get/>`_. mingw32 is the only C and Fortran compiler supported by SpacePy on Windows. Unzip into C:\MinGW. At a command prompt (Start, Run, cmd) type::
+If using these installers, the :doc:`dependencies` will not be
+installed automatically.
 
-      mingw-get install gcc g++ mingw32-make fortran
+Dependencies via conda
+======================
 
-See also `the mingw docs <http://www.mingw.org/wiki/Getting_Started>`_
+Installation via ``pip`` will automatically install most Python
+dependencies (but not :ref:`ffnet <windows_fortran>` or the :ref:`NASA
+CDF library <windows_CDF>`). They can also be installed from conda::
 
-Create a file ``distutils.cfg`` in ``C:\Python27\Lib\distutils``
-(change appropriately for Python 2.6). It should contain::
+  conda install numpy scipy matplotlib networkx h5py
 
-    [build]
-    compiler=mingw32
+Standalone dependencies
+=======================
 
-Unzip the SpacePy source documentation. Open a command prompt in the
-resulting directory and run::
-
-    python setup.py install
-
+Most of the :doc:`dependencies` have Windows installers available via
+their pages, but ``pip`` or ``conda`` are recommended instead.
 
 Developers
 ==========
 
 If you want to build the documentation yourself (rather than using the
 documentation shipped with SpacePy), install sphinx and numpydoc. The
-easiest way is via pip.
+easiest way is via pip::
 
-Download and run `distribute_setup.py
-<https://pypi.python.org/pypi/distribute/#distribute-setup-py>`_.
+  pip install sphinx numpydoc
 
-Download and run `get-pip.py
-<http://www.pip-installer.org/en/latest/installing.html#using-get-pip>`_.
+They are also available via conda::
 
-Then::
-
-    pip install sphinx numpydoc
+  conda install sphinx numpydoc


### PR DESCRIPTION
As discussed in #163 , this splits out the simple stuff ("just run pip") from all the complications. This really only affects Windows and Linux; we really need somebody to do this for Mac.