### PR TITLE
pybats: IdlFile/Bats2d: Fix overflow of integer file positions on Windows for large files

### DIFF
--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -534,9 +534,9 @@ def readarray(f,dtype=np.float32,inttype=np.int32):
     if seekable:
         f.seek(0, 2)
         endpos = f.tell()
-        if endpos - startpos < (rec_len[0] + np.dtype(inttype).itemsize):
+        if endpos - startpos < (int(rec_len[0]) + np.dtype(inttype).itemsize):
             raise EOFError('File is shorter than expected data')
-        f.seek(startpos + rec_len[0], 0)
+        f.seek(startpos + int(rec_len[0]), 0)
         rec_len_end = np.fromfile(f,dtype=inttype,count=1)
         f.seek(startpos, 0)
         if rec_len_end != rec_len:


### PR DESCRIPTION
Closes #186 

As discussed in #186, explicitly cast the calculated record length to int so that adding the numpy int to the start position won't cause an integer overflow on Windows, when attempting to read binary BATSRUS files larger than 2GB.

Tested locally per discussion in #186.