### PR TITLE
Release prep

### DIFF
--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -57,6 +57,8 @@ Test PyPI
 
 https://packaging.python.org/guides/using-testpypi/
 
+Consider https://www.python.org/dev/peps/pep-0440/#pre-releases
+
 Make a .pypirc file, see https://docs.python.org/3.3/distutils/packageindex.html
 
 [distutils]
@@ -79,7 +81,12 @@ Put all the builds (wheels, source dists) into one directory and:
 
 PyPI does not support Windows standalone installers.
 
+Test installing with:
 
+  pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ spacepy
+
+Do this on Windows without compilers installed, and in a clean Linux
+Anaconda env.
 
 Release to PyPI
 ---------------

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -97,7 +97,7 @@ https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html
 
 There's no longer any capability to edit information on PyPI, it's
 straight from the setup.py metadata. This may cause problems with the
-face that we're CamelCase on PyPI...
+fact that we're CamelCase on PyPI...
 
 Release to github
 -----------------

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -1,64 +1,119 @@
-Building spacepy for distribution (20141223)
+Building spacepy for distribution (20190619)
 ============================================
 Since this has to happen on multiple platforms, a single script doesn't work.
 
-Edit Doc/source/conf.py. Around line 124, remove (DRAFT) from the title.
-    Change version around line 68 (two places!)
-Change version in setup.py, actual call to setup near bottom.
-Change __version__ around line 136 of __init__.py. Also change all through
-    the license.
+Prepare the release commit
+--------------------------
+
+Note: it's probably best to get the latest up on test PyPI first to
+make sure it works!
+
+Edit the CHANGELOG to include the release date.
+
+Edit Doc/source/conf.py. Around line 128, remove (DRAFT) from the title.
+    Change version around line 72 (two places!)
+Change version in setup.py, in setup_kwargs near bottom.
+Change __version__ around line 136 of __init__.py.
+
+Commit these changes. Tag as release-VERSION
+(e.g. release-0.2.0). Push commit and tags.
+
+Prepare the source build
+------------------------
 
 On a Unix machine:
-check out the latest from git.
+check out the latest from git (hopefully the release commit!)
+
+Build and install so you're getting the latest inputs for the autodocs. Then:
     python setup.py sdist --formats=gztar,zip
 Tarball and zip are in the dist directory.
 
 Note: building the source distribution will build the docs, but no longer needs
 to do a binary build.
 
-Windows build:
-Follow the "hard way" directions from the installation docs.
-unzip the source distribution from the Unix side
-(Rebuilding of the source distribution will ensure the latest
-docs are in the Windows installer.)
-    python setup.py bdist_wininst
-installer exe is in the dist directory.
-Run the installer and make sure it works. Copy it out.
+Prepare the Windows binaries
+----------------------------
 
-Now revert to the snapshot and do it ALL OVER for Python 2.7!
+Unzip the source distribution from the Unix side. Get the Windows
+build scripts from the repository. They're in developer/scripts but
+are not included in the source distribution. They need to be put in
+developer/scripts in the unzipped source so they can find the rest of
+SpacePy. Yes this could be improved.
 
-Website is in /n/www/html/spacepy/external
-newgroup spacepy
-umask 002
-under repository, make spacepy-VERSION directory
-In here should go:
--.zip and .tar.gz of source
--2.6 and 2.7 of Windows installer
--PDF documentation, called spacepy-VER-doc.pdf
--html documentation spacepy-VER-html_docs.zip. Rooted at build/html.
-(DOUBLE CHECK PERMISSIONS)
-(in Doc/build/html, zip -r spacepy-VER-html_docs.zip *)
-Unzip the new docs into doc-VER
-Move old docs (doc) to doc-OLDVER
-Move new docs to doc
-Copy new pdf docs into doc, named SpacePy.pdf
-(DOUBLE CHECK PERMISSIONS ON DOCS)
-Put latest CHANGELOG in top level directory of site
+Download latest (currently 3.7) 64-bit Miniconda from
+https://docs.conda.io/en/latest/miniconda.html and put it in the
+system-default download directory (%USERPROFILE%\Downloads)
 
-Now get the latest on sourceforge:
-log in, click on files
-in spacepy folder, add folder (spacepy-VER)
-upload everything that went into repository on website:
-scp * USER@frs.sourceforge.net:/home/frs/project/spacepy/spacepy/spacepy-VER
-In the version folder, click on the "i" next to .tar.gz; set as default for BSD, Linux, Solaris. .zip as default for other, mac; exe as default for windows.
+Run win_build_system_setup.cmd, build_win.cmd, and
+win_build_system_teardown.cmd. Windows binaries and wheels will be in
+the "dist" directory of the SpacePy distribution.
 
-Log in to pypi.python.org
-Click on "SpacePy" under "your packages"
-Now click "edit" (top bar)
-EDIT PKG-INFO from the source distribution tarball, put "Name" field into CamelCase (this should probably be fixed in the installer, or make it not camelcase on pypi)
-Upload PKG-INFO (there's a browse button, and then "add package information" DIRECTLY under that)
-hide the release until it's propagated out
-upload the zip file for the latest documentation
-(go to https://pypi.python.org/pypi?%3Aaction=pkg_edit&name=SpacePy and click on "Upload Documentation", basically the same zip file as goes on LANL page)
-Same page, file, upload a source distribution.
-Testing pip installation: see https://wiki.python.org/moin/TestPyPI
+The wheels are compliant with metadata 2.0 but are labeled as 2.1, which makes for problems unless everybody has the very newest version of everything. For now, we should edit them.
+
+for i in *.whl; do unzip $i "spacepy-*.dist-info/METADATA"; sed -i -e "s/Metadata-Version: 2.1/Metadata-Version: 2.0/" spacepy-*.dist-info/METADATA; zip $i "spacepy-*.dist-info/METADATA"; rm -rf spacepy-*.dist-info; done
+
+Test PyPI
+---------
+
+https://packaging.python.org/guides/using-testpypi/
+
+Make a .pypirc file, see https://docs.python.org/3.3/distutils/packageindex.html
+
+[distutils]
+index-servers =
+    pypi
+    testpypi
+
+[pypi]
+username: <username>
+
+[testpypi]
+repository: https://test.pypi.org/legacy
+username: <username>
+
+(end of .pypirc)
+
+Put all the builds (wheels, source dists) into one directory and:
+
+  twine upload -r testpypi spacepy-*.gz spacepy-*.zip spacepy-*.whl
+
+PyPI does not support Windows standalone installers.
+
+
+
+Release to PyPI
+---------------
+
+https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html
+
+  twine upload spacepy-*.gz spacepy-*.zip spacepy-*.whl
+
+There's no longer any capability to edit information on PyPI, it's
+straight from the setup.py metadata. This may cause problems with the
+face that we're CamelCase on PyPI...
+
+Release to github
+-----------------
+
+https://help.github.com/en/articles/creating-releases
+
+Upload all the files: source distribution, Windows installers, wheels.
+
+Relevant notes
+--------------
+
+Reference that have been useful for putting the wheels together (this
+can eventually be captured elsewhere.)
+
+https://www.python.org/dev/peps/pep-0427/
+https://pip.pypa.io/en/stable/reference/pip_wheel/
+https://docs.python.org/2/library/sysconfig.html#installation-paths
+https://github.com/dask/hdfs3/issues/113
+https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html
+https://packaging.python.org/tutorials/packaging-projects/
+
+Wheel is a separate package but seems to be included with
+miniconda. (It's not just pip or setuptools, but it might be a
+requirement for pip? Although not installed on Linux with pip.)
+
+https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it

--- a/Doc/source/help.rst
+++ b/Doc/source/help.rst
@@ -17,7 +17,7 @@ within Python/IPython::
 >>> print(spacepy.pycdf.__contact__)
 
 A web version of this documentation is currently hosted at
-`pythonhosted.org <https://pythonhosted.org/SpacePy/>`_.
+`spacepy.github.io <https://spacepy.github.io/>`_.
 
 
 Contributing

--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -40,9 +40,12 @@ If you are installing for a single user, and are not working in a
 virtual environment, add the ``--user`` flag when installing with pip.
 
 Source releases are available from `PyPI
-<https://pypi.org/project/SpacePy/#files>`__; releases and current
-development are available from `our github
-<https://github.com/spacepy/spacepy>`_. After downloading and
+<https://pypi.org/project/SpacePy/#files>`__ and `our github
+<https://github.com/spacepy/spacepy/releases>`__. Development versions
+are on `github <https://github.com/spacepy/spacepy>`__.
+
+
+After downloading and
 unpacking, run (a virtual environment, such as a conda environment, is
 recommended)::
 

--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -21,8 +21,16 @@ Python 3. Anaconda includes much of the scientific Python
 stack. Another excellent distribution is `Canopy
 <https://www.enthought.com/product/canopy/>`_.
 
+You may need to install the dependencies some way other than pip; for
+example, if you are running an earlier version of Python. The latest
+version of many dependencies requires Python 3.6 and pip will not
+install older versions to get around this. See :ref:`linux_dep_conda`
+and :ref:`linux_dep_apt`.
+
 .. contents::
    :local:
+
+.. _linux_dep_conda:
 
 Dependencies via conda
 ======================
@@ -32,6 +40,8 @@ dependencies (but not the :ref:`NASA CDF library <linux_CDF>`). They
 can also be installed from conda::
 
   conda install numpy scipy matplotlib networkx h5py
+
+.. _linux_dep_apt:
 
 Dependencies via system packages
 ================================

--- a/Doc/source/install_windows.rst
+++ b/Doc/source/install_windows.rst
@@ -80,8 +80,8 @@ Standalone installers
 =====================
 
 Self-extracting and self-installing executables are also available for
-download direct from `PyPI
-<https://pypi.org/project/SpacePy/#files>`_. Be sure to choose the
+download direct from `our github
+<https://github.com/spacepy/spacepy/releases>`__. Be sure to choose the
 file that matches your Python installation, both in Python version and
 word size (64-bit vs. 32-bit.)
 E.g. ``spacepy-0.2.0.win-amd64.py36.exe`` is the installer for Python

--- a/Doc/source/install_windows.rst
+++ b/Doc/source/install_windows.rst
@@ -13,6 +13,11 @@ Python 3. Anaconda includes much of the scientific Python
 stack. Another excellent distribution is `Canopy
 <https://www.enthought.com/product/canopy/>`_.
 
+You may need to install the dependencies some way other than pip; for
+example, if you are running an earlier version of Python. The latest
+version of many dependencies requires Python 3.6 and pip will not
+install older versions to get around this. See :ref:`win_dep_conda`.
+
 .. contents::
    :local:
 
@@ -92,6 +97,8 @@ Once downloaded, these can be installed without an internet connection.
 
 If using these installers, the :doc:`dependencies` will not be
 installed automatically.
+
+.. _win_dep_conda:
 
 Dependencies via conda
 ======================

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The latest "bleeding-edge" source code is available from our github repository a
 python setup.py install --user
 ```
 
-Further installation documentation can be found [here](https://pythonhosted.org/SpacePy/install.html) Mac-specific information can be found [here](https://pythonhosted.org/SpacePy/install_mac.html)
-Full documentation is at [https://pythonhosted.org/SpacePy](https://pythonhosted.org/SpacePy)
+Further installation documentation can be found [here](https://spacepy.github.io/install.html) Mac-specific information can be found [here](https://spacepy.github.io/install_mac.html)
+Full documentation is at [https://spacepy.github.io](https://spacepy.github.io)
 
 SpacePy supports both Python 2.7 and 3.x.
 


### PR DESCRIPTION
A bit of a mishmash PR but it's all pertaining to release prep.

- Update the DISTRIBUTE document which describes making a release
- PyPI no longer hosts Windows standalone installers, so reference GitHub for those
- pythonhosted is dead so move documentation to github as well. We can always put more of "home page" there later and put the docs in a subdirectory.