### PR TITLE
Postrelease 0.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Changes in Version 0.2.1 (2019-xx-xx)
+=====================================
+
 Changes in Version 0.2.0 (2019-06-22)
 =====================================
 - Many installer updates, including binary wheels for Windows

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -15,8 +15,7 @@ Edit Doc/source/conf.py. Around line 128, remove (DRAFT) from the title.
 Change version in setup.py, in setup_kwargs near bottom.
 Change __version__ around line 136 of __init__.py.
 
-Commit these changes. Tag as release-VERSION
-(e.g. release-0.2.0). Push commit and tags.
+Commit these changes. Submit PR. (Tagging is done on github now.)
 
 Prepare the source build
 ------------------------
@@ -93,7 +92,9 @@ Release to PyPI
 
 https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html
 
-  twine upload spacepy-*.gz spacepy-*.zip spacepy-*.whl
+  twine upload spacepy-*.zip spacepy-*.whl
+
+Do not upload the .tar.gz since can only upload one source package per release.
 
 There's no longer any capability to edit information on PyPI, it's
 straight from the setup.py metadata. This may cause problems with the
@@ -104,7 +105,24 @@ Release to github
 
 https://help.github.com/en/articles/creating-releases
 
-Upload all the files: source distribution, Windows installers, wheels.
+On the code tab, click on "n releases" (between branches and
+contributors). Click "Draft a new release." Make the tag
+"release-x.y.z" and hopefully the target will be master if it's up to
+date. The most consistent with what we've done so far (which is not
+necessarily the best) is to use just "x.y.z" as the title with nothing
+the "describe."
+
+Click in the "upload binaries" area and upload all the files: source
+distribution, Windows installers, wheels. Also upload the
+documentation PDF (spacepy-x.y.z-doc.pdf) and a zip
+(spacepy-x.y.z-doc.zip).
+
+Documentation update
+--------------------
+
+Check out the spacepy.github.io repository. Right now the root of the
+repo is basically the root of the Doc/build/html output. Copy all the
+freshly-built docs there, commit, submit PR.
 
 Relevant notes
 --------------

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -125,8 +125,8 @@ html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = "%s v%s Manual (DRAFT)" % (project, version)
-html_title = "%s v%s Manual" % (project, version)
+html_title = "%s v%s Manual (DRAFT)" % (project, version)
+#html_title = "%s v%s Manual" % (project, version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -20,7 +20,7 @@ IF "%1"=="32" (
 set PYVER="%2"
 CALL %USERPROFILE%\Miniconda3\Scripts\activate py%2_%1
 pushd %~dp0\..\..\
-rmdir /s /y build
+rmdir /s /q build
 CALL python setup.py bdist_wheel
 CALL python setup.py bdist_wininst
 for %%f in (dist\spacepy-*.*.*.win32.exe dist\spacepy-*.*.*.win-amd64.exe) DO (

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -133,7 +133,7 @@ dmarray = datamodel.dmarray
 SpaceData = datamodel.SpaceData
 
 #package info
-__version__ = '0.2.0'
+__version__ = 'UNRELEASED'
 __author__ = 'The SpacePy Team'
 __team__ = ['Steve Morley', 'Josef Koller', 'Dan Welling', 'Brian Larsen', 'Jon Niehof', 'Mike Henderson']
 __contact__ = 'spacepy@lanl.gov'


### PR DESCRIPTION
A few commits that do post 0.2.0 release cleanup:

- Version number back to unreleased
- A fix in the Windows build script that appeared after 0.2.0 was tagged anyhow (doesn't affect the built product)
- Some more notes on how to do a release, capturing experience from this time.
