### PR TITLE
Add 'version of spacepy' to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -65,3 +65,7 @@ print('matplotlib={0}'.format(matplotlib.__version__))
 ```
 -->
 
+### Version of SpacePy
+<!-- What version of SpacePy are you using and where did you
+download it from?
+-->


### PR DESCRIPTION
This PR adds "What version of SpacePy are you using" to the issue template. Triggered by #190 being an old version.
