### PR TITLE
toolbox: update to close #181. The num parameters are explicitly cast to int

### DIFF
--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -215,10 +215,10 @@ class spectrogram(dm.SpaceData):
                 # use the toolbox version of linspace so it works on dates
                 self.specSettings['bins'] = [dm.dmarray(tb.linspace(self.specSettings['xlim'][0],
                                                  self.specSettings['xlim'][1],
-                                                 np.sqrt(len(data[self.specSettings['variables'][0]])))),
+                                                 int(np.sqrt(len(data[self.specSettings['variables'][0]]))))),
                     dm.dmarray(tb.linspace(self.specSettings['ylim'][0],
                                                  self.specSettings['ylim'][1],
-                                                 np.sqrt(len(data[self.specSettings['variables'][1]]))))]
+                                                 int(np.sqrt(len(data[self.specSettings['variables'][1]])))))]
 
         # copy all the used keys
         for key in self.specSettings['variables']:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1256,7 +1256,7 @@ def logspace(min, max, num, **kwargs):
         ans = spt.no_tzinfo(ans)
         return np.array(ans)
     else:
-        return np.logspace(np.log10(min), np.log10(max), int(num), **kwargs)
+        return np.logspace(np.log10(min), np.log10(max), num, **kwargs)
 
 def linspace(min, max, num, **kwargs):
     """

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1252,11 +1252,11 @@ def logspace(min, max, num, **kwargs):
     """
     if isinstance(min, datetime.datetime):
         from matplotlib.dates import date2num, num2date
-        ans = num2date(np.logspace(np.log10(date2num(min)), np.log10(date2num(max)), num, **kwargs))
+        ans = num2date(np.logspace(np.log10(date2num(min)), np.log10(date2num(max)), int(num), **kwargs))
         ans = spt.no_tzinfo(ans)
         return np.array(ans)
     else:
-        return np.logspace(np.log10(min), np.log10(max), num, **kwargs)
+        return np.logspace(np.log10(min), np.log10(max), int(num), **kwargs)
 
 def linspace(min, max, num, **kwargs):
     """
@@ -1303,11 +1303,11 @@ def linspace(min, max, num, **kwargs):
         max = max.item()
     if isinstance(min, datetime.datetime):
         from matplotlib.dates import date2num, num2date
-        ans = num2date(np.linspace(date2num(min), date2num(max), num, **kwargs))
+        ans = num2date(np.linspace(date2num(min), date2num(max), int(num), **kwargs))
         ans = spt.no_tzinfo(ans)
         return np.array(ans)
     else:
-        return np.linspace(min, max, num, **kwargs)
+        return np.linspace(min, max, int(num), **kwargs)
 
 def geomspace(start, ratio=None, stop=False, num=50):
     """

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1252,7 +1252,7 @@ def logspace(min, max, num, **kwargs):
     """
     if isinstance(min, datetime.datetime):
         from matplotlib.dates import date2num, num2date
-        ans = num2date(np.logspace(np.log10(date2num(min)), np.log10(date2num(max)), int(num), **kwargs))
+        ans = num2date(np.logspace(np.log10(date2num(min)), np.log10(date2num(max)), num, **kwargs))
         ans = spt.no_tzinfo(ans)
         return np.array(ans)
     else:
@@ -1303,11 +1303,11 @@ def linspace(min, max, num, **kwargs):
         max = max.item()
     if isinstance(min, datetime.datetime):
         from matplotlib.dates import date2num, num2date
-        ans = num2date(np.linspace(date2num(min), date2num(max), int(num), **kwargs))
+        ans = num2date(np.linspace(date2num(min), date2num(max), num, **kwargs))
         ans = spt.no_tzinfo(ans)
         return np.array(ans)
     else:
-        return np.linspace(min, max, int(num), **kwargs)
+        return np.linspace(min, max, num, **kwargs)
 
 def geomspace(start, ratio=None, stop=False, num=50):
     """

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -9,7 +9,7 @@ Copyright ©2010 Los Alamos National Security, LLC.
 import unittest
 
 import numpy as np
-import datetime as dt
+import datetime
 
 import spacepy.datamodel as dm
 import spacepy.toolbox as tb
@@ -24,9 +24,9 @@ class spectrogramTests(unittest.TestCase):
         self.kwargs = {}
         self.kwargs['variables'] = ['xval', 'yval', 'zval']
         np.random.seed(8675309)
-        self.data = dm.SpaceData(xval = dm.dmarray(np.random.random_sample(200)), 
-                            yval = dm.dmarray(np.random.random_sample(200)), 
-                            zval = dm.dmarray(np.random.random_sample(200)))
+        self.data = dm.SpaceData(xval=dm.dmarray(np.random.random_sample(200)),
+                                 yval=dm.dmarray(np.random.random_sample(200)),
+                                 zval=dm.dmarray(np.random.random_sample(200)))
 
 
     def tearDown(self):
@@ -34,8 +34,8 @@ class spectrogramTests(unittest.TestCase):
 
     def test_keywords(self):
         """there is some input checking"""
-        self.assertRaises(KeyError, spectrogram, self.data, variables=['bad'] )
-        self.assertRaises(KeyError, spectrogram, self.data, bad_keyword=['bad'] )
+        self.assertRaises(KeyError, spectrogram, self.data, variables=['bad'])
+        self.assertRaises(KeyError, spectrogram, self.data, bad_keyword=['bad'])
 
     def test_init_raise_len(self):
         """__init__ does some checking on data length"""
@@ -50,21 +50,21 @@ class spectrogramTests(unittest.TestCase):
     def test_defaults(self):
         """run it and check that defaults were set correctly"""
         a = spectrogram(self.data, variables=self.kwargs['variables'], extended_out=False)
-        ans = {'bins': [dm.dmarray([ 0.00120857,  0.07751865,  0.15382872,  0.2301388 ,  0.30644887,
-                               0.38275895,  0.45906902,  0.5353791 ,  0.61168917,  0.68799925,
-                               0.76430932,  0.8406194 ,  0.91692947,  0.99323955]),
-                        dm.dmarray([ 0.00169679,  0.07848775,  0.1552787 ,  0.23206965,  0.30886061,
-                               0.38565156,  0.46244251,  0.53923347,  0.61602442,  0.69281538,
-                               0.76960633,  0.84639728,  0.92318824,  0.99997919])],
-                'variables': ['xval', 'yval', 'zval'],
-                'xlim': (0.0012085702179961411, 0.99323954710300699),
-                'ylim': (0.001696792515639145, 0.99997919064162388),
-                'zlim': (0.012544022260691956, 0.99059103521121727)}
+        ans = {'bins': [dm.dmarray([0.00120857, 0.07751865, 0.15382872, 0.2301388, 0.30644887,
+                                    0.38275895, 0.45906902, 0.5353791, 0.61168917, 0.68799925,
+                                    0.76430932, 0.8406194, 0.91692947, 0.99323955]),
+                        dm.dmarray([0.00169679, 0.07848775, 0.1552787, 0.23206965, 0.30886061,
+                                    0.38565156, 0.46244251, 0.53923347, 0.61602442, 0.69281538,
+                                    0.76960633, 0.84639728, 0.92318824, 0.99997919])],
+               'variables': ['xval', 'yval', 'zval'],
+               'xlim': (0.0012085702179961411, 0.99323954710300699),
+               'ylim': (0.001696792515639145, 0.99997919064162388),
+               'zlim': (0.012544022260691956, 0.99059103521121727)}
         for key in ans:
             if key == 'variables':
                 self.assertEqual(a.specSettings[key], ans[key])
             else:
-#                np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
+                # np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
                 np.testing.assert_almost_equal(a.specSettings[key], ans[key],  decimal=7)
         self.assertRaises(NotImplementedError, a.add_data, self.data)
 
@@ -72,21 +72,21 @@ class spectrogramTests(unittest.TestCase):
     def test_defaults_extended(self):
         """run it and check that defaults were set correctly (extended_out)"""
         a = spectrogram(self.data, variables=self.kwargs['variables'])
-        ans = {'bins': [dm.dmarray([ 0.00120857,  0.07751865,  0.15382872,  0.2301388 ,  0.30644887,
-                               0.38275895,  0.45906902,  0.5353791 ,  0.61168917,  0.68799925,
-                               0.76430932,  0.8406194 ,  0.91692947,  0.99323955]),
-                        dm.dmarray([ 0.00169679,  0.07848775,  0.1552787 ,  0.23206965,  0.30886061,
-                               0.38565156,  0.46244251,  0.53923347,  0.61602442,  0.69281538,
-                               0.76960633,  0.84639728,  0.92318824,  0.99997919])],
-                'variables': ['xval', 'yval', 'zval'],
-                'xlim': (0.0012085702179961411, 0.99323954710300699),
-                'ylim': (0.001696792515639145, 0.99997919064162388),
-                'zlim': (0.012544022260691956, 0.99059103521121727)}
+        ans = {'bins': [dm.dmarray([0.00120857, 0.07751865, 0.15382872, 0.2301388, 0.30644887,
+                                    0.38275895, 0.45906902, 0.5353791, 0.61168917, 0.68799925,
+                                    0.76430932, 0.8406194, 0.91692947, 0.99323955]),
+                        dm.dmarray([0.00169679, 0.07848775, 0.1552787, 0.23206965, 0.30886061,
+                                    0.38565156, 0.46244251, 0.53923347, 0.61602442, 0.69281538,
+                                    0.76960633, 0.84639728, 0.92318824, 0.99997919])],
+               'variables': ['xval', 'yval', 'zval'],
+               'xlim': (0.0012085702179961411, 0.99323954710300699),
+               'ylim': (0.001696792515639145, 0.99997919064162388),
+               'zlim': (0.012544022260691956, 0.99059103521121727)}
         for key in ans:
             if key == 'variables':
                 self.assertEqual(a.specSettings[key], ans[key])
             else:
-#                np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
+                # np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
                 np.testing.assert_almost_equal(a.specSettings[key], ans[key], decimal=8)
 
     def test_add_data(self):
@@ -108,13 +108,12 @@ class spectrogramTests(unittest.TestCase):
 class spectrogramDateTests(unittest.TestCase):
     def setUp(self):
         super(spectrogramDateTests, self).setUp()
-        self.kwargs = {}
-        self.kwargs['variables'] = ['xval', 'yval', 'zval']
+        self.kwargs = {'variables': ['xval', 'yval', 'zval']}
         np.random.seed(8675309)
-        self.data = dm.SpaceData(xval = dm.dmarray([dt.datetime(2000,1,1)+dt.timedelta(days=nn) for nn in range(200)]), 
-                            yval = dm.dmarray(np.random.random_sample(200)), 
-                            zval = dm.dmarray(np.random.random_sample(200)))
-
+        self.data = dm.SpaceData(
+            xval=dm.dmarray([datetime.datetime(2000, 1, 1) + datetime.timedelta(days=nn) for nn in range(200)]),
+            yval=dm.dmarray(np.random.random_sample(200)),
+            zval=dm.dmarray(np.random.random_sample(200)))
 
     def tearDown(self):
         super(spectrogramDateTests, self).tearDown()
@@ -122,17 +121,17 @@ class spectrogramDateTests(unittest.TestCase):
     def test_defaults(self):
         """run it and check that defaults were set correctly"""
         a = spectrogram(self.data, variables=self.kwargs['variables'])
-        ans = {'bins': [dm.dmarray([ 730120.0,  730135.30769231,  730150.61538462,
-        730165.92307692,  730181.23076923,  730196.53846154,
-        730211.84615385,  730227.15384615,  730242.46153846,
-        730257.76923077,  730273.07692308,  730288.38461538,
-        730303.69230769,  730319.        ]),
-                   dm.dmarray([ 0.00169679,  0.07848775,  0.1552787 ,  0.23206965,  0.30886061,
-                               0.38565156,  0.46244251,  0.53923347,  0.61602442,  0.69281538,
-                               0.76960633,  0.84639728,  0.92318824,  0.99997919])],
-                'variables': ['xval', 'yval', 'zval'],
-                'ylim': (0.0012085702179961411, 0.99323954710300699),
-                'zlim': (0.001696792515639145, 0.99997919064162388)}
+        ans = {'bins': [dm.dmarray([730120.0, 730135.30769231, 730150.61538462,
+                                    730165.92307692, 730181.23076923, 730196.53846154,
+                                    730211.84615385, 730227.15384615, 730242.46153846,
+                                    730257.76923077, 730273.07692308, 730288.38461538,
+                                    730303.69230769, 730319.]),
+                        dm.dmarray([0.00169679, 0.07848775, 0.1552787, 0.23206965, 0.30886061,
+                                    0.38565156, 0.46244251, 0.53923347, 0.61602442, 0.69281538,
+                                    0.76960633, 0.84639728, 0.92318824, 0.99997919])],
+               'variables': ['xval', 'yval', 'zval'],
+               'ylim': (0.0012085702179961411, 0.99323954710300699),
+               'zlim': (0.001696792515639145, 0.99997919064162388)}
         for key in ans:
             if key == 'variables':
                 self.assertEqual(a.specSettings[key], ans[key])


### PR DESCRIPTION
This will close #181. The fix is a simple cast to int for the `num` parameter in `linspace` and `logspace`.