### PR TITLE
docs: add Fortran options to Linux install instructions

### DIFF
--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -124,8 +124,10 @@ If this fails, specify a Fortran compiler::
 
     python setup.py build --fcompiler=gnu95
 
-(``python setup.py build --help-fcompiler`` will list options for
-Fortran compilers.)
+``python setup.py build --help-fcompiler`` will list options for
+Fortran compilers. Currently available compilers are ``pg``,
+``gnu95``, ``gnu``, ``intelem``, ``intel`` or ``none`` (to skip all
+Fortran); ``gnu95`` (the GNU gfortran compiler) is recommended.
 
 Install for one user::
 


### PR DESCRIPTION
Small docs update to list the Fortran options in Linux (as it is on Mac and used to be in the generic instructions.)