### PR TITLE
pycdf support for ISTP-compliant CDFs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ pycdf
  - Allow access to attributes via "meta" property
  - Single element references now return Python types not numpy scalars
  - Fix type-guessing on numpy object arrays with no values
+ - New "istp" module supporting CDFs with ISTP-compliant metadata
 
 Changes in Version 0.2.0 (2019-06-22)
 =====================================

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -64,6 +64,7 @@ SpacePy Documents
     case_studies
     publications
     pythonic
+    scripts
 
 SpacePy Code
 ============

--- a/Doc/source/pycdf.rst
+++ b/Doc/source/pycdf.rst
@@ -16,6 +16,7 @@ Contents
     - `Non record-varying`_
     - `Slicing and indexing`_
 - `Class reference`_
+- `Submodules`_
 
 Quickstart
 ----------
@@ -237,7 +238,7 @@ The underlying C library is represented by the :attr:`~spacepy.pycdf.lib`
 variable.
 
 Class reference
-===============
+---------------
 
 .. autosummary::
     :template: clean_class.rst
@@ -270,6 +271,12 @@ Class reference
     >>> pycdf.lib.version
         (3, 3, 0, ' ')
 
-.. attribute:: const
+Submodules
+----------
 
-.. automodule:: spacepy.pycdf.const
+.. autosummary::
+    :toctree: autosummary  
+    :template: clean_module.rst
+
+    const
+    istp

--- a/Doc/source/scripts.rst
+++ b/Doc/source/scripts.rst
@@ -1,0 +1,24 @@
+***************
+SpacePy Scripts
+***************
+
+Some scripts using SpacePy are included in the ``scripts`` directory
+of the source distribution. At the moment they are not installed by
+the installer.
+
+istp_checks.py
+==============
+.. program:: istp_checks.py
+
+Checks for various ISTP compliance issues in a file and prints any
+issues found. This script is supplemental to the checker included with
+the `ISTP skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_;
+it primarily checks for errors that the skeleton editor does not.
+
+This is just a thin wrapper to :meth:`spacepy.pycdf.istp.FileChecks.all`.
+
+.. option:: cdffile
+
+    Name of the CDF file to check (required)
+
+

--- a/Doc/source/scripts.rst
+++ b/Doc/source/scripts.rst
@@ -15,6 +15,10 @@ issues found. This script is supplemental to the checker included with
 the `ISTP skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_;
 it primarily checks for errors that the skeleton editor does not.
 
+Badly noncompliant files may result in this script exiting with
+unusual errors because they violate some assumption underlying the
+check.
+
 This is just a thin wrapper to :meth:`spacepy.pycdf.istp.FileChecks.all`.
 
 .. option:: cdffile

--- a/Doc/source/scripts.rst
+++ b/Doc/source/scripts.rst
@@ -15,11 +15,15 @@ issues found. This script is supplemental to the checker included with
 the `ISTP skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_;
 it primarily checks for errors that the skeleton editor does not.
 
-Badly noncompliant files may result in this script exiting with
-unusual errors because they violate some assumption underlying the
-check.
+Badly noncompliant files generally result in the error "Test x did not
+complete". This means the test crashed due to some failure in the
+assumptions about the CDF structure. Please run the individual test to
+get a traceback and `open an issue
+<https://github.com/spacepy/spacepy/issues>`_.
 
-This is just a thin wrapper to :meth:`spacepy.pycdf.istp.FileChecks.all`.
+This is just a thin wrapper to
+:meth:`spacepy.pycdf.istp.FileChecks.all`; that documentation (plus
+other methods in the class) describes the actual checks.
 
 .. option:: cdffile
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,8 @@ include spacepy/pybats/ctrace2dtest.c
 #Tests
 graft tests
 prune tests/htmlcov
+#Scripts. Not installing right now but handy
+include scripts/*.py
 #Cruft to keep out
 recursive-exclude * *.o *.pyc *~ *.bak
 recursive-exclude spacepy realtime.*

--- a/scripts/istp_checks.py
+++ b/scripts/istp_checks.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import sys
+
+import spacepy.pycdf
+import spacepy.pycdf.istp
+
+
+def main(f):
+    """Do all checks on a file
+
+    :param str f: filename to check
+    """
+    with spacepy.pycdf.CDF(f) as cdffile:
+        errs = spacepy.pycdf.istp.FileChecks.all(cdffile)
+    if errs:
+        print('\n'.join(errs))
+
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])

--- a/scripts/istp_checks.py
+++ b/scripts/istp_checks.py
@@ -12,7 +12,7 @@ def main(f):
     :param str f: filename to check
     """
     with spacepy.pycdf.CDF(f) as cdffile:
-        errs = spacepy.pycdf.istp.FileChecks.all(cdffile)
+        errs = spacepy.pycdf.istp.FileChecks.all(cdffile, catch=True)
     if errs:
         print('\n'.join(errs))
 

--- a/scripts/istp_checks.py
+++ b/scripts/istp_checks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys
+import argparse
 
 import spacepy.pycdf
 import spacepy.pycdf.istp
@@ -18,4 +18,9 @@ def main(f):
 
 
 if __name__ == '__main__':
-    main(*sys.argv[1:])
+    parser = argparse.ArgumentParser(
+        description="Check a CDF file for ISTP compliance.")
+    parser.add_argument('cdffile', action='store',
+                        help='Path to CDF file to check')
+    args = parser.parse_args()
+    main(args.cdffile)

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -44,7 +44,6 @@ Contact: Jonathan.Niehof@unh.edu
 
 
 Copyright 2010-2015 Los Alamos National Security, LLC.
-
 """
 
 __contact__ = 'Jon Niehof, Jonathan.Niehof@unh.edu'

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1150,11 +1150,12 @@ class Library(object):
         raise NotImplementedError(
             'TT2000 functions require CDF library 3.4.0 or later')
 
-    @staticmethod
-    def get_minmax(cdftype):
+    def get_minmax(self, cdftype):
         """Find minimum, maximum possible value based on CDF type.
 
-        This returns the "raw" (unparsed) value.
+        This returns the processed value (e.g. datetimes for Epoch
+        types) because comparisons to EPOCH16s are otherwise
+        difficult.
 
         Parameters
         ==========
@@ -1170,27 +1171,23 @@ class Library(object):
         out : tuple
             minimum, maximum value supported by type (of type matching the
             CDF type).
+
         """
         try:
             cdftype = cdftype.value
         except:
             pass
         if cdftype == spacepy.pycdf.const.CDF_EPOCH.value:
-            return (
-                spacepy.pycdf.lib.datetime_to_epoch(
-                    datetime.datetime(1, 1, 1)),
+            return (datetime.datetime(1, 1, 1),
                 #Can get asymptotically closer, but why bother
-                spacepy.pycdf.lib.datetime_to_epoch(
-                    datetime.datetime(9999, 12, 31, 23, 59, 59)))
+                datetime.datetime(9999, 12, 31, 23, 59, 59))
         elif cdftype == spacepy.pycdf.const.CDF_EPOCH16.value:
-            return (
-                spacepy.pycdf.lib.datetime_to_epoch16(
-                    datetime.datetime(1, 1, 1)),
-                spacepy.pycdf.lib.datetime_to_epoch16(
-                    datetime.datetime(9999, 12, 31, 23, 59, 59)))
+            return (datetime.datetime(1, 1, 1),
+                datetime.datetime(9999, 12, 31, 23, 59, 59))
         elif cdftype == spacepy.pycdf.const.CDF_TIME_TT2000.value:
             inf = numpy.iinfo(numpy.int64)
-            return (inf.min, inf.max)
+            return (self.tt2000_to_datetime(inf.min),
+                    self.tt2000_to_datetime(inf.max))
         dtype = spacepy.pycdf.lib.numpytypedict.get(cdftype, None)
         if dtype is None:
             raise ValueError('Unknown data type: {}'.format(cdftype))

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -305,7 +305,6 @@ class VariableChecks(object):
                 errs.append('VALIDMIN > VALIDMAX.')
         return errs
 
-    
     @classmethod
     def validscale(cls, v):
         """Check that SCALEMIN<=SCALEMAX, and neither goes out 
@@ -336,7 +335,6 @@ class VariableChecks(object):
             if raw_v.attrs['SCALEMIN'] > raw_v.attrs['SCALEMAX']:
                 errs.append('SCALEMIN > SCALEMAX.')
         return errs
-
 
     @classmethod
     def validplottype(cls, v):

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -33,7 +33,6 @@ import datetime
 import math
 import os.path
 import re
-import sys
 
 import numpy
 import spacepy.pycdf.const
@@ -258,22 +257,16 @@ class VariableChecks(object):
         :returns: All error messages
         :rtype: list of str
         """
-        if sys.version_info >= (3,0):
-            time_st = b'time_series'
-            spec_st = b'spectrogram'
-        else:
-            time_st = 'time_series'
-            spec_st = 'spectrogram'
+        time_st = 'time_series'
+        spec_st = 'spectrogram'
         errs = []
-        raw_v = v.cdf_file.raw_var(v.name())
-        data = raw_v[...]
-        if 'DISPLAY_TYPE' in raw_v.attrs:
-            if (len(raw_v.shape) == 1) and (raw_v.attrs['DISPLAY_TYPE'] != time_st):
+        if 'DISPLAY_TYPE' in v.attrs:
+            if (len(v.shape) == 1) and (v.attrs['DISPLAY_TYPE'] != time_st):
                 errs.append('{}: 1 dim variable with {} display type.'.format(
-                    raw_v.name(), raw_v.attrs['DISPLAY_TYPE']))
-            elif (len(raw_v.shape) > 1) and (raw_v.attrs['DISPLAY_TYPE'] != spec_st):
+                    v.name(), v.attrs['DISPLAY_TYPE']))
+            elif (len(v.shape) > 1) and (v.attrs['DISPLAY_TYPE'] != spec_st):
                 errs.append('{}: multi dim variable with {} display type.'.format(
-                    raw_v.name(), raw_v.attrs['DISPLAY_TYPE']))
+                    v.name(), v.attrs['DISPLAY_TYPE']))
         return errs
 
     @classmethod

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -481,7 +481,7 @@ class FileChecks(object):
         """
         errs = []
         for a in ('Logical_source', 'Logical_file_id'):
-            if not a in f.attrs:
+            if not a in f.attrs or len(f.attrs[a]) == 0:
                 errs.append('No {} in global attrs.'.format(a))
         if errs:
             return errs

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -302,7 +302,7 @@ class VariableChecks(object):
                     which, rawattrval, minval, maxval, v.name()))
         if ('VALIDMIN' in v.attrs) and ('VALIDMAX' in v.attrs):
             if numpy.any(v.attrs['VALIDMIN'] > v.attrs['VALIDMAX']):
-                errs.append('VALIDMIM > VALIDMAX for {}.'.format(v.name()))
+                errs.append('VALIDMIN > VALIDMAX.')
         return errs
 
     
@@ -325,21 +325,16 @@ class VariableChecks(object):
         raw_v = v.cdf_file.raw_var(v.name())
         minval, maxval = spacepy.pycdf.lib.get_minmax(raw_v.type())
         data = raw_v[...]
-        if 'SCALEMIN' in raw_v.attrs:
-            if (raw_v.attrs['SCALEMIN'] < minval) or \
-               (raw_v.attrs['SCALEMIN'] > maxval):
-                errs.append('SCALEMIN ({}) outside data range ({},{}) for {}.'.format(
-                    raw_v.attrs['SCALEMIN'], minval, maxval,
-                    raw_v.name()))
-        if 'SCALEMAX' in raw_v.attrs:
-            if (raw_v.attrs['SCALEMAX'] < minval) or \
-               (raw_v.attrs['SCALEMAX'] > maxval):
-                errs.append('SCALEMAX ({}) outside data range ({},{}) for {}.'.format(
-                    raw_v.attrs['SCALEMAX'], minval, maxval,
-                    raw_v.name()))
+        for which in ('SCALEMIN', 'SCALEMAX'):
+            if not which in v.attrs:
+                continue
+            rawattrval = raw_v.attrs[which]
+            if (rawattrval < minval) or (rawattrval > maxval):
+                errs.append('{} ({}) outside data range ({},{}).'.format(
+                    which, rawattrval, minval, maxval))
         if ('SCALEMIN' in raw_v.attrs) and ('SCALEMAX' in raw_v.attrs):
             if raw_v.attrs['SCALEMIN'] > raw_v.attrs['SCALEMAX']:
-                errs.append('SCALEMIN > SCALEMAX for {}.'.format(v.name()))
+                errs.append('SCALEMIN > SCALEMAX.')
         return errs
 
 

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -52,16 +52,41 @@ class VariableChecks(object):
     will check all tests and concatenate all errors. :meth:`all`
     should be updated with the list of all tests so that
     helper functions aren't called, subtests aren't called twice, etc.
+
+    .. autosummary::
+
+        all
+        depends
+        depsize
+        fieldnam
+        recordcount
+        validplottype
+        validrange
+        validscale
+        
+    .. automethod:: all
+    .. automethod:: depends
+    .. automethod:: depsize
+    .. automethod:: fieldnam
+    .. automethod:: recordcount
+    .. automethod:: validplottype
+    .. automethod:: validrange
+    .. automethod:: validscale
     """
 
     @classmethod
     def all(cls, v):
         """Call all test functions in this class
 
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         callme = (cls.depends, cls.depsize, cls.fieldnam, cls.recordcount,
                   cls.validrange, cls.validscale, cls.validplottype)
@@ -74,10 +99,15 @@ class VariableChecks(object):
     def depends(cls, v):
         """Checks that DEPEND and LABL_PTR variables actually exist
 
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         return ['{} variable {} missing'.format(a, v.attrs[a])
                 for a in v.attrs
@@ -88,10 +118,15 @@ class VariableChecks(object):
     def depsize(cls, v):
         """Checks that DEPEND has same shape as that dim
 
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         rv = int(v.rv()) #RV is a leading dimension
         errs = []
@@ -162,10 +197,15 @@ class VariableChecks(object):
     def recordcount(cls, v):
         """Check that the DEPEND_0 has same record count as variable
 
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         if not v.rv() or not 'DEPEND_0' in v.attrs:
             return []
@@ -181,10 +221,15 @@ class VariableChecks(object):
     def validrange(cls, v):
         """Check that all values are within VALIDMIN/VALIDMAX, or FILLVAL
 
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
@@ -230,10 +275,16 @@ class VariableChecks(object):
     def validscale(cls, v):
         """Check that SCALEMIN<=SCALEMAX, and neither goes out 
         of range for CDF datatype.
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
@@ -260,10 +311,16 @@ class VariableChecks(object):
     @classmethod
     def validplottype(cls, v):
         """Check that plottype matches dimensions.
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         time_st = 'time_series'
         spec_st = 'spectrogram'
@@ -281,10 +338,15 @@ class VariableChecks(object):
     def fieldnam(cls, v):
         """Check that FIELDNAM attribute matches variable name.
 
-        :param v: Variable to check
-        :type v: :class:`~spacepy.pycdf.Var`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        v : :class:`~spacepy.pycdf.Var`
+            Variable to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         errs = []
         vname = v.name()
@@ -303,16 +365,33 @@ class FileChecks(object):
     will check all tests and concatenate all errors. :meth:`all`
     should be updated with the list of all tests so that
     helper functions aren't called, subtests aren't called twice, etc.
+
+    .. autosummary::
+
+        all
+        filename
+        time_monoton
+        times
+        
+    .. automethod:: all
+    .. automethod:: filename
+    .. automethod:: time_monoton
+    .. automethod:: times
     """
 
     @classmethod
     def all(cls, f):
         """Call all test functions, AND all test functions on all variables
 
-        :param f: File to check
-        :type f: :class:`~spacepy.pycdf.CDF`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        f : :class:`~spacepy.pycdf.CDF`
+            Open CDF file to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         callme = (cls.filename, cls.time_monoton, cls.times,)
         errors = []
@@ -330,10 +409,15 @@ class FileChecks(object):
         Check that the logical_file_id matches the actual filename,
         and logical_source also matches.
 
-        :param f: File to check
-        :type f: :class:`~spacepy.pycdf.CDF`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        f : :class:`~spacepy.pycdf.CDF`
+            Open CDF file to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         errs = []
         for a in ('Logical_source', 'Logical_file_id'):
@@ -358,10 +442,15 @@ class FileChecks(object):
 
         Check that all Epoch variables are monotonically increasing.
 
-        :param f: File to check
-        :type f: :class:`~spacepy.pycdf.CDF`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        f : :class:`~spacepy.pycdf.CDF`
+            Open CDF file to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         errs = []
         for v in f:
@@ -383,10 +472,15 @@ class FileChecks(object):
 
         Check that all Epoch variables only contain times matching filename
 
-        :param f: File to check
-        :type f: :class:`~spacepy.pycdf.CDF`
-        :returns: All error messages
-        :rtype: list of str
+        Parameters
+        ----------
+        f : :class:`~spacepy.pycdf.CDF`
+            Open CDF file to check
+
+        Returns
+        -------
+        list of str
+            All error messages
         """
         errs = []
         fname = os.path.basename(f.pathname)
@@ -415,8 +509,10 @@ class FileChecks(object):
 def fillval(v): 
     """Automatically set ISTP-compliant FILLVAL on a variable
 
-    :param v: Variable to update
-    :type v: :class:`~spacepy.pycdf.Var`
+    Parameters
+    ----------
+    v : :class:`~spacepy.pycdf.Var`
+        Variable to update
     """
     #Fill value, indexed by the CDF type (numeric)
     fillvals = {}
@@ -450,12 +546,16 @@ def fillval(v):
 def format(v, use_scaleminmax=False, dryrun=False):
     """Automatically set ISTP-compliant FORMAT on a variable
 
-    :param v: Variable to update
-    :type v: :class:`~spacepy.pycdf.Var`
-    :param bool use_scaleminmax: Use SCALEMIN/MAX instead of VALIDMIN/MAX.
-                                 Note: istpchecks may complain about result.
-    :param bool dryrun: Print the decided format to stdout instead of modifying
-                        the CDF.  (For use in command-line debugging.)
+    Parameters
+    ----------
+    v : :class:`~spacepy.pycdf.Var`
+        Variable to update
+    use_scaleminmax : bool, optional
+        Use SCALEMIN/MAX instead of VALIDMIN/MAX (default False).
+        Note: istpchecks may complain about result.
+    dryrun : bool, optional
+        Print the decided format to stdout instead of modifying
+        the CDF (for use in command-line debugging) (default False).
     """
     if use_scaleminmax:
         minn = 'SCALEMIN'

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -8,6 +8,14 @@ relationships between the variables and their physical interpretation.
 
 This module supports that subset of CDFs.
 
+Authors: Jon Niehof
+
+Additional Contributors: Lorna Ellis, Asher Merrill
+
+Institution: University of New Hampshire
+
+Contact: Jonathan.Niehof@unh.edu
+
 .. rubric:: Classes
 
 .. autosummary::

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -307,11 +307,17 @@ class VariableChecks(object):
                 else:
                     badidx = badidx[0] #Just recover the index value
                 direction = 'under' if which == whichmin else 'over'
-                errs.append('Value {} at index {} {} {} {}.'.format(
-                    ', '.join(str(d) for d in badvals),
-                    ', '.join(str(d) for d in badidx),
-                    direction, which,
-                    attrval[0, :] if multidim else attrval))
+                if len(badvals) < 10:
+                    badvalstr = ', '.join(str(d) for d in badvals)
+                    badidxstr = ', '.join(str(d) for d in badidx)
+                    errs.append('Value {} at index {} {} {} {}.'.format(
+                        badvalstr, badidxstr,
+                        direction, which,
+                        attrval[0, :] if multidim else attrval))
+                else:
+                    errs.append('{} values {} {} {}'.format(
+                        len(badvals), direction, which,
+                        attrval[0, :] if multidim else attrval))
         if (whichmin in v.attrs) and (whichmax in v.attrs):
             if numpy.any(v.attrs[whichmin] > v.attrs[whichmax]):
                 errs.append('{} > {}.'.format(whichmin, whichmax))

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -575,75 +575,65 @@ def format(v, use_scaleminmax=False, dryrun=False):
         v.attrs.new('FORMAT', data=fmt, type=spacepy.pycdf.const.CDF_CHAR)
 
 
-def get_max(type): 
+def _dtype_info(cdftype):
+    """Find the dtype info structure for a CDF type
+
+    :param int cdftype: the CDF type number
+    :return: numpy iinfo/finfo structure
+    """
+    dtype = spacepy.pycdf.lib.numpytypedict.get(cdftype, None)
+    if dtype is None:
+        raise ValueError('Unknown data type: {}'.format(cdftype))
+    if numpy.issubdtype(dtype, numpy.integer):
+        return numpy.iinfo(dtype)
+    elif numpy.issubdtype(dtype, numpy.float):
+        return numpy.finfo(dtype)
+    else:
+        raise ValueError('Unknown data type: {}'.format(cdftype))
+
+
+def get_max(cdftype):
     """Find maximum possible value based on datatype.
 
-    :param int type: Type number
-    :return: Maximum valid number
+    :param int cdftype: CDF type number from :mod:`~spacepy.pycdf.const`
+    :return: Maximum valid value
     :rtype: int
     """
+    try:
+        cdftype = cdftype.value
+    except:
+        pass
+    if cdftype == spacepy.pycdf.const.CDF_EPOCH.value:
+        #Can get asymptotically closer, but why bother
+        return spacepy.pycdf.lib.datetime_to_epoch(
+            datetime.datetime(9999, 12, 31, 23, 59, 59))
+    elif cdftype == spacepy.pycdf.const.CDF_EPOCH16.value:
+        #Can get asymptotically closer, but why bother
+        return spacepy.pycdf.lib.datetime_to_epoch16(
+            datetime.datetime(9999, 12, 31, 23, 59, 59))
+    elif cdftype == spacepy.pycdf.const.CDF_TIME_TT2000.value:
+        return numpy.iinfo(numpy.int64).max
+    return _dtype_info(cdftype).max
 
-    if(type == spacepy.pycdf.const.CDF_BYTE.value) or \
-      (type == spacepy.pycdf.const.CDF_INT1.value) or \
-      (type == spacepy.pycdf.const.CDF_CHAR.value):
-        return 127
-    elif(type == spacepy.pycdf.const.CDF_UINT1.value) or \
-        (type == spacepy.pycdf.const.CDF_UCHAR.value):
-        return 255
-    elif(type == spacepy.pycdf.const.CDF_INT2.value):
-        return 32767
-    elif(type == spacepy.pycdf.const.CDF_UINT2.value):
-        return 65535
-    elif(type == spacepy.pycdf.const.CDF_INT4.value):
-        return 2147483647
-    elif(type == spacepy.pycdf.const.CDF_UINT4.value):
-        return 4294967295
-    elif(type == spacepy.pycdf.const.CDF_INT8.value):
-        return 9223372036854775807
-    elif(type == spacepy.pycdf.const.CDF_REAL4.value) or \
-        (type == spacepy.pycdf.const.CDF_FLOAT.value): # from https://www.ias.ac.in/article/fulltext/reso/021/01/0011-0030
-        return 3.4E38
-    elif(type == spacepy.pycdf.const.CDF_REAL8.value) or \
-        (type == spacepy.pycdf.const.CDF_DOUBLE.value) or \
-        (type == spacepy.pycdf.const.CDF_EPOCH.value):
-        return 1E4932
-    elif(type == spacepy.pycdf.const.CDF_TIME_TT2000.value):
-        return 9223372036854775807
-    else:
-        raise ValueError('Unknown data type: {}'.format(type))
 
-    
-def get_min(type): 
+def get_min(cdftype):
     """Find minimum possible value based on datatype.
 
-    :param int type: Type number
+    :param int cdftype: CDF type number from :mod:`~spacepy.pycdf.const`
     :return: Minimum valid number
     :rtype: int
     """
+    try:
+        cdftype = cdftype.value
+    except:
+        pass
+    if cdftype == spacepy.pycdf.const.CDF_EPOCH.value:
+        return spacepy.pycdf.lib.datetime_to_epoch(
+            datetime.datetime(1, 1, 1))
+    elif cdftype == spacepy.pycdf.const.CDF_EPOCH16.value:
+        return spacepy.pycdf.lib.datetime_to_epoch16(
+            datetime.datetime(1, 1, 1))
+    elif cdftype == spacepy.pycdf.const.CDF_TIME_TT2000.value:
+            numpy.iinfo(numpy.int64).min + 2 #2ns is magic, but it works.
+    return _dtype_info(cdftype).min
 
-    if(type == spacepy.pycdf.const.CDF_BYTE.value) or \
-      (type == spacepy.pycdf.const.CDF_INT1.value) or \
-      (type == spacepy.pycdf.const.CDF_CHAR.value):
-        return -128
-    elif(type == spacepy.pycdf.const.CDF_UINT1.value) or \
-        (type == spacepy.pycdf.const.CDF_UINT2.value) or \
-        (type == spacepy.pycdf.const.CDF_UINT4.value) or \
-        (type == spacepy.pycdf.const.CDF_UCHAR.value):
-        return 0
-    elif(type == spacepy.pycdf.const.CDF_INT2.value):
-        return -32768
-    elif(type == spacepy.pycdf.const.CDF_INT4.value):
-        return -2147483648
-    elif(type == spacepy.pycdf.const.CDF_INT8.value):
-        return -9223372036854775808
-    elif(type == spacepy.pycdf.const.CDF_REAL4.value) or \
-        (type == spacepy.pycdf.const.CDF_FLOAT.value): # from https://www.ias.ac.in/article/fulltext/reso/021/01/0011-0030
-        return -3.4E38
-    elif(type == spacepy.pycdf.const.CDF_REAL8.value) or \
-        (type == spacepy.pycdf.const.CDF_DOUBLE.value) or \
-        (type == spacepy.pycdf.const.CDF_EPOCH.value):        
-        return -1E4932
-    elif(type == spacepy.pycdf.const.CDF_TIME_TT2000.value):
-        return -9223372036854775808
-    else:
-        raise ValueError('Unknown data type: {}'.format(type))    

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -46,12 +46,14 @@ import spacepy.pycdf.const
 
 
 class VariableChecks(object):
-    """Tests of a single variable
+    """ISTP compliance checks for a single variable.
 
-    All tests return a list of errors (empty if none). :meth:`all`
-    will check all tests and concatenate all errors. :meth:`all`
-    should be updated with the list of all tests so that
-    helper functions aren't called, subtests aren't called twice, etc.
+    Checks a variable's compliance with ISTP standards. This mostly
+    performs checks that are not currently performed by the `ISTP
+    skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_.  All
+    tests return a list, one error string for every noncompliance
+    found (empty list if compliant). :meth:`all` will perform all
+    tests and concatenate all errors.
 
     .. autosummary::
 
@@ -72,11 +74,13 @@ class VariableChecks(object):
     .. automethod:: validplottype
     .. automethod:: validrange
     .. automethod:: validscale
+
     """
+    #When adding new tests, add to list above, and the list in all()
 
     @classmethod
     def all(cls, v):
-        """Call all test functions in this class
+        """Perform all variable tests
 
         Parameters
         ----------
@@ -86,8 +90,18 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
+
+        Examples
+        --------
+        >>> import spacepy.pycdf
+        >>> import spacepy.pycdf.istp
+        >>> f = spacepy.pycdf.CDF('foo.cdf', create=True)
+        >>> v = f.new('Var', data=[1, 2, 3])
+        >>> spacepy.pycdf.istp.VariableChecks.all(v)
+        ['Var: no FIELDNAM attribute.']
         """
+        #Update this list when adding new test functions
         callme = (cls.depends, cls.depsize, cls.fieldnam, cls.recordcount,
                   cls.validrange, cls.validscale, cls.validplottype)
         errors = []
@@ -107,7 +121,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         return ['{} variable {} missing'.format(a, v.attrs[a])
                 for a in v.attrs
@@ -126,7 +140,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         rv = int(v.rv()) #RV is a leading dimension
         errs = []
@@ -205,7 +219,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         if not v.rv() or not 'DEPEND_0' in v.attrs:
             return []
@@ -229,7 +243,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
@@ -284,7 +298,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
@@ -320,7 +334,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         time_st = 'time_series'
         spec_st = 'spectrogram'
@@ -346,7 +360,7 @@ class VariableChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         errs = []
         vname = v.name()
@@ -359,12 +373,14 @@ class VariableChecks(object):
 
 
 class FileChecks(object):
-    """Tests of a file
+    """ISTP compliance checks for a CDF file.
 
-    All tests return a list of errors (empty if none). :meth:`all`
-    will check all tests and concatenate all errors. :meth:`all`
-    should be updated with the list of all tests so that
-    helper functions aren't called, subtests aren't called twice, etc.
+    Checks a file's compliance with ISTP standards. This mostly
+    performs checks that are not currently performed by the `ISTP
+    skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_.  All
+    tests return a list, one error string for every noncompliance
+    found (empty list if compliant). :meth:`all` will perform all
+    tests and concatenate all errors.
 
     .. autosummary::
 
@@ -377,11 +393,16 @@ class FileChecks(object):
     .. automethod:: filename
     .. automethod:: time_monoton
     .. automethod:: times
+
     """
+    #When adding new tests, add to list above, and the list in all()
 
     @classmethod
     def all(cls, f):
-        """Call all test functions, AND all test functions on all variables
+        """Perform all variable and file-level tests
+
+        In addition to calling every test in this class, will also call
+        :meth:`VariableChecks.all` for every variable in the file.
 
         Parameters
         ----------
@@ -391,8 +412,21 @@ class FileChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
+
+        Examples
+        --------
+        >>> import spacepy.pycdf
+        >>> import spacepy.pycdf.istp
+        >>> f = spacepy.pycdf.CDF('foo.cdf', create=True)
+        >>> v = f.new('Var', data=[1, 2, 3])
+        >>> spacepy.pycdf.istp.FileChecks.all(f)
+        ['No Logical_source in global attrs',
+        'No Logical_file_id in global attrs',
+        'Cannot parse date from filename foo.cdf',
+        'Var: Var: no FIELDNAM attribute.']
         """
+        #Update this list when adding new test functions
         callme = (cls.filename, cls.time_monoton, cls.times,)
         errors = []
         for func in callme:
@@ -417,7 +451,7 @@ class FileChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         errs = []
         for a in ('Logical_source', 'Logical_file_id'):
@@ -450,7 +484,7 @@ class FileChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         errs = []
         for v in f:
@@ -480,7 +514,7 @@ class FileChecks(object):
         Returns
         -------
         list of str
-            All error messages
+            Description of each validation failure.
         """
         errs = []
         fname = os.path.basename(f.pathname)
@@ -507,12 +541,26 @@ class FileChecks(object):
 
 
 def fillval(v): 
-    """Automatically set ISTP-compliant FILLVAL on a variable
+    """Set ISTP-compliant FILLVAL on a variable
+
+    Sets a CDF variable's `FILLVAL
+    <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FILLVAL>`_
+    attribute to the value required by ISTP (based on variable type).
 
     Parameters
     ----------
     v : :class:`~spacepy.pycdf.Var`
-        Variable to update
+        CDF variable to update
+
+    Examples
+    --------
+    >>> import spacepy.pycdf
+    >>> import spacepy.pycdf.istp
+    >>> f = spacepy.pycdf.CDF('foo.cdf', create=True)
+    >>> v = f.new('Var', data=[1, 2, 3])
+    >>> spacepy.pycdf.istp.fillval(v)
+    >>> v.attrs['FILLVAL']
+    -128
     """
     #Fill value, indexed by the CDF type (numeric)
     fillvals = {}
@@ -544,7 +592,15 @@ def fillval(v):
 
 
 def format(v, use_scaleminmax=False, dryrun=False):
-    """Automatically set ISTP-compliant FORMAT on a variable
+    """Set ISTP-compliant FORMAT on a variable
+
+    Sets a CDF variable's `FORMAT
+    <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FORMAT>`_
+    attribute, which provides a Fortran-like format string that should
+    be useable for printing any valid value in the variable. Sets
+    according to the VALIDMIN/VALIDMAX attributes (or, optionally,
+    SCALEMIN/SCALEMAX) if present, otherwise uses the full range of
+    the type.
 
     Parameters
     ----------
@@ -556,6 +612,17 @@ def format(v, use_scaleminmax=False, dryrun=False):
     dryrun : bool, optional
         Print the decided format to stdout instead of modifying
         the CDF (for use in command-line debugging) (default False).
+
+    Examples
+    --------
+    >>> import spacepy.pycdf
+    >>> import spacepy.pycdf.istp
+    >>> f = spacepy.pycdf.CDF('foo.cdf', create=True)
+    >>> v = f.new('Var', data=[1, 2, 3])
+    >>> spacepy.pycdf.istp.format(v)
+    >>> v.attrs['FORMAT']
+    'I4'
+
     """
     if use_scaleminmax:
         minn = 'SCALEMIN'

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -519,6 +519,12 @@ class FileChecks(object):
         -------
         list of str
             Description of each validation failure.
+
+        Notes
+        -----
+        This function assumes daily files and should be extended based on the
+        File_naming_convention global attribute (which itself is another good
+        check to have.)
         """
         errs = []
         fname = os.path.basename(f.pathname)

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -24,7 +24,6 @@ This module supports that subset of CDFs.
 
     fillval
     format
-    get_minmax
 """
 
 import datetime
@@ -33,8 +32,9 @@ import os.path
 import re
 
 import numpy
-import spacepy.pycdf.const
 import spacepy.datamodel
+import spacepy.pycdf
+import spacepy.pycdf.const
 
 
 class VariableChecks(object):
@@ -181,7 +181,7 @@ class VariableChecks(object):
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
         data = raw_v[...]
-        minval, maxval = get_minmax(raw_v.type())
+        minval, maxval = spacepy.pycdf.lib.get_minmax(raw_v.type())
         if 'VALIDMIN' in raw_v.attrs:
             idx = data < raw_v.attrs['VALIDMIN']
             if ('FILLVAL' in raw_v.attrs) and (idx.size != 0):
@@ -229,7 +229,7 @@ class VariableChecks(object):
         """
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
-        minval, maxval = get_minmax(raw_v.type())
+        minval, maxval = spacepy.pycdf.lib.get_minmax(raw_v.type())
         data = raw_v[...]
         if 'SCALEMIN' in raw_v.attrs:
             if (raw_v.attrs['SCALEMIN'] < minval) or \
@@ -568,42 +568,3 @@ def format(v, use_scaleminmax=False, dryrun=False):
         v.attrs.new('FORMAT', data=fmt, type=spacepy.pycdf.const.CDF_CHAR)
 
 
-def get_minmax(cdftype):
-    """Find minimum, maximum possible value based on CDF type.
-
-    This returns the "raw" (unparsed) value.
-
-    :param int cdftype: CDF type number from :mod:`~spacepy.pycdf.const`
-    :return: minimum, maximum value supported by type
-    :rtype: tuple
-    """
-    try:
-        cdftype = cdftype.value
-    except:
-        pass
-    if cdftype == spacepy.pycdf.const.CDF_EPOCH.value:
-        return (
-            spacepy.pycdf.lib.datetime_to_epoch(
-                datetime.datetime(1, 1, 1)),
-            #Can get asymptotically closer, but why bother
-            spacepy.pycdf.lib.datetime_to_epoch(
-                datetime.datetime(9999, 12, 31, 23, 59, 59)))
-    elif cdftype == spacepy.pycdf.const.CDF_EPOCH16.value:
-        return (
-            spacepy.pycdf.lib.datetime_to_epoch16(
-                datetime.datetime(1, 1, 1)),
-            spacepy.pycdf.lib.datetime_to_epoch16(
-                datetime.datetime(9999, 12, 31, 23, 59, 59)))
-    elif cdftype == spacepy.pycdf.const.CDF_TIME_TT2000.value:
-        inf = numpy.iinfo(numpy.int64)
-        return (inf.min, inf.max)
-    dtype = spacepy.pycdf.lib.numpytypedict.get(cdftype, None)
-    if dtype is None:
-        raise ValueError('Unknown data type: {}'.format(cdftype))
-    if numpy.issubdtype(dtype, numpy.integer):
-        inf = numpy.iinfo(dtype)
-    elif numpy.issubdtype(dtype, numpy.float):
-        inf = numpy.finfo(dtype)
-    else:
-        raise ValueError('Unknown data type: {}'.format(cdftype))
-    return (inf.min, inf.max)

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -280,7 +280,7 @@ class VariableChecks(object):
                     attrval = numpy.reshape(attrval, (1, -1))
             if numpy.any((attrval < minval)) \
                or numpy.any((attrval > maxval)):
-                errs.append('{} ({}) outside data range ({},{}) for {}.'.format(
+                errs.append('{} ({}) outside data range ({},{}).'.format(
                     which, attrval, minval, maxval, v.name()))
             if not len(data): #nothing to compare
                 continue
@@ -322,16 +322,12 @@ class VariableChecks(object):
             Description of each validation failure.
         """
         errs = []
-        #This makes datetime comparisons a lot easier
-        raw_v = v.cdf_file.raw_var(v.name())
         vshape = v.shape
-        minval, maxval = spacepy.pycdf.lib.get_minmax(raw_v.type())
+        minval, maxval = spacepy.pycdf.lib.get_minmax(v.type())
         for which in ('SCALEMIN', 'SCALEMAX'):
             if not which in v.attrs:
                 continue
             attrval = v.attrs[which]
-            #This is all c/p from validrange, should pull out
-            #but they're slightly different contexts.
             multidim = bool(numpy.shape(attrval)) #multi-dimensional
             if multidim: #Compare shapes, require only 1D var
                 #Match attribute dim to first non-record var dim

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python
+
+"""Support for ISTP-compliant CDFs
+
+.. rubric:: Classes
+
+.. autosummary::
+    :toctree: autosummary  
+    :template: clean_class.rst
+
+    FileChecks
+    VariableChecks
+
+.. rubric:: Functions
+
+.. autosummary::
+    :toctree: autosummary  
+
+    fillval
+    format
+    get_max
+    get_min
+
+"""
+
+import datetime
+import math
+import os.path
+import re
+import sys
+
+import numpy
+import spacepy.pycdf.const
+import spacepy.datamodel
+
+
+class VariableChecks(object):
+    """Tests of a single variable
+
+    All tests return a list of errors (empty if none). :meth:`all`
+    will check all tests and concatenate all errors. :meth:`all`
+    should be updated with the list of all tests so that
+    helper functions aren't called, subtests aren't called twice, etc.
+    """
+
+    @classmethod
+    def all(cls, v):
+        """Call all test functions in this class
+
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        callme = (cls.depends, cls.depsize, cls.fieldnam, cls.recordcount,
+                  cls.validrange, cls.validscale, cls.validplottype)
+        errors = []
+        for f in callme:
+            errors.extend(f(v))
+        return errors
+
+    @classmethod
+    def depends(cls, v):
+        """Checks that DEPEND and LABL_PTR variables actually exist
+
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        return ['{} variable {} missing'.format(a, v.attrs[a])
+                for a in v.attrs
+                if a.startswith(('DEPEND_', 'LABL_PTR_')) and
+                not v.attrs[a] in v.cdf_file]
+
+    @classmethod
+    def depsize(cls, v):
+        """Checks that DEPEND has same shape as that dim
+
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        rv = int(v.rv()) #RV is a leading dimension
+        errs = []
+        # Check that don't have invalid DEPEND_1
+        if v.shape == (0,):
+            if 'DEPEND_1' in v.attrs or 'DEPEND_2' in v.attrs:
+                errs.append('Do not expect DEPEND_1 or DEPEND_2 in 1 dimensional variable.')
+        for i in range(rv, len(v.shape)): #This is index on shape (of var)
+            depidx = i + 1 - rv #This is x in  DEPEND_x
+            target = v.shape[i]
+            if not 'DEPEND_{}'.format(depidx) in v.attrs:
+                continue
+            d = v.attrs['DEPEND_{}'.format(depidx)]
+            if d in v.cdf_file:
+                dv = v.cdf_file[d]
+            else:
+                continue #this is a different error
+            #We hope the only weirdness is whether the dependency
+            #is constant, or dependent on record. If it's dependent
+            #on another dependency, this gets really weird really fast
+            # If the dependency is dependent, remove the lower level
+            # dependency size from consideration
+            # eg. if counts [80,48], depends on energy [80,48],
+            # depends on look [80], remove 80 from the view of energy
+            # so that we accurately check 48==48.
+            # NB: This assumes max of two layers of dependency
+            if 'DEPEND_2' in dv.attrs:
+                errs.append('Do not expect three layers of dependency.')
+                continue
+            elif 'DEPEND_1' in dv.attrs:
+                dd = dv.attrs['DEPEND_1']
+                if dd in v.cdf_file:
+                    ddv = v.cdf_file[dd]
+                else:
+                    continue #this is a different error
+                actual = list(dv.shape)
+                for ii in actual:
+                    if ii in ddv.shape:
+                        actual.remove(ii)
+                if 'DEPEND_0' in dv.attrs:
+                    # record varying
+                    dd = dv.attrs['DEPEND_0']
+                    if dd[:5] != 'Epoch':
+                        errs.append('Expect DEPEND_0 to be Epoch')
+                        continue
+                    if dd in v.cdf_file:
+                        ddv = v.cdf_file[dd]
+                    else:
+                        continue #this is a different error
+                    for ii in actual:
+                        if ii in ddv.shape:
+                            actual.remove(ii)
+                    
+                if len(actual) != 1:
+                    errs.append('More complicated double dependency than taken into account.')
+                    continue
+                else:
+                    actual = actual[0]
+            else:
+                actual = dv.shape[int(dv.rv())]
+            if target != actual:
+                errs.append('Dim {} sized {} but DEPEND_{} {} sized {}'.format(
+                    i, target, depidx, d, actual))
+
+        return errs
+
+    @classmethod
+    def recordcount(cls, v):
+        """Check that the DEPEND_0 has same record count as variable
+
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        if not v.rv() or not 'DEPEND_0' in v.attrs:
+            return []
+        dep0 = v.attrs['DEPEND_0']
+        if not dep0 in v.cdf_file: #This is a DIFFERENT error
+            return []
+        if len(v) != len(v.cdf_file[dep0]):
+            return ['{} records; DEPEND_0 {} has {}'.format(
+                len(v), dep0, len(v.cdf_file[dep0]))]
+        return []
+
+    @classmethod
+    def validrange(cls, v):
+        """Check that all values are within VALIDMIN/VALIDMAX, or FILLVAL
+
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        errs = []
+        raw_v = v.cdf_file.raw_var(v.name())
+        data = raw_v[...]
+        if 'VALIDMIN' in raw_v.attrs:
+            idx = data < raw_v.attrs['VALIDMIN']
+            if ('FILLVAL' in raw_v.attrs) and (idx.size != 0):
+                is_fill = numpy.isclose(data, raw_v.attrs['FILLVAL'])
+                idx = numpy.logical_and(idx, numpy.logical_not(is_fill))
+            if idx.any():
+                errs.append('Value {} at index {} under VALIDMIN {}'.format(
+                    ', '.join(str(d) for d in v[...][idx]),
+                    ', '.join(str(d) for d in numpy.nonzero(idx)[0]),
+                    v.attrs['VALIDMIN']))
+            if (raw_v.attrs['VALIDMIN'] < get_min(raw_v.type())) or \
+               (raw_v.attrs['VALIDMIN'] > get_max(raw_v.type())):
+                errs.append('VALIDMIN ({}) outside data range ({},{}) for {}.'.format(
+                    raw_v.attrs['VALIDMIN'], get_min(raw_v.type()), get_max(raw_v.type()),
+                    raw_v.name()))
+        if 'VALIDMAX' in raw_v.attrs:
+            idx = data > raw_v.attrs['VALIDMAX']
+            if 'FILLVAL' in raw_v.attrs:
+                is_fill = numpy.isclose(data, raw_v.attrs['FILLVAL'])
+                idx = numpy.logical_and(idx, numpy.logical_not(is_fill))
+            if idx.any():
+                errs.append('Value {} at index {} over VALIDMAX {}'.format(
+                    ', '.join(str(d) for d in v[...][idx]),
+                    ', '.join(str(d) for d in numpy.nonzero(idx)[0]),
+                    v.attrs['VALIDMAX']))
+            if (raw_v.attrs['VALIDMIN'] < get_min(raw_v.type())) or \
+               (raw_v.attrs['VALIDMAX'] > get_max(raw_v.type())):
+                errs.append('VALIDMAX ({}) outside data range ({},{}) for {}.'.format(
+                    raw_v.attrs['VALIDMAX'], get_min(raw_v.type()), get_max(raw_v.type()),
+                    raw_v.name()))
+        if ('VALIDMIN' in raw_v.attrs) and ('VALIDMAX' in raw_v.attrs):
+            if raw_v.attrs['VALIDMIN'] > raw_v.attrs['VALIDMAX']:
+                errs.append('VALIDMIM > VALIDMAX for {}'.format(v.name()))
+        return errs
+
+    
+    @classmethod
+    def validscale(cls, v):
+        """Check that SCALEMIN<=SCALEMAX, and neither goes out 
+        of range for CDF datatype.
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        errs = []
+        raw_v = v.cdf_file.raw_var(v.name())
+        data = raw_v[...]
+        if 'SCALEMIN' in raw_v.attrs:
+            if (raw_v.attrs['SCALEMIN'] < get_min(raw_v.type())) or \
+               (raw_v.attrs['SCALEMIN'] > get_max(raw_v.type())):
+                errs.append('SCALEMIN ({}) outside data range ({},{}) for {}.'.format(
+                    raw_v.attrs['SCALEMIN'], get_min(raw_v.type()), get_max(raw_v.type()),
+                    raw_v.name()))
+        if 'SCALEMAX' in raw_v.attrs:
+            if (raw_v.attrs['SCALEMAX'] < get_min(raw_v.type())) or \
+               (raw_v.attrs['SCALEMAX'] > get_max(raw_v.type())):
+                errs.append('SCALEMAX ({}) outside data range ({},{}) for {}.'.format(
+                    raw_v.attrs['SCALEMAX'], get_min(raw_v.type()), get_max(raw_v.type()),
+                    raw_v.name()))
+        if ('SCALEMIN' in raw_v.attrs) and ('SCALEMAX' in raw_v.attrs):
+            if raw_v.attrs['SCALEMIN'] > raw_v.attrs['SCALEMAX']:
+                errs.append('SCALEMIN > SCALEMAX for {}'.format(v.name()))
+        return errs
+
+
+    @classmethod
+    def validplottype(cls, v):
+        """Check that plottype matches dimensions.
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        if sys.version_info >= (3,0):
+            time_st = b'time_series'
+            spec_st = b'spectrogram'
+        else:
+            time_st = 'time_series'
+            spec_st = 'spectrogram'
+        errs = []
+        raw_v = v.cdf_file.raw_var(v.name())
+        data = raw_v[...]
+        if 'DISPLAY_TYPE' in raw_v.attrs:
+            if (len(raw_v.shape) == 1) and (raw_v.attrs['DISPLAY_TYPE'] != time_st):
+                errs.append('{}: 1 dim variable with {} display type.'.format(
+                    raw_v.name(), raw_v.attrs['DISPLAY_TYPE']))
+            elif (len(raw_v.shape) > 1) and (raw_v.attrs['DISPLAY_TYPE'] != spec_st):
+                errs.append('{}: multi dim variable with {} display type.'.format(
+                    raw_v.name(), raw_v.attrs['DISPLAY_TYPE']))
+        return errs
+
+    @classmethod
+    def fieldnam(cls, v):
+        """Check that FIELDNAM attribute matches variable name.
+
+        :param v: Variable to check
+        :type v: :class:`~spacepy.pycdf.Var`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        errs = []
+        vname = v.name()
+        if 'FIELDNAM' not in v.attrs:
+            errs.append('{}: no FIELDNAM attribute.'.format(vname))
+        elif v.attrs['FIELDNAM'] != vname:
+            errs.append('{}: FIELDNAM attribute {} does not match var name.'
+                        .format(vname, v.attrs['FIELDNAM']))
+        return errs
+
+
+class FileChecks(object):
+    """Tests of a file
+
+    All tests return a list of errors (empty if none). :meth:`all`
+    will check all tests and concatenate all errors. :meth:`all`
+    should be updated with the list of all tests so that
+    helper functions aren't called, subtests aren't called twice, etc.
+    """
+
+    @classmethod
+    def all(cls, f):
+        """Call all test functions, AND all test functions on all variables
+
+        :param f: File to check
+        :type f: :class:`~spacepy.pycdf.CDF`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        callme = (cls.filename, cls.time_monoton, cls.times,)
+        errors = []
+        for func in callme:
+            errors.extend(func(f))
+        for v in f:
+            errors.extend(('{}: {}'.format(v, e)
+                           for e in VariableChecks.all(f[v])))
+        return errors
+                
+    @classmethod
+    def filename(cls, f):
+        """Compare filename to global attributes
+
+        Check that the logical_file_id matches the actual filename,
+        and logical_source also matches.
+
+        :param f: File to check
+        :type f: :class:`~spacepy.pycdf.CDF`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        errs = []
+        for a in ('Logical_source', 'Logical_file_id'):
+            if not a in f.attrs:
+                errs.append('No {} in global attrs'.format(a))
+        if errs:
+            return errs
+        fname = os.path.basename(f.pathname)
+        if not bytes is str:
+            fname = fname.decode('ascii')
+        if not fname.startswith(f.attrs['Logical_source'][0]):
+            errs.append("Logical_source {} doesn't match filename {}".format(
+                f.attrs['Logical_source'][0], fname))
+        if fname[:-4] != f.attrs['Logical_file_id'][0]:
+            errs.append("Logical_file_id {} doesn't match filename {}".format(
+                f.attrs['Logical_file_id'][0], fname))
+        return errs
+
+    @classmethod
+    def time_monoton(cls, f):
+        """Checks that times are monotonic
+
+        Check that all Epoch variables are monotonically increasing.
+
+        :param f: File to check
+        :type f: :class:`~spacepy.pycdf.CDF`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        errs = []
+        for v in f:
+            if not f[v].type() in (spacepy.pycdf.const.CDF_EPOCH.value,
+                                   spacepy.pycdf.const.CDF_EPOCH16.value,
+                                   spacepy.pycdf.const.CDF_TIME_TT2000.value):
+                continue
+            data = f[v][...]
+            idx = numpy.where(numpy.diff(data) < datetime.timedelta(0))[0]
+            if not any(idx):
+                continue
+            errs.append('{}: nonmonotonic time at record {}'.format(
+                v, ', '.join((str(i) for i in (idx + 1)))))
+        return errs
+
+    @classmethod
+    def times(cls, f):
+        """Compare filename to times
+
+        Check that all Epoch variables only contain times matching filename
+
+        :param f: File to check
+        :type f: :class:`~spacepy.pycdf.CDF`
+        :returns: All error messages
+        :rtype: list of str
+        """
+        errs = []
+        fname = os.path.basename(f.pathname)
+        if not bytes is str:
+            fname = fname.decode('ascii')
+        m = re.search('\d{8}', fname)
+        if not m:
+            return ['Cannot parse date from filename {}'.format(fname)]
+        datestr = m.group(0)
+        for v in f:
+            if f[v].type() in (spacepy.pycdf.const.CDF_EPOCH.value,
+                               spacepy.pycdf.const.CDF_EPOCH16.value,
+                               spacepy.pycdf.const.CDF_TIME_TT2000.value):
+                datestrs = list(set((d.strftime('%Y%m%d') for d in f[v][...])))
+                if len(datestrs) == 0:
+                    continue
+                elif len(datestrs) > 1:
+                    errs.append('{}: multiple days {}'.format(
+                        v, ', '.join(sorted(datestrs))))
+                elif datestrs[0] != datestr:
+                    errs.append('{}: date {} doesn\'t match file {}'.format(
+                        v, datestrs[0], fname))
+        return errs
+
+
+def fillval(v): 
+    """Automatically set ISTP-compliant FILLVAL on a variable
+
+    :param v: Variable to update
+    :type v: :class:`~spacepy.pycdf.Var`
+    """
+    #Fill value, indexed by the CDF type (numeric)
+    fillvals = {}
+    #Integers
+    for i in (1, 2, 4, 8):
+        fillvals[getattr(spacepy.pycdf.const, 'CDF_INT{}'.format(i)).value] = \
+            - 2 ** (8*i - 1)
+        if i == 8:
+            continue
+        fillvals[getattr(spacepy.pycdf.const, 'CDF_UINT{}'.format(i)).value] = \
+            2 ** (8*i) - 1
+    fillvals[spacepy.pycdf.const.CDF_EPOCH16.value] = (-1e31, -1e31)
+    fillvals[spacepy.pycdf.const.CDF_REAL8.value] = -1e31
+    fillvals[spacepy.pycdf.const.CDF_REAL4.value] = -1e31
+    fillvals[spacepy.pycdf.const.CDF_CHAR.value] = ' '
+    fillvals[spacepy.pycdf.const.CDF_UCHAR.value] = ' '
+    #Equivalent pairs
+    for cdf_t, equiv in (
+            (spacepy.pycdf.const.CDF_TIME_TT2000, spacepy.pycdf.const.CDF_INT8),
+            (spacepy.pycdf.const.CDF_EPOCH, spacepy.pycdf.const.CDF_REAL8),
+            (spacepy.pycdf.const.CDF_BYTE, spacepy.pycdf.const.CDF_INT1),
+            (spacepy.pycdf.const.CDF_FLOAT, spacepy.pycdf.const.CDF_REAL4),
+            (spacepy.pycdf.const.CDF_DOUBLE, spacepy.pycdf.const.CDF_REAL8),
+    ):
+        fillvals[cdf_t.value] = fillvals[equiv.value]
+    if 'FILLVAL' in v.attrs:
+        del v.attrs['FILLVAL']
+    v.attrs.new('FILLVAL', data=fillvals[v.type()], type=v.type())
+
+
+def format(v, use_scaleminmax=False, dryrun=False):
+    """Automatically set ISTP-compliant FORMAT on a variable
+
+    :param v: Variable to update
+    :type v: :class:`~spacepy.pycdf.Var`
+    :param bool use_scaleminmax: Use SCALEMIN/MAX instead of VALIDMIN/MAX.
+                                 Note: istpchecks may complain about result.
+    :param bool dryrun: Print the decided format to stdout instead of modifying
+                        the CDF.  (For use in command-line debugging.)
+    """
+    if use_scaleminmax:
+        minn = 'SCALEMIN'
+        maxx = 'SCALEMAX'
+    else:
+        minn = 'VALIDMIN'
+        maxx = 'VALIDMAX'
+    cdftype = v.type()
+    if cdftype in (spacepy.pycdf.const.CDF_INT1.value,
+                   spacepy.pycdf.const.CDF_INT2.value,
+                   spacepy.pycdf.const.CDF_INT4.value,
+                   spacepy.pycdf.const.CDF_INT8.value,
+                   spacepy.pycdf.const.CDF_UINT1.value,
+                   spacepy.pycdf.const.CDF_UINT2.value,
+                   spacepy.pycdf.const.CDF_UINT4.value,
+                   spacepy.pycdf.const.CDF_BYTE.value):
+        if minn in v.attrs: #Just use validmin or scalemin
+            minval = v.attrs[minn]
+        elif cdftype in (spacepy.pycdf.const.CDF_UINT1.value,
+                         spacepy.pycdf.const.CDF_UINT2.value,
+                         spacepy.pycdf.const.CDF_UINT4.value): #unsigned, easy
+            minval = 0
+        elif cdftype == spacepy.pycdf.const.CDF_BYTE.value:
+            minval = - 2 ** 7
+        else: #Signed, harder
+            size = next((i for i in (1, 2, 4, 8) if getattr(
+                spacepy.pycdf.const, 'CDF_INT{}'.format(i)).value == cdftype))
+            minval = - 2 ** (8*size  - 1)
+        if maxx in v.attrs: #Just use max
+            maxval = v.attrs[maxx]
+        elif cdftype == spacepy.pycdf.const.CDF_BYTE.value:
+            maxval = 2 ** 7 - 1
+        else:
+            size = next((8 * i for i in (1, 2, 4) if getattr(
+                spacepy.pycdf.const, 'CDF_UINT{}'.format(i)).value == cdftype),
+                        None)
+            if size is None:
+                size = next((8 * i for i in (1, 2, 4, 8) if getattr(
+                    spacepy.pycdf.const, 'CDF_INT{}'.format(i)).value ==
+                             cdftype)) - 1
+            maxval = 2 ** size - 1
+        #Two tricks:
+        #-Truncate and add 1 rather than ceil so get
+        #powers of 10 (log10(10) = 1 but needs two digits)
+        #-Make sure not taking log of zero
+        if minval < 0: #Need an extra space for the negative sign
+            fmt = 'I{}'.format(int(math.log10(max(
+                abs(maxval), abs(minval), 1))) + 2)
+        else:
+            fmt = 'I{}'.format(int(
+                math.log10(maxval) if maxval != 0 else 1) + 1)
+    elif cdftype == spacepy.pycdf.const.CDF_TIME_TT2000.value:
+        fmt = 'A{}'.format(len('9999-12-31T23:59:59.999999999'))
+    elif cdftype == spacepy.pycdf.const.CDF_EPOCH16.value:
+        fmt = 'A{}'.format(len('31-Dec-9999 23:59:59.999.999.000.000'))
+    elif cdftype == spacepy.pycdf.const.CDF_EPOCH.value:
+        fmt = 'A{}'.format(len('31-Dec-9999 23:59:59.999'))
+    elif cdftype in (spacepy.pycdf.const.CDF_REAL8.value,
+                     spacepy.pycdf.const.CDF_REAL4.value,
+                     spacepy.pycdf.const.CDF_FLOAT.value,
+                     spacepy.pycdf.const.CDF_DOUBLE.value):
+        # Prioritize SCALEMIN/MAX to find the number of decimals to include
+        if 'SCALEMIN' in v.attrs and 'SCALEMAX' in v.attrs:
+            range = v.attrs['SCALEMAX'] - v.attrs['SCALEMIN']
+        # If not, use VALIDMIN/MAX
+        elif 'VALIDMIN' in v.attrs and 'VALIDMAX' in v.attrs:
+            range = v.attrs['VALIDMAX'] - v.attrs['VALIDMIN']
+        # If not, just use nothing.
+        else:
+            range = None
+        # Find how many spaces we need for the 'integer' part of the number
+        # (Use maxx-minn for this...effectively uses VALIDMIN/MAX for most
+        # cases.)
+        if range and (minn in v.attrs and maxx in v.attrs):
+            if len(str(int(v.attrs[maxx]))) >=\
+               len(str(int(v.attrs[minn]))):
+                ln = str(int(v.attrs[maxx]))
+            else:
+                ln = str(int(v.attrs[minn]))
+        if range and ln and range < 0: # Cover all our bases:
+            # raise ValueError('Range ({} - {}) cannot be negative:'
+                # '\nVarname: {}\nRange: {}'.format(maxx, minn, v, range))
+            ### Instead of throwing an error, just use None
+            # There are old cases that for some reason have negative ranges, so
+            # this is really more of a compatibility choice than a good
+            # decision.
+            range = None
+        # All of the lengths below (the +4, +3, +2, etc...) should be EXACTLY
+        # enough.  Consider adding 1, (4+1=5, 3+1=4, etc...) to possibly make
+        # this easier.
+        # elif range and ln and range <= 11: # If range <= 11, we want 2 decimal places:
+        if range and ln and range <= 11: # If range <= 11, we want 2 decimal places:
+            # Need extra for '.', and 3 decimal places (4 extra)
+            fmt = 'F{}.3'.format(len([i for i in ln]) + 4)
+        elif range and ln and 11 < range <= 101:
+            # Need extra for '.' (1 extra)
+            fmt = 'F{}.2'.format(len([i for i in ln]) + 3)
+        elif range and ln and 101 < range <= 1000:
+            # Need extra for '.' (1 extra)
+            fmt = 'F{}.1'.format(len([i for i in ln]) + 2)
+        else:
+            # No range, must not be populated, copied from REAL4/8(s) above
+            # OR we don't care because it's a 'big' number:
+            fmt = 'G10.2E3'
+    elif cdftype in (spacepy.pycdf.const.CDF_CHAR.value,
+                     spacepy.pycdf.const.CDF_UCHAR.value):
+        #This is a bit weird but pycdf consider nelems private. Should change.
+        fmt = 'A{}'.format(v._nelems())
+    else:
+        raise ValueError("Couldn't find FORMAT for {} of type {}".format(
+            v.name(),
+            spacepy.pycdf.lib.cdftypenames.get(cdftype, 'UNKNOWN')))
+    if dryrun:
+        print(fmt)
+    else:
+        if 'FORMAT' in v.attrs:
+            del v.attrs['FORMAT']
+        v.attrs.new('FORMAT', data=fmt, type=spacepy.pycdf.const.CDF_CHAR)
+
+
+def get_max(type): 
+    """Find maximum possible value based on datatype.
+
+    :param int type: Type number
+    :return: Maximum valid number
+    :rtype: int
+    """
+
+    if(type == spacepy.pycdf.const.CDF_BYTE.value) or \
+      (type == spacepy.pycdf.const.CDF_INT1.value) or \
+      (type == spacepy.pycdf.const.CDF_CHAR.value):
+        return 127
+    elif(type == spacepy.pycdf.const.CDF_UINT1.value) or \
+        (type == spacepy.pycdf.const.CDF_UCHAR.value):
+        return 255
+    elif(type == spacepy.pycdf.const.CDF_INT2.value):
+        return 32767
+    elif(type == spacepy.pycdf.const.CDF_UINT2.value):
+        return 65535
+    elif(type == spacepy.pycdf.const.CDF_INT4.value):
+        return 2147483647
+    elif(type == spacepy.pycdf.const.CDF_UINT4.value):
+        return 4294967295
+    elif(type == spacepy.pycdf.const.CDF_INT8.value):
+        return 9223372036854775807
+    elif(type == spacepy.pycdf.const.CDF_REAL4.value) or \
+        (type == spacepy.pycdf.const.CDF_FLOAT.value): # from https://www.ias.ac.in/article/fulltext/reso/021/01/0011-0030
+        return 3.4E38
+    elif(type == spacepy.pycdf.const.CDF_REAL8.value) or \
+        (type == spacepy.pycdf.const.CDF_DOUBLE.value) or \
+        (type == spacepy.pycdf.const.CDF_EPOCH.value):
+        return 1E4932
+    elif(type == spacepy.pycdf.const.CDF_TIME_TT2000.value):
+        return 9223372036854775807
+    else:
+        raise ValueError('Unknown data type: {}'.format(type))
+
+    
+def get_min(type): 
+    """Find minimum possible value based on datatype.
+
+    :param int type: Type number
+    :return: Minimum valid number
+    :rtype: int
+    """
+
+    if(type == spacepy.pycdf.const.CDF_BYTE.value) or \
+      (type == spacepy.pycdf.const.CDF_INT1.value) or \
+      (type == spacepy.pycdf.const.CDF_CHAR.value):
+        return -128
+    elif(type == spacepy.pycdf.const.CDF_UINT1.value) or \
+        (type == spacepy.pycdf.const.CDF_UINT2.value) or \
+        (type == spacepy.pycdf.const.CDF_UINT4.value) or \
+        (type == spacepy.pycdf.const.CDF_UCHAR.value):
+        return 0
+    elif(type == spacepy.pycdf.const.CDF_INT2.value):
+        return -32768
+    elif(type == spacepy.pycdf.const.CDF_INT4.value):
+        return -2147483648
+    elif(type == spacepy.pycdf.const.CDF_INT8.value):
+        return -9223372036854775808
+    elif(type == spacepy.pycdf.const.CDF_REAL4.value) or \
+        (type == spacepy.pycdf.const.CDF_FLOAT.value): # from https://www.ias.ac.in/article/fulltext/reso/021/01/0011-0030
+        return -3.4E38
+    elif(type == spacepy.pycdf.const.CDF_REAL8.value) or \
+        (type == spacepy.pycdf.const.CDF_DOUBLE.value) or \
+        (type == spacepy.pycdf.const.CDF_EPOCH.value):        
+        return -1E4932
+    elif(type == spacepy.pycdf.const.CDF_TIME_TT2000.value):
+        return -9223372036854775808
+    else:
+        raise ValueError('Unknown data type: {}'.format(type))    

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -160,6 +160,10 @@ class VariableChecks(object):
                 dv = v.cdf_file[d]
             else:
                 continue #this is a different error
+            if dv.rv() != ('DEPEND_0' in dv.attrs):
+                errs.append('DEPEND_{} {} is RV but has no DEPEND_0.'
+                            .format(depidx, d))
+                continue
             #We hope the only weirdness is whether the dependency
             #is constant, or dependent on record. If it's dependent
             #on another dependency, this gets really weird really fast

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -62,7 +62,7 @@ class VariableChecks(object):
         depsize
         fieldnam
         recordcount
-        validplottype
+        validdisplaytype
         validrange
         validscale
         
@@ -71,7 +71,7 @@ class VariableChecks(object):
     .. automethod:: depsize
     .. automethod:: fieldnam
     .. automethod:: recordcount
-    .. automethod:: validplottype
+    .. automethod:: validdisplaytype
     .. automethod:: validrange
     .. automethod:: validscale
 
@@ -110,7 +110,7 @@ class VariableChecks(object):
         """
         #Update this list when adding new test functions
         callme = (cls.depends, cls.depsize, cls.fieldnam, cls.recordcount,
-                  cls.validrange, cls.validscale, cls.validplottype)
+                  cls.validrange, cls.validscale, cls.validdisplaytype)
         errors = []
         for f in callme:
             try:
@@ -127,6 +127,13 @@ class VariableChecks(object):
     def depends(cls, v):
         """Checks that DEPEND and LABL_PTR variables actually exist
 
+        Check that variables specified in the variable attributes for
+        `DEPEND
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DEPEND_0>`_
+        and `LABL_PTR
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#LABL_PTR_1>`_
+        exist in the CDF.
+
         Parameters
         ----------
         v : :class:`~spacepy.pycdf.Var`
@@ -136,6 +143,7 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         return ['{} variable {} missing'.format(a, v.attrs[a])
                 for a in v.attrs
@@ -146,6 +154,12 @@ class VariableChecks(object):
     def depsize(cls, v):
         """Checks that DEPEND has same shape as that dim
 
+        Compares the size of variables specified in the variable
+        attributes for `DEPEND
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DEPEND_0>`_
+        and compares to the size of the corresponding dimension in
+        this variable.
+
         Parameters
         ----------
         v : :class:`~spacepy.pycdf.Var`
@@ -155,6 +169,7 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         rv = int(v.rv()) #RV is a leading dimension
         errs = []
@@ -229,6 +244,11 @@ class VariableChecks(object):
     def recordcount(cls, v):
         """Check that the DEPEND_0 has same record count as variable
 
+        Checks the record count of the variable specified in the
+        variable attribute for `DEPEND_0
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DEPEND_0>`_
+        and compares to the record count for this variable.
+
         Parameters
         ----------
         v : :class:`~spacepy.pycdf.Var`
@@ -238,6 +258,7 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         if not v.rv() or not 'DEPEND_0' in v.attrs:
             return []
@@ -344,6 +365,12 @@ class VariableChecks(object):
     def validrange(cls, v):
         """Check that all values are within VALIDMIN/VALIDMAX, or FILLVAL
 
+        Compare all values of this variable to `VALIDMIN
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#VALIDMIN>`_
+        and ``VALIDMAX``; fails validation if any values are below
+        VALIDMIN or above ``VALIDMAX`` unless equal to `FILLVAL
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FILLVAL>`_.
+
         Parameters
         ----------
         v : :class:`~spacepy.pycdf.Var`
@@ -353,13 +380,18 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         return cls._validhelper(v)
 
     @classmethod
     def validscale(cls, v):
-        """Check that SCALEMIN<=SCALEMAX, and neither goes out 
-        of range for CDF datatype.
+        """Check SCALEMIN<=SCALEMAX, and both in range for CDF datatype.
+
+        Compares `SCALEMIN
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#SCALEMIN>`_
+        to ``SCALEMAX`` to make sure it isn't larger and both are
+        within range of the variable CDF datatype.
 
         Parameters
         ----------
@@ -370,12 +402,18 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         return cls._validhelper(v, False)
 
     @classmethod
-    def validplottype(cls, v):
+    def validdisplaytype(cls, v):
         """Check that plottype matches dimensions.
+
+        Check `DISPLAYTYPE
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#DISPLAY_TYPE>`_
+        of this variable and makes sure it is reasonable for the
+        variable dimensions.
 
         Parameters
         ----------
@@ -386,6 +424,7 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         time_st = 'time_series'
         spec_st = 'spectrogram'
@@ -403,6 +442,11 @@ class VariableChecks(object):
     def fieldnam(cls, v):
         """Check that FIELDNAM attribute matches variable name.
 
+        Compare `FIELDNAM
+        <https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#FIELDNAM>`_
+        attribute to the variable name; fail validation if they don't
+        match.
+
         Parameters
         ----------
         v : :class:`~spacepy.pycdf.Var`
@@ -412,6 +456,7 @@ class VariableChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         errs = []
         vname = v.name()
@@ -506,8 +551,11 @@ class FileChecks(object):
     def filename(cls, f):
         """Compare filename to global attributes
 
-        Check that the logical_file_id matches the actual filename,
-        and logical_source also matches.
+        Check global attribute `Logical_file_id
+        <https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Logical_file_id>`_
+        and `Logical_source
+        <https://spdf.gsfc.nasa.gov/istp_guide/gattributes.html#Logical_source>`_
+        for consistency with CDF filename.
 
         Parameters
         ----------
@@ -518,6 +566,7 @@ class FileChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         errs = []
         for a in ('Logical_source', 'Logical_file_id'):
@@ -540,7 +589,9 @@ class FileChecks(object):
     def time_monoton(cls, f):
         """Checks that times are monotonic
 
-        Check that all Epoch variables are monotonically increasing.
+        Check that all `Epoch
+        <https://spdf.gsfc.nasa.gov/istp_guide/variables.html#support_data_eg1>`_
+        variables are monotonically increasing.
 
         Parameters
         ----------
@@ -551,6 +602,7 @@ class FileChecks(object):
         -------
         list of str
             Description of each validation failure.
+
         """
         errs = []
         for v in f:
@@ -570,7 +622,9 @@ class FileChecks(object):
     def times(cls, f):
         """Compare filename to times
 
-        Check that all Epoch variables only contain times matching filename
+        Check that all `Epoch
+        <https://spdf.gsfc.nasa.gov/istp_guide/variables.html#support_data_eg1>`_
+        variables only contain times matching filename.
 
         Parameters
         ----------
@@ -587,6 +641,7 @@ class FileChecks(object):
         This function assumes daily files and should be extended based on the
         File_naming_convention global attribute (which itself is another good
         check to have.)
+
         """
         errs = []
         fname = os.path.basename(f.pathname)

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -77,6 +77,8 @@ class VariableChecks(object):
 
     """
     #When adding new tests, add to list above, and the list in all()
+    #Validation failures should be formatted as a sentence (initial cap,
+    #closing period) and NOT include the variable name.
 
     @classmethod
     def all(cls, v):
@@ -99,7 +101,7 @@ class VariableChecks(object):
         >>> f = spacepy.pycdf.CDF('foo.cdf', create=True)
         >>> v = f.new('Var', data=[1, 2, 3])
         >>> spacepy.pycdf.istp.VariableChecks.all(v)
-        ['Var: no FIELDNAM attribute.']
+        ['No FIELDNAM attribute.']
         """
         #Update this list when adding new test functions
         callme = (cls.depends, cls.depsize, cls.fieldnam, cls.recordcount,
@@ -184,7 +186,7 @@ class VariableChecks(object):
                     # record varying
                     dd = dv.attrs['DEPEND_0']
                     if dd[:5] != 'Epoch':
-                        errs.append('Expect DEPEND_0 to be Epoch')
+                        errs.append('Expect DEPEND_0 to be Epoch.')
                         continue
                     if dd in v.cdf_file:
                         ddv = v.cdf_file[dd]
@@ -202,7 +204,7 @@ class VariableChecks(object):
             else:
                 actual = dv.shape[int(dv.rv())]
             if target != actual:
-                errs.append('Dim {} sized {} but DEPEND_{} {} sized {}'.format(
+                errs.append('Dim {} sized {} but DEPEND_{} {} sized {}.'.format(
                     i, target, depidx, d, actual))
 
         return errs
@@ -227,7 +229,7 @@ class VariableChecks(object):
         if not dep0 in v.cdf_file: #This is a DIFFERENT error
             return []
         if len(v) != len(v.cdf_file[dep0]):
-            return ['{} records; DEPEND_0 {} has {}'.format(
+            return ['{} records; DEPEND_0 {} has {}.'.format(
                 len(v), dep0, len(v.cdf_file[dep0]))]
         return []
 
@@ -255,7 +257,7 @@ class VariableChecks(object):
                 is_fill = numpy.isclose(data, raw_v.attrs['FILLVAL'])
                 idx = numpy.logical_and(idx, numpy.logical_not(is_fill))
             if idx.any():
-                errs.append('Value {} at index {} under VALIDMIN {}'.format(
+                errs.append('Value {} at index {} under VALIDMIN {}.'.format(
                     ', '.join(str(d) for d in v[...][idx]),
                     ', '.join(str(d) for d in numpy.nonzero(idx)[0]),
                     v.attrs['VALIDMIN']))
@@ -270,7 +272,7 @@ class VariableChecks(object):
                 is_fill = numpy.isclose(data, raw_v.attrs['FILLVAL'])
                 idx = numpy.logical_and(idx, numpy.logical_not(is_fill))
             if idx.any():
-                errs.append('Value {} at index {} over VALIDMAX {}'.format(
+                errs.append('Value {} at index {} over VALIDMAX {}.'.format(
                     ', '.join(str(d) for d in v[...][idx]),
                     ', '.join(str(d) for d in numpy.nonzero(idx)[0]),
                     v.attrs['VALIDMAX']))
@@ -281,7 +283,7 @@ class VariableChecks(object):
                     raw_v.name()))
         if ('VALIDMIN' in raw_v.attrs) and ('VALIDMAX' in raw_v.attrs):
             if raw_v.attrs['VALIDMIN'] > raw_v.attrs['VALIDMAX']:
-                errs.append('VALIDMIM > VALIDMAX for {}'.format(v.name()))
+                errs.append('VALIDMIM > VALIDMAX for {}.'.format(v.name()))
         return errs
 
     
@@ -318,7 +320,7 @@ class VariableChecks(object):
                     raw_v.name()))
         if ('SCALEMIN' in raw_v.attrs) and ('SCALEMAX' in raw_v.attrs):
             if raw_v.attrs['SCALEMIN'] > raw_v.attrs['SCALEMAX']:
-                errs.append('SCALEMIN > SCALEMAX for {}'.format(v.name()))
+                errs.append('SCALEMIN > SCALEMAX for {}.'.format(v.name()))
         return errs
 
 
@@ -341,11 +343,11 @@ class VariableChecks(object):
         errs = []
         if 'DISPLAY_TYPE' in v.attrs:
             if (len(v.shape) == 1) and (v.attrs['DISPLAY_TYPE'] != time_st):
-                errs.append('{}: 1 dim variable with {} display type.'.format(
-                    v.name(), v.attrs['DISPLAY_TYPE']))
+                errs.append('1 dim variable with {} display type.'.format(
+                    v.attrs['DISPLAY_TYPE']))
             elif (len(v.shape) > 1) and (v.attrs['DISPLAY_TYPE'] != spec_st):
-                errs.append('{}: multi dim variable with {} display type.'.format(
-                    v.name(), v.attrs['DISPLAY_TYPE']))
+                errs.append('Multi dim variable with {} display type.'.format(
+                    v.attrs['DISPLAY_TYPE']))
         return errs
 
     @classmethod
@@ -365,10 +367,10 @@ class VariableChecks(object):
         errs = []
         vname = v.name()
         if 'FIELDNAM' not in v.attrs:
-            errs.append('{}: no FIELDNAM attribute.'.format(vname))
+            errs.append('No FIELDNAM attribute.')
         elif v.attrs['FIELDNAM'] != vname:
-            errs.append('{}: FIELDNAM attribute {} does not match var name.'
-                        .format(vname, v.attrs['FIELDNAM']))
+            errs.append('FIELDNAM attribute {} does not match var name.'
+                        .format(v.attrs['FIELDNAM']))
         return errs
 
 
@@ -396,6 +398,8 @@ class FileChecks(object):
 
     """
     #When adding new tests, add to list above, and the list in all()
+    #Validation failures should be formatted as a sentence (initial cap,
+    #closing period).
 
     @classmethod
     def all(cls, f):
@@ -424,7 +428,7 @@ class FileChecks(object):
         ['No Logical_source in global attrs',
         'No Logical_file_id in global attrs',
         'Cannot parse date from filename foo.cdf',
-        'Var: Var: no FIELDNAM attribute.']
+        'Var: No FIELDNAM attribute.']
         """
         #Update this list when adding new test functions
         callme = (cls.filename, cls.time_monoton, cls.times,)
@@ -456,17 +460,17 @@ class FileChecks(object):
         errs = []
         for a in ('Logical_source', 'Logical_file_id'):
             if not a in f.attrs:
-                errs.append('No {} in global attrs'.format(a))
+                errs.append('No {} in global attrs.'.format(a))
         if errs:
             return errs
         fname = os.path.basename(f.pathname)
         if not bytes is str:
             fname = fname.decode('ascii')
         if not fname.startswith(f.attrs['Logical_source'][0]):
-            errs.append("Logical_source {} doesn't match filename {}".format(
+            errs.append("Logical_source {} doesn't match filename {}.".format(
                 f.attrs['Logical_source'][0], fname))
         if fname[:-4] != f.attrs['Logical_file_id'][0]:
-            errs.append("Logical_file_id {} doesn't match filename {}".format(
+            errs.append("Logical_file_id {} doesn't match filename {}.".format(
                 f.attrs['Logical_file_id'][0], fname))
         return errs
 
@@ -496,7 +500,7 @@ class FileChecks(object):
             idx = numpy.where(numpy.diff(data) < datetime.timedelta(0))[0]
             if not any(idx):
                 continue
-            errs.append('{}: nonmonotonic time at record {}'.format(
+            errs.append('{}: Nonmonotonic time at record {}.'.format(
                 v, ', '.join((str(i) for i in (idx + 1)))))
         return errs
 
@@ -532,10 +536,10 @@ class FileChecks(object):
                 if len(datestrs) == 0:
                     continue
                 elif len(datestrs) > 1:
-                    errs.append('{}: multiple days {}'.format(
+                    errs.append('{}: multiple days {}.'.format(
                         v, ', '.join(sorted(datestrs))))
                 elif datestrs[0] != datestr:
-                    errs.append('{}: date {} doesn\'t match file {}'.format(
+                    errs.append('{}: date {} doesn\'t match file {}.'.format(
                         v, datestrs[0], fname))
         return errs
 

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -425,9 +425,9 @@ class FileChecks(object):
         >>> f = spacepy.pycdf.CDF('foo.cdf', create=True)
         >>> v = f.new('Var', data=[1, 2, 3])
         >>> spacepy.pycdf.istp.FileChecks.all(f)
-        ['No Logical_source in global attrs',
-        'No Logical_file_id in global attrs',
-        'Cannot parse date from filename foo.cdf',
+        ['No Logical_source in global attrs.',
+        'No Logical_file_id in global attrs.',
+        'Cannot parse date from filename foo.cdf.',
         'Var: No FIELDNAM attribute.']
         """
         #Update this list when adding new test functions

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -323,7 +323,6 @@ class VariableChecks(object):
         errs = []
         raw_v = v.cdf_file.raw_var(v.name())
         minval, maxval = spacepy.pycdf.lib.get_minmax(raw_v.type())
-        data = raw_v[...]
         for which in ('SCALEMIN', 'SCALEMAX'):
             if not which in v.attrs:
                 continue
@@ -334,13 +333,13 @@ class VariableChecks(object):
             if multidim: #Compare shapes, require only 1D var
                 #Match attribute dim to first non-record var dim
                 firstdim = int(v.rv())
-                if data.shape[firstdim] != numpy.shape(rawattrval)[0]:
+                if v.shape[firstdim] != numpy.shape(rawattrval)[0]:
                     errs.append(('{} element count {} does not match first data'
                                  ' dimension size {}.').format(
                                      which, numpy.shape(rawattrval)[0],
-                                     data.shape[firstdim]))
+                                     v.shape[firstdim]))
                     continue
-                if len(data.shape) != firstdim + 1: #only one non-record dim
+                if len(v.shape) != firstdim + 1: #only one non-record dim
                     errs.append('Multi-element {} only valid with 1D variable.'
                                 .format(which))
                     continue

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -2,6 +2,12 @@
 
 """Support for ISTP-compliant CDFs
 
+The `ISTP metadata standard  <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+specifies the interpretation of the attributes in a CDF to describe
+relationships between the variables and their physical interpretation.
+
+This module supports that subset of CDFs.
+
 .. rubric:: Classes
 
 .. autosummary::

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -268,27 +268,27 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(
             1, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
         errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
-        self.assertEqual('SCALEMIN > SCALEMAX for var1.', errs[0])
+        self.assertEqual('SCALEMIN > SCALEMAX.', errs[0])
         v.attrs['SCALEMIN'] = -200
         self.assertEqual(
             1, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
         errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
-        self.assertEqual('SCALEMIN (-200) outside data range (-128,127) for var1.', errs[0])
+        self.assertEqual('SCALEMIN (-200) outside data range (-128,127).', errs[0])
         v.attrs['SCALEMIN'] = 200
         self.assertEqual(
             2, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
         errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
-        self.assertEqual('SCALEMIN (200) outside data range (-128,127) for var1.', errs[0])
+        self.assertEqual('SCALEMIN (200) outside data range (-128,127).', errs[0])
         v.attrs['SCALEMAX'] = -200
         self.assertEqual(
             3, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
         errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
-        self.assertEqual('SCALEMAX (-200) outside data range (-128,127) for var1.', errs[1])
+        self.assertEqual('SCALEMAX (-200) outside data range (-128,127).', errs[1])
         v.attrs['SCALEMAX'] = 200
         self.assertEqual(
             2, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
         errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
-        self.assertEqual('SCALEMAX (200) outside data range (-128,127) for var1.', errs[1])
+        self.assertEqual('SCALEMAX (200) outside data range (-128,127).', errs[1])
         
     def testValidPlotType(self):
         """Check plot type."""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python
+
+"""Unit testing for istp support"""
+
+import datetime
+import os.path
+import shutil
+import tempfile
+import unittest
+
+import numpy
+import spacepy.pycdf
+import spacepy.pycdf.const
+import spacepy.pycdf.istp
+
+
+class ISTPTestsBase(unittest.TestCase):
+    """Base class for ISTP check functions, provide a blank CDF to modify"""
+
+    def setUp(self):
+        """Setup: make an empty, open, writeable CDF"""
+        self.tempdir = tempfile.mkdtemp()
+        self.cdf = spacepy.pycdf.CDF(os.path.join(
+            self.tempdir, 'source_descriptor_datatype_19990101_v00.cdf'),
+                                     create=True)
+
+    def tearDown(self):
+        """Delete the empty cdf"""
+        try:
+            self.cdf.close()
+        except:
+            pass
+        shutil.rmtree(self.tempdir)
+
+
+class VariablesTests(ISTPTestsBase):
+    """Tests of variable-checking functions"""
+
+    def testDepends(self):
+        """Dependencies, valid and not"""
+        self.cdf['var1'] = [1, 2, 3]
+        self.cdf['var1'].attrs['DEPEND_0'] = 'var2'
+        errs = spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])
+        self.assertEqual(1, len(errs))
+        self.assertEqual('DEPEND_0 variable var2 missing', errs[0])
+        self.cdf['var2'] = [1, 2, 3]
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])))
+
+    def testValidRangeNRV(self):
+        """Validmin/validmax"""
+        v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])
+        v.attrs['VALIDMIN'] = 1
+        v.attrs['VALIDMAX'] = 3
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+        v.attrs['VALIDMIN'] = 2
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value 1 at index 0 under VALIDMIN 2', errs[0])
+        v.attrs['VALIDMAX'] = 2
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(2, len(errs))
+        self.assertEqual('Value 3 at index 2 over VALIDMAX 2', errs[1])
+
+    def testValidRangeNRVFillval(self):
+        """Validmin/validmax with fillval set"""
+        v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])
+        v.attrs['VALIDMIN'] = 1
+        v.attrs['VALIDMAX'] = 3
+        v.attrs['FILLVAL'] = 99
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+        
+        v.attrs['VALIDMIN'] = 2
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value 1 at index 0 under VALIDMIN 2', errs[0])
+        
+        v.attrs['VALIDMAX'] = 2
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(2, len(errs))
+        self.assertEqual('Value 3 at index 2 over VALIDMAX 2', errs[1])
+        
+        v.attrs['FILLVAL'] = 3
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value 1 at index 0 under VALIDMIN 2', errs[0])
+
+        v.attrs['FILLVAL'] = 1
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value 3 at index 2 over VALIDMAX 2', errs[0])
+
+    def testValidRangeFillvalFloat(self):
+        """Validmin/validmax with fillval set, floating-point"""
+        #This is a bit contrived to force a difference that's only
+        #in terms of the precision of the float
+        v = self.cdf.new('var1', recVary=False, data=[1, 2, 3],
+                         type=spacepy.pycdf.const.CDF_DOUBLE)
+        v.attrs['VALIDMIN'] = 0
+        v.attrs['VALIDMAX'] = 10
+        v.attrs.new('FILLVAL', -1e31, type=spacepy.pycdf.const.CDF_FLOAT)
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+
+        v[0] = -100
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value -100.0 at index 0 under VALIDMIN 0.0', errs[0])
+
+        v[0] = -1e31
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+
+    def testValidRangeFillvalDatetime(self):
+        """Validmin/validmax with fillval set, Epoch var"""
+        v = self.cdf.new(
+            'var1', data=[datetime.datetime(2010, 1, i) for i in range(1, 6)])
+        v.attrs['VALIDMIN'] = datetime.datetime(2010, 1, 1)
+        v.attrs['VALIDMAX'] = datetime.datetime(2010, 1, 31)
+        v.attrs['FILLVAL'] = datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+
+        v[-1] = datetime.datetime(2010, 2, 1)
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value 2010-02-01 00:00:00 at index 4 over VALIDMAX '
+                         '2010-01-31 00:00:00', errs[0])
+
+        v[-1] = datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+
+    def testMatchingRecordCount(self):
+        """Same number of records for DEPEND_0"""
+        e = self.cdf.new(
+            'Epoch', type=spacepy.pycdf.const.CDF_EPOCH,
+            data=[datetime.datetime(2010, 1, i + 1) for i in range(5)])
+        v = self.cdf.new('Data', data=list(range(4)))
+        v.attrs['DEPEND_0'] = 'Epoch'
+        errs = spacepy.pycdf.istp.VariableChecks.recordcount(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('4 records; DEPEND_0 Epoch has 5',
+                         errs[0])
+        v.append(5)
+        errs = spacepy.pycdf.istp.VariableChecks.recordcount(v)
+        self.assertEqual(0, len(errs))
+
+    def testDepSize(self):
+        """Depends are appropriately sized"""
+        e = self.cdf.new(
+            'Epoch', type=spacepy.pycdf.const.CDF_EPOCH,
+            data=[datetime.datetime(2010, 1, i + 1) for i in range(5)])
+        v = self.cdf.new('Data', data=[[1, 2], [3, 4], [5, 6]])
+        v.attrs['DEPEND_0'] = 'Epoch'
+        d = self.cdf.new('thedep', recVary=False, data=[1, 2, 3])
+        v.attrs['DEPEND_1'] = 'thedep'
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Dim 1 sized 2 but DEPEND_1 thedep sized 3', errs[0])
+        del self.cdf['thedep']
+        d = self.cdf.new('thedep', recVary=False, data=[1, 2])
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual(0, len(errs))
+
+    def testDepSize2(self):
+        """Depends are appropriately sized, depend_2"""
+        e = self.cdf.new(
+            'Epoch', type=spacepy.pycdf.const.CDF_EPOCH,
+            data=[datetime.datetime(2010, 1, i + 1) for i in range(5)])
+        v = self.cdf.new('Data', data=[[[1, 2], [3, 4], [5, 6]]])
+        v.attrs['DEPEND_0'] = 'Epoch'
+        self.cdf.new('thedep', recVary=False, data=[1, 2, 3])
+        v.attrs['DEPEND_1'] = 'thedep'
+        self.cdf.new('dep2', recVary=False, data=[1])
+        v.attrs['DEPEND_2'] = 'dep2'
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Dim 2 sized 2 but DEPEND_2 dep2 sized 1', errs[0])
+        del self.cdf['dep2']
+        self.cdf.new('dep2', recVary=False, data=[1, 2])
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual(0, len(errs))
+
+    def testMultiLayeredDep(self):
+        """Check multi layered dependency."""
+        # First Simple Case
+        e = self.cdf.new(
+            'Epoch', type=spacepy.pycdf.const.CDF_EPOCH,
+            data=[datetime.datetime(2010, 1, i + 1) for i in range(5)])
+        v = self.cdf.new('Data', data=[[[1,2,3],[4,5,6]],
+                                       [[11,12,13],[14,15,16]],
+                                       [[21,22,23],[24,25,26]],
+                                       [[31,32,33],[34,35,36]],
+                                       [[41,42,43],[44,45,46]]])
+        v.attrs['DEPEND_0'] = 'Epoch'
+        self.cdf.new('dep1', recVary=False, data=[10,20])
+        v.attrs['DEPEND_1'] = 'dep1'
+        self.cdf.new('dep2', recVary=False, data=[30,40,50])
+        v.attrs['DEPEND_2'] = 'dep2'
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual(0, len(errs))
+        # Now make layered
+        del self.cdf['dep2']
+        vv = self.cdf.new('dep2', recVary=False, data=[[333,444,555],[666,777,888]])
+        vv.attrs['DEPEND_1'] = 'dep1'
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        # Now make fail
+        del self.cdf['dep1']
+        vv = self.cdf.new('dep1', recVary=False, data=[10,20,30])
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual('Dim 1 sized 2 but DEPEND_1 dep1 sized 3', errs[0])
+        self.assertEqual('Dim 2 sized 3 but DEPEND_2 dep2 sized 2', errs[1])
+        
+    def testValidScale(self):
+        """Check scale min and max."""
+        v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])
+        v.attrs['SCALEMIN'] = 1
+        v.attrs['SCALEMAX'] = 3
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
+        v.attrs['SCALEMIN'] = 5
+        v.attrs['SCALEMAX'] = 3
+        self.assertEqual(
+            1, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
+        self.assertEqual('SCALEMIN > SCALEMAX for var1', errs[0])
+        v.attrs['SCALEMIN'] = -200
+        self.assertEqual(
+            1, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
+        self.assertEqual('SCALEMIN (-200) outside data range (-128,127) for var1.', errs[0])
+        v.attrs['SCALEMIN'] = 200
+        self.assertEqual(
+            2, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
+        self.assertEqual('SCALEMIN (200) outside data range (-128,127) for var1.', errs[0])
+        v.attrs['SCALEMAX'] = -200
+        self.assertEqual(
+            3, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
+        self.assertEqual('SCALEMAX (-200) outside data range (-128,127) for var1.', errs[1])
+        v.attrs['SCALEMAX'] = 200
+        self.assertEqual(
+            2, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
+        self.assertEqual('SCALEMAX (200) outside data range (-128,127) for var1.', errs[1])
+        
+    def testValidPlotType(self):
+        """Check plot type."""
+        err1 = 'var1: 1 dim variable with spectrogram display type.'
+        err2 = 'var2: multi dim variable with time_series display type.'
+        v = self.cdf.new('var1', recVary=True, data=[1, 2, 3])
+        v.attrs['DISPLAY_TYPE'] = 'time_series'
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
+        v.attrs['DISPLAY_TYPE'] = 'spectrogram'
+        self.assertEqual(
+            1, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validplottype(v)
+        self.assertEqual(err1, errs[0])
+        v = self.cdf.new('var2', recVary=True, data=[[1, 2, 3],[4,5,6]])
+        v.attrs['DISPLAY_TYPE'] = 'spectrogram'
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
+        v.attrs['DISPLAY_TYPE'] = 'time_series'
+        self.assertEqual(
+            1, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validplottype(v)
+        self.assertEqual(err2, errs[0])
+
+    def testFieldnam(self):
+        """Check field name matching"""
+        v = self.cdf.new('var1', recVary=True, data=[1, 2, 3])
+        errs = spacepy.pycdf.istp.VariableChecks.fieldnam(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('var1: no FIELDNAM attribute.', errs[0])
+        v.attrs['FIELDNAM'] = 'var2'
+        errs = spacepy.pycdf.istp.VariableChecks.fieldnam(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual(
+            'var1: FIELDNAM attribute var2 does not match var name.', errs[0])
+        v.attrs['FIELDNAM'] = 'var1'
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.fieldnam(v)))
+        
+
+        
+class FileTests(ISTPTestsBase):
+    """Tests of file-checking functions"""
+
+    def testAll(self):
+        """Calling all file checks"""
+        self.cdf['var1'] = [1, 2, 3]
+        self.cdf['var1'].attrs['DEPEND_0'] = 'var2'
+        self.cdf['var1'].attrs['FIELDNAM'] = 'var1'
+        self.cdf.attrs['Logical_source'] = \
+            'source_descriptor_datatype'
+        self.cdf.attrs['Logical_file_id'] = \
+            'source_descriptor_datatype_19990101_v00'
+        errs = spacepy.pycdf.istp.FileChecks.all(self.cdf)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('var1: DEPEND_0 variable var2 missing', errs[0])
+
+    def testFilename(self):
+        """Compare filename to global attrs"""
+        self.cdf.attrs['Logical_source'] = \
+            'source_descriptor_blargh'
+        self.cdf.attrs['Logical_file_id'] = \
+            'source_descriptor_datatype_19990102_v00'
+        errs = spacepy.pycdf.istp.FileChecks.filename(self.cdf)
+        self.assertEqual(2, len(errs))
+        self.assertTrue("Logical_source source_descriptor_blargh doesn't match "
+                        "filename source_descriptor_datatype_19990101_v00.cdf"
+                        in errs)
+        self.assertTrue(
+            "Logical_file_id source_descriptor_datatype_19990102_v00 doesn't "
+            "match filename source_descriptor_datatype_19990101_v00.cdf"
+            in errs)
+        self.cdf.attrs['Logical_source'] = \
+            'source_descriptor_datatype'
+        self.cdf.attrs['Logical_file_id'] = \
+            'source_descriptor_datatype_19990101_v00'
+        errs = spacepy.pycdf.istp.FileChecks.filename(self.cdf)
+        self.assertEqual(0, len(errs))
+
+    def testTimesMonoton(self):
+        """Test monotonic time"""
+        self.cdf['Epoch'] = [datetime.datetime(1999, 1, 1, i) for i in range(3)]
+        self.cdf['Epoch'].append(datetime.datetime(1999, 1, 1, 5))
+        self.cdf['Epoch'].append(datetime.datetime(1999, 1, 1, 4))
+        errs = spacepy.pycdf.istp.FileChecks.time_monoton(self.cdf)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Epoch: nonmonotonic time at record 4', errs[0])
+
+    def testTimes(self):
+        """Compare filename to Epoch times"""
+        self.cdf['Epoch'] = [datetime.datetime(1999, 1, 1, i) for i in range(3)]
+        self.cdf['Epoch'].append(datetime.datetime(1999, 1, 2, 0))
+        errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Epoch: multiple days 19990101, 19990102', errs[0])
+        del self.cdf['Epoch'][-1]
+        errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
+        self.assertEqual(0, len(errs))
+        self.cdf['Epoch'] = [datetime.datetime(1999, 1, 2, i) for i in range(3)]
+        errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Epoch: date 19990102 doesn\'t match file '
+                         'source_descriptor_datatype_19990101_v00.cdf', errs[0])
+
+
+class FuncTests(ISTPTestsBase):
+    """Tests of simple functions"""
+
+    def testFillval(self):
+        """Set fill value"""
+        expected = ((spacepy.pycdf.const.CDF_EPOCH,
+                     datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)),
+                    (spacepy.pycdf.const.CDF_BYTE, -128),
+                    (spacepy.pycdf.const.CDF_UINT1, 255),
+                    (spacepy.pycdf.const.CDF_CHAR, ' '),
+                    #Explicit casts to certain size so compare to same precision
+                    (spacepy.pycdf.const.CDF_FLOAT, numpy.float32(-1e31)),
+                    (spacepy.pycdf.const.CDF_REAL8, numpy.float64(-1e31)),
+        )
+        for t, e in expected:
+            v = self.cdf.new('var', [1, 2,3], type=t)
+            spacepy.pycdf.istp.fillval(v)
+            self.assertEqual(e, v.attrs['FILLVAL'])
+            del self.cdf['var']
+
+    def testFormat(self):
+        """Set the format"""
+        #This is done by: type, expected, validmin, validmax (None okay)
+        expected = ((spacepy.pycdf.const.CDF_EPOCH, 'A24', None, None),
+                    (spacepy.pycdf.const.CDF_INT2, 'I2', -2, 9),
+                    (spacepy.pycdf.const.CDF_UINT2, 'I5', None, None),
+                    (spacepy.pycdf.const.CDF_INT2, 'I6', None, None),
+                    (spacepy.pycdf.const.CDF_UINT2, 'I2', 0, 10),
+        )
+        for t, e, vmin, vmax in expected:
+            v = self.cdf.new('var', type=t)
+            if vmin is not None:
+                v.attrs['VALIDMIN'] = vmin
+            if vmin is not None:
+                v.attrs['VALIDMAX'] = vmin
+            spacepy.pycdf.istp.format(v)
+            self.assertEqual(e, v.attrs['FORMAT'])
+            del self.cdf['var']
+
+    def testFormatChar(self):
+        v = self.cdf.new('var', data=['hi', 'there'])
+        spacepy.pycdf.istp.format(v)
+        self.assertEqual('A5', v.attrs['FORMAT'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -57,11 +57,11 @@ class VariablesTests(ISTPTestsBase):
         v.attrs['VALIDMIN'] = 2
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Value 1 at index 0 under VALIDMIN 2', errs[0])
+        self.assertEqual('Value 1 at index 0 under VALIDMIN 2.', errs[0])
         v.attrs['VALIDMAX'] = 2
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(2, len(errs))
-        self.assertEqual('Value 3 at index 2 over VALIDMAX 2', errs[1])
+        self.assertEqual('Value 3 at index 2 over VALIDMAX 2.', errs[1])
 
     def testValidRangeNRVFillval(self):
         """Validmin/validmax with fillval set"""
@@ -75,22 +75,22 @@ class VariablesTests(ISTPTestsBase):
         v.attrs['VALIDMIN'] = 2
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Value 1 at index 0 under VALIDMIN 2', errs[0])
+        self.assertEqual('Value 1 at index 0 under VALIDMIN 2.', errs[0])
         
         v.attrs['VALIDMAX'] = 2
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(2, len(errs))
-        self.assertEqual('Value 3 at index 2 over VALIDMAX 2', errs[1])
+        self.assertEqual('Value 3 at index 2 over VALIDMAX 2.', errs[1])
         
         v.attrs['FILLVAL'] = 3
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Value 1 at index 0 under VALIDMIN 2', errs[0])
+        self.assertEqual('Value 1 at index 0 under VALIDMIN 2.', errs[0])
 
         v.attrs['FILLVAL'] = 1
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Value 3 at index 2 over VALIDMAX 2', errs[0])
+        self.assertEqual('Value 3 at index 2 over VALIDMAX 2.', errs[0])
 
     def testValidRangeFillvalFloat(self):
         """Validmin/validmax with fillval set, floating-point"""
@@ -107,7 +107,7 @@ class VariablesTests(ISTPTestsBase):
         v[0] = -100
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Value -100.0 at index 0 under VALIDMIN 0.0', errs[0])
+        self.assertEqual('Value -100.0 at index 0 under VALIDMIN 0.0.', errs[0])
 
         v[0] = -1e31
         self.assertEqual(
@@ -127,7 +127,7 @@ class VariablesTests(ISTPTestsBase):
         errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
         self.assertEqual(1, len(errs))
         self.assertEqual('Value 2010-02-01 00:00:00 at index 4 over VALIDMAX '
-                         '2010-01-31 00:00:00', errs[0])
+                         '2010-01-31 00:00:00.', errs[0])
 
         v[-1] = datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)
         self.assertEqual(
@@ -142,7 +142,7 @@ class VariablesTests(ISTPTestsBase):
         v.attrs['DEPEND_0'] = 'Epoch'
         errs = spacepy.pycdf.istp.VariableChecks.recordcount(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('4 records; DEPEND_0 Epoch has 5',
+        self.assertEqual('4 records; DEPEND_0 Epoch has 5.',
                          errs[0])
         v.append(5)
         errs = spacepy.pycdf.istp.VariableChecks.recordcount(v)
@@ -159,7 +159,7 @@ class VariablesTests(ISTPTestsBase):
         v.attrs['DEPEND_1'] = 'thedep'
         errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Dim 1 sized 2 but DEPEND_1 thedep sized 3', errs[0])
+        self.assertEqual('Dim 1 sized 2 but DEPEND_1 thedep sized 3.', errs[0])
         del self.cdf['thedep']
         d = self.cdf.new('thedep', recVary=False, data=[1, 2])
         errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
@@ -178,7 +178,7 @@ class VariablesTests(ISTPTestsBase):
         v.attrs['DEPEND_2'] = 'dep2'
         errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Dim 2 sized 2 but DEPEND_2 dep2 sized 1', errs[0])
+        self.assertEqual('Dim 2 sized 2 but DEPEND_2 dep2 sized 1.', errs[0])
         del self.cdf['dep2']
         self.cdf.new('dep2', recVary=False, data=[1, 2])
         errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
@@ -211,8 +211,8 @@ class VariablesTests(ISTPTestsBase):
         del self.cdf['dep1']
         vv = self.cdf.new('dep1', recVary=False, data=[10,20,30])
         errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
-        self.assertEqual('Dim 1 sized 2 but DEPEND_1 dep1 sized 3', errs[0])
-        self.assertEqual('Dim 2 sized 3 but DEPEND_2 dep2 sized 2', errs[1])
+        self.assertEqual('Dim 1 sized 2 but DEPEND_1 dep1 sized 3.', errs[0])
+        self.assertEqual('Dim 2 sized 3 but DEPEND_2 dep2 sized 2.', errs[1])
         
     def testValidScale(self):
         """Check scale min and max."""
@@ -226,7 +226,7 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(
             1, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
         errs = spacepy.pycdf.istp.VariableChecks.validscale(v)
-        self.assertEqual('SCALEMIN > SCALEMAX for var1', errs[0])
+        self.assertEqual('SCALEMIN > SCALEMAX for var1.', errs[0])
         v.attrs['SCALEMIN'] = -200
         self.assertEqual(
             1, len(spacepy.pycdf.istp.VariableChecks.validscale(v)))
@@ -250,8 +250,8 @@ class VariablesTests(ISTPTestsBase):
         
     def testValidPlotType(self):
         """Check plot type."""
-        err1 = 'var1: 1 dim variable with spectrogram display type.'
-        err2 = 'var2: multi dim variable with time_series display type.'
+        err1 = '1 dim variable with spectrogram display type.'
+        err2 = 'Multi dim variable with time_series display type.'
         v = self.cdf.new('var1', recVary=True, data=[1, 2, 3])
         v.attrs['DISPLAY_TYPE'] = 'time_series'
         self.assertEqual(
@@ -276,12 +276,12 @@ class VariablesTests(ISTPTestsBase):
         v = self.cdf.new('var1', recVary=True, data=[1, 2, 3])
         errs = spacepy.pycdf.istp.VariableChecks.fieldnam(v)
         self.assertEqual(1, len(errs))
-        self.assertEqual('var1: no FIELDNAM attribute.', errs[0])
+        self.assertEqual('No FIELDNAM attribute.', errs[0])
         v.attrs['FIELDNAM'] = 'var2'
         errs = spacepy.pycdf.istp.VariableChecks.fieldnam(v)
         self.assertEqual(1, len(errs))
         self.assertEqual(
-            'var1: FIELDNAM attribute var2 does not match var name.', errs[0])
+            'FIELDNAM attribute var2 does not match var name.', errs[0])
         v.attrs['FIELDNAM'] = 'var1'
         self.assertEqual(
             0, len(spacepy.pycdf.istp.VariableChecks.fieldnam(v)))
@@ -313,11 +313,11 @@ class FileTests(ISTPTestsBase):
         errs = spacepy.pycdf.istp.FileChecks.filename(self.cdf)
         self.assertEqual(2, len(errs))
         self.assertTrue("Logical_source source_descriptor_blargh doesn't match "
-                        "filename source_descriptor_datatype_19990101_v00.cdf"
+                        "filename source_descriptor_datatype_19990101_v00.cdf."
                         in errs)
         self.assertTrue(
             "Logical_file_id source_descriptor_datatype_19990102_v00 doesn't "
-            "match filename source_descriptor_datatype_19990101_v00.cdf"
+            "match filename source_descriptor_datatype_19990101_v00.cdf."
             in errs)
         self.cdf.attrs['Logical_source'] = \
             'source_descriptor_datatype'
@@ -333,7 +333,7 @@ class FileTests(ISTPTestsBase):
         self.cdf['Epoch'].append(datetime.datetime(1999, 1, 1, 4))
         errs = spacepy.pycdf.istp.FileChecks.time_monoton(self.cdf)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Epoch: nonmonotonic time at record 4', errs[0])
+        self.assertEqual('Epoch: Nonmonotonic time at record 4.', errs[0])
 
     def testTimes(self):
         """Compare filename to Epoch times"""
@@ -341,7 +341,7 @@ class FileTests(ISTPTestsBase):
         self.cdf['Epoch'].append(datetime.datetime(1999, 1, 2, 0))
         errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
         self.assertEqual(1, len(errs))
-        self.assertEqual('Epoch: multiple days 19990101, 19990102', errs[0])
+        self.assertEqual('Epoch: multiple days 19990101, 19990102.', errs[0])
         del self.cdf['Epoch'][-1]
         errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
         self.assertEqual(0, len(errs))
@@ -349,7 +349,8 @@ class FileTests(ISTPTestsBase):
         errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
         self.assertEqual(1, len(errs))
         self.assertEqual('Epoch: date 19990102 doesn\'t match file '
-                         'source_descriptor_datatype_19990101_v00.cdf', errs[0])
+                         'source_descriptor_datatype_19990101_v00.cdf.',
+                         errs[0])
 
 
 class FuncTests(ISTPTestsBase):

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -47,6 +47,48 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(
             0, len(spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])))
 
+    def testValidRangeDimensioned(self):
+        """Validmin/validmax with multiple elements"""
+        v = self.cdf.new('var1', data=[[1, 10], [2, 20], [3, 30]])
+        v.attrs['VALIDMIN'] = [1, 20]
+        v.attrs['VALIDMAX'] = [3, 30]
+        v.attrs['FILLVAL'] = -100
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Value 10 at index [0 1] under VALIDMIN [ 1 20].',
+                         errs[0])
+        v.attrs['VALIDMIN'] = [1, 10]
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(0, len(errs))
+        v[0, 0] = -100
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(0, len(errs))
+
+    def testValidRangeDimensionMismatch(self):
+        """Validmin/validmax with something wrong in dimensionality"""
+        v = self.cdf.new('var1', data=[[1, 10], [2, 20], [3, 30]])
+        v.attrs['VALIDMIN'] = [1, 10, 100]
+        v.attrs['VALIDMAX'] = [3, 30, 300]
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(2, len(errs))
+        self.assertEqual('VALIDMIN element count 3 does not match '
+                         'first data dimension size 2.', errs[0])
+        self.assertEqual('VALIDMAX element count 3 does not match '
+                         'first data dimension size 2.', errs[1])
+
+    def testValidRangeHighDimension(self):
+        """Validmin/validmax with high-dimension variables"""
+        v = self.cdf.new('var1',
+                         data=numpy.reshape(numpy.arange(27.), (3, 3, 3,)))
+        v.attrs['VALIDMIN'] = [1, 10, 100]
+        v.attrs['VALIDMAX'] = [3, 30, 300]
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(2, len(errs))
+        self.assertEqual('Multi-element VALIDMIN only valid with 1D variable.',
+                         errs[0])
+        self.assertEqual('Multi-element VALIDMAX only valid with 1D variable.',
+                         errs[1])
+
     def testValidRangeNRV(self):
         """Validmin/validmax"""
         v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -406,6 +406,11 @@ class FileTests(ISTPTestsBase):
             'source_descriptor_datatype_19990101_v00'
         errs = spacepy.pycdf.istp.FileChecks.filename(self.cdf)
         self.assertEqual(0, len(errs))
+        del self.cdf.attrs['Logical_source'][0]
+        errs = spacepy.pycdf.istp.FileChecks.filename(self.cdf)
+        self.assertEqual(1, len(errs))
+        self.assertEqual(['No Logical_source in global attrs.'],
+                         errs)
 
     def testTimesMonoton(self):
         """Test monotonic time"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -357,27 +357,27 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual('Multi-element SCALEMAX only valid with 1D variable.',
                          errs[1])
 
-    def testValidPlotType(self):
+    def testValiddisplaytype(self):
         """Check plot type."""
         err1 = '1 dim variable with spectrogram display type.'
         err2 = 'Multi dim variable with time_series display type.'
         v = self.cdf.new('var1', recVary=True, data=[1, 2, 3])
         v.attrs['DISPLAY_TYPE'] = 'time_series'
         self.assertEqual(
-            0, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
+            0, len(spacepy.pycdf.istp.VariableChecks.validdisplaytype(v)))
         v.attrs['DISPLAY_TYPE'] = 'spectrogram'
         self.assertEqual(
-            1, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
-        errs = spacepy.pycdf.istp.VariableChecks.validplottype(v)
+            1, len(spacepy.pycdf.istp.VariableChecks.validdisplaytype(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validdisplaytype(v)
         self.assertEqual(err1, errs[0])
         v = self.cdf.new('var2', recVary=True, data=[[1, 2, 3],[4,5,6]])
         v.attrs['DISPLAY_TYPE'] = 'spectrogram'
         self.assertEqual(
-            0, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
+            0, len(spacepy.pycdf.istp.VariableChecks.validdisplaytype(v)))
         v.attrs['DISPLAY_TYPE'] = 'time_series'
         self.assertEqual(
-            1, len(spacepy.pycdf.istp.VariableChecks.validplottype(v)))
-        errs = spacepy.pycdf.istp.VariableChecks.validplottype(v)
+            1, len(spacepy.pycdf.istp.VariableChecks.validdisplaytype(v)))
+        errs = spacepy.pycdf.istp.VariableChecks.validdisplaytype(v)
         self.assertEqual(err2, errs[0])
 
     def testFieldnam(self):

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -269,6 +269,21 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(1, len(errs))
         self.assertEqual('DEPEND_1 thedep is RV but has no DEPEND_0.', errs[0])
 
+    def testValidRangeScalar(self):
+        """Check validmin/max on a scalar"""
+        v = self.cdf.new('var1', recVary=False, data=1)
+        v.attrs['VALIDMIN'] = 0
+        v.attrs['VALIDMAX'] = 2
+        v.attrs['FILLVAL'] = -100
+        self.assertEqual(
+            0, len(spacepy.pycdf.istp.VariableChecks.validrange(v)))
+        v.attrs['VALIDMIN'] = 2
+        v.attrs['VALIDMAX'] = 3
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual(
+            'Value 1 under VALIDMIN 2.', errs[0])
+
     def testValidScale(self):
         """Check scale min and max."""
         v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -256,6 +256,19 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual('Dim 1 sized 2 but DEPEND_1 dep1 sized 3.', errs[0])
         self.assertEqual('Dim 2 sized 3 but DEPEND_2 dep2 sized 2.', errs[1])
         
+    def testDepSizeBadRV(self):
+        """Depend size check with RV, non-depend 0 dep"""
+        e = self.cdf.new(
+            'Epoch', type=spacepy.pycdf.const.CDF_EPOCH,
+            data=[datetime.datetime(2010, 1, i + 1) for i in range(5)])
+        v = self.cdf.new('Data', data=[[1, 2], [3, 4], [5, 6]])
+        v.attrs['DEPEND_0'] = 'Epoch'
+        d = self.cdf.new('thedep', recVary=True, data=[1, 2, 3])
+        v.attrs['DEPEND_1'] = 'thedep'
+        errs = spacepy.pycdf.istp.VariableChecks.depsize(v)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('DEPEND_1 thedep is RV but has no DEPEND_0.', errs[0])
+
     def testValidScale(self):
         """Check scale min and max."""
         v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])

--- a/tests/test_spacepy.py
+++ b/tests/test_spacepy.py
@@ -26,6 +26,7 @@ from test_coordinates import *
 from test_seapy import *
 from test_poppy import *
 from test_pycdf import *
+from test_pycdf_istp import *
 from test_data_assimilation import *
 from test_spectrogram import *
 from test_irbempy import *


### PR DESCRIPTION
This PR adds a module specifically for CDFs that use ISTP-compliant metadata (as opposed to CDFs in general). There's more to come but these are the first few useful functions.
