### PR TITLE
Pybats: Write coordinate system to IMF file from ImfInput.write

### DIFF
--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1529,7 +1529,7 @@ class ImfInput(PbData):
             out.write(head)
 
         # Handle Params:
-	if self.attrs['coor']:
+        if self.attrs['coor']:
             out.write('#COOR\n{}\n\n'.format(self.attrs['coor']))
         if self.attrs['zerobx']:
             out.write('#ZEROBX\nT\n\n')


### PR DESCRIPTION
The ImfInput routine was reading in the coordinate parameter but not writing it out, this fix writes out the coordinate system, even if it is in GSM. Another option would be to change line 1532 to "if self.attrs['coor'] != 'GSM':" since GSM is the default coordinate system.