### PR TITLE
Bootstrap-based histogram with error bars

### DIFF
--- a/Doc/source/toolbox.rst
+++ b/Doc/source/toolbox.rst
@@ -52,6 +52,7 @@ Other functions
     :toctree: autosummary
 
     assemble
+    bootHisto
     dictree
     eventTimer
     feq

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1211,7 +1211,7 @@ def binHisto(data, verbose=False):
             print("Used F-D rule")
     return (binw, nbins)
 
-def bootHisto(data, inter=90., n=100, seed=None, plot=False, **kwargs):
+def bootHisto(data, inter=90., n=1000, seed=None, plot=False, **kwargs):
     """Bootstrap confidence intervals for a histogram.
 
     All other keyword arguments are passed to `numpy.histogram`

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1211,11 +1211,12 @@ def binHisto(data, verbose=False):
             print("Used F-D rule")
     return (binw, nbins)
 
-def bootHisto(data, inter=90., n=1000, seed=None, plot=False, **kwargs):
+def bootHisto(data, inter=90., n=1000, seed=None,
+              plot=False, target=None, figsize=None, loc=None, **kwargs):
     """Bootstrap confidence intervals for a histogram.
 
-    All other keyword arguments are passed to `numpy.histogram`
-    or `matplotlib.pyplot.bar`.
+    All other keyword arguments are passed to :func:`numpy.histogram`
+    or :func:`matplotlib.pyplot.bar`.
 
     Parameters
     ==========
@@ -1230,9 +1231,16 @@ def bootHisto(data, inter=90., n=1000, seed=None, plot=False, **kwargs):
     seed : int (optional)
         Optional seed for the random number generator. If not
         specified; numpy generator will not be reseeded.
-    plot : bool or AxesSubplot (optional)
-        Plot the result. If True, create a new plot; also accepts
-        an AxesSubplot object into which to draw.
+    plot : bool (optional)
+        Plot the result. Plots if True or ``target``, ``figsize``,
+        or ``loc`` specified.
+    target : (optional)
+        Target on which to plot the figure (figure or axes). See
+        :func:`spacepy.plot.utils.set_target` for details.
+    figsize : tuple (optional)
+        Passed to :func:`spacepy.plot.utils.set_target`.
+    loc : int (optional)
+        Passed to :func:`spacepy.plot.utils.set_target`.
 
     Returns
     =======
@@ -1273,6 +1281,7 @@ def bootHisto(data, inter=90., n=1000, seed=None, plot=False, **kwargs):
     See Also
     ========
     binHisto
+    plot.utils.set_target
     numpy.histogram
     matplotlib.pyplot.hist
     """
@@ -1289,10 +1298,11 @@ def bootHisto(data, inter=90., n=1000, seed=None, plot=False, **kwargs):
         data, n, inter,
         lambda x: np.histogram(x, **histogram_kwargs)[0],
         nretvals=len(bin_edges) - 1)
-    if not plot:
+    if not plot and all([x is None for f in (target, figsize, loc)]):
         return bin_edges, ci_low, ci_high, sample
-    import matplotlib.pyplot as plt
-    ax = plt if plot is True else plot
+    import spacepy.plot.utils
+    _, ax = spacepy.plot.utils.set_target(
+        target, figsize=figsize, loc=(111 if loc is None else loc))
     if 'ecolor' not in bar_kwargs:
         bar_kwargs['ecolor'] = 'k'
     bars = ax.bar(

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1298,7 +1298,7 @@ def bootHisto(data, inter=90., n=1000, seed=None,
         data, n, inter,
         lambda x: np.histogram(x, **histogram_kwargs)[0],
         nretvals=len(bin_edges) - 1)
-    if not plot and all([x is None for f in (target, figsize, loc)]):
+    if not plot and all([x is None for x in (target, figsize, loc)]):
         return bin_edges, ci_low, ci_high, sample
     import spacepy.plot.utils
     _, ax = spacepy.plot.utils.set_target(

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -334,6 +334,28 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertEqual(result, "Used F-D rule\n")
         sys.stdout = realstdout
 
+    def testBootHisto(self):
+        """Bootstrap histogram known output for known input"""
+        numpy.random.seed(28420)
+        data = numpy.random.randn(1000)
+        bin_edges, ci_low, ci_high, sample = spacepy.toolbox.bootHisto(
+            data, n=1000, seed=28420)
+        numpy.testing.assert_allclose(
+            [-3.17371804, -2.40693385, -1.64014966, -0.87336547,
+             -0.10658127, 0.66020292,  1.42698711,  2.1937713 ,
+             2.9605555 ,  3.72733969, 4.49412388],
+            bin_edges, rtol=1e-5)
+        numpy.testing.assert_equal(
+            [  7,  45, 149, 283, 272, 162,  71,   9,   0,   2], sample)
+        #This is a very coarse chunk-check to allow for variations in
+        #RNGs. Values from 100000 iterations
+        numpy.testing.assert_allclose(
+            [3.,  34., 131., 260., 249., 143.,  58.,   4.,   0.,   0.],
+            ci_low, atol=2, rtol=1e-2)
+        numpy.testing.assert_allclose(
+            [12.,  56., 168., 306., 295., 181.,  84.,  14.,   0.,   5.],
+            ci_high, atol=2, rtol=1e-2)
+
     def test_logspace(self):
         """logspace should return know answer for known input"""
         try:


### PR DESCRIPTION
This PR adds a toolbox function to calculate bootstrap-based confidence intervals on histograms (and optionally plot.) It's nothing earthshattering but I had a student who wasn't putting error bars on a histo and figured it was worth making easy.