### PR TITLE
time.py: minor update to docstring to close #169

### DIFF
--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1450,7 +1450,7 @@ class Ticktock(MutableSequence):
 
         See Also
         ========
-        datetime.datetime.now()
+        datetime.datetime.now
 
         """
         dt = datetime.datetime.now()


### PR DESCRIPTION
This seems like an upstream issue in sphinx or in numpydoc. But this really minor change allows for the docs to build. Closes #169 