### PR TITLE
poppy.boots_ci: fix handling of multiple return values in C version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Changes in Version 0.2.1 (2019-xx-xx)
 =====================================
+poppy
+ - Fix bootstrapping when aggregating function has multiple outputs
 
 Changes in Version 0.2.0 (2019-06-22)
 =====================================

--- a/spacepy/poppy.py
+++ b/spacepy/poppy.py
@@ -756,9 +756,10 @@ def boots_ci(data, n, inter, func, seed=None, target=None, sample_size=None, use
                   ctypes.c_ulong(n), ctypes.c_ulong(n_els),
                   ctypes.c_ulong(sample_size),
                   ctypes.c_ulong(seed), clock_seed)
-        surr_quan = sorted(
-            (func(surr_ser[i * sample_size:(i  + 1) * sample_size])
-             for i in range(n)))
+        gen = (func(surr_ser[i * sample_size:(i  + 1) * sample_size])
+               for i in range(n))
+        #Can't sort if more than one return value
+        surr_quan = sorted(gen) if nretvals == 1 else np.stack(gen)
     #get confidence interval
     if nretvals>1:
         pul = np.empty((2, nretvals))

--- a/tests/test_poppy.py
+++ b/tests/test_poppy.py
@@ -162,6 +162,33 @@ class BootstrapTests(unittest.TestCase):
             self.assertAlmostEqual(3.57505503117, ci_low, places=10)
             self.assertAlmostEqual(4.4100232162, ci_high, places=10)
 
+    def testMultOutputs(self):
+        """Check bootstrap on a function with multiple outputs"""
+        numpy.random.seed(8201) #reproducible
+        data = numpy.random.randn(1000)
+        ci_low, ci_high = poppy.boots_ci(
+            data, 1000, 90.,
+            lambda x: (numpy.mean(x), numpy.median(x)),
+            nretvals=2, seed=8201)
+        #Simple regression. Mostly we want to test that this works at all,
+        #but this is coarse enough that should be near regardless of details
+        self.assertAlmostEqual(-0.08, ci_low[0], places=2)
+        self.assertAlmostEqual(-0.1, ci_low[1], places=2)
+        #Same thing with numpy output of function
+        ci_low, ci_high = poppy.boots_ci(
+            data, 1000, 90.,
+            lambda x: numpy.array([numpy.mean(x), numpy.median(x)]),
+            nretvals=2, seed=8201)
+        self.assertAlmostEqual(-0.08, ci_low[0], places=2)
+        self.assertAlmostEqual(-0.1, ci_low[1], places=2)
+        #And compare against single-value version
+        ci_low, ci_high = poppy.boots_ci(
+            data, 1000, 90., numpy.mean, seed=8201)
+        self.assertAlmostEqual(-0.08, ci_low, places=2)
+        ci_low, ci_high = poppy.boots_ci(
+            data, 1000, 90., numpy.median, seed=8201)
+        self.assertAlmostEqual(-0.1, ci_low, places=2)
+
 
 class AssocTests(unittest.TestCase):
     """Tests of association analysis"""


### PR DESCRIPTION
poppy.boots_ci was failing (C version only) if the aggregating function returned multiple values. This PR adds a test and fixes this.

In the case of multiple returns, the result isn't sorted, since there isn't one sort order. This shouldn't affect the results; I think the sorting was largely an efficiency measure
