### PR TITLE
Fix unicode symbol in irbem source

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Changes in Version 0.2.1 (2019-xx-xx)
 =====================================
+irbempy
+ - Fix compilation issues on certain systems
 poppy
  - Fix bootstrapping when aggregating function has multiple outputs
 

--- a/spacepy/irbempy/NOTES.md
+++ b/spacepy/irbempy/NOTES.md
@@ -7,11 +7,11 @@ mv drift_bounce_orbit_new.f drift_bounce_orbit.f
 ### replace myOwnMagField.f with Dungey model
 cp [previousRev]/source/myOwnMagField.f [newRev]/source/myOwnMagField.f
 
-### fix comments
+### fix comments; unicode
 It seems that some comment lines confuse f2py.
 E.g., line 690 (in rev546) "      REAL*8 Bmirror  ! particle's mirror field strength"
 The apostrophe breaks the compile, so it needs to be removed.
-Lines 331 and 3058 (in rev546) have unicode degree symbols that should be removed.
+Lines 331 and 3083 (in rev616) have unicode degree symbols that should be removed.
 There are a lot of wanrings about lines with an exclamation as comment marker - for now we ignore these.
 
 ### TS07D updates

--- a/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/onera_desp_lib.f
+++ b/spacepy/irbempy/irbem-lib-2019-04-04-rev616/source/onera_desp_lib.f
@@ -328,7 +328,7 @@ c
             GOTO 99
           endif
 c
-c Compute Bmin assuming 90� PA at S/C
+c Compute Bmin assuming 90deg PA at S/C
          k_l=0
            IPA=1
            CALL calcul_Lstar_opt(t_resol,r_resol,xGEO
@@ -3080,7 +3080,7 @@ c      collect the B components for return in maginput() array
          maginput(16)=baddata
       ENDIF
 c
-c Compute Bmin assuming 90� PA at S/C
+c Compute Bmin assuming 90deg PA at S/C
          k_l=0
            IPA=1
 c             all returned values except Bmin are subsequently overwritten


### PR DESCRIPTION
Fixes compilation problems in #190 and updates notes on upgrading to new IRBEM (just updated line numbers.) Making this change was already on the IRBEM update checklist but apparently got missed.
