### PR TITLE
pycdf: put CDF-specific metadata in VarCopy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Changes in Version 0.2.2 (2019-xx-xx)
 =====================================
+pycdf
+ - VarCopy objects now carry information to help reproduce original
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Changes in Version 0.2.2 (2019-xx-xx)
 =====================================
 pycdf
  - VarCopy objects now carry information to help reproduce original
+ - Newly-public method nelems to get number of elements in zVar
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3699,11 +3699,14 @@ class VarCopy(spacepy.datamodel.dmarray):
             }
         return obj
 
-    def compress(self):
+    def compress(self, *args, **kwargs):
         """Gets compression of the variable this was copied from.
 
         For details on CDF compression, see
         :meth:`spacepy.pycdf.Var.compress`.
+
+        If any arguments are specified, calls
+        :meth:`numpy.ndarray.compress` instead (as the names conflict)
 
         Returns
         =======
@@ -3711,7 +3714,10 @@ class VarCopy(spacepy.datamodel.dmarray):
             compression type, parameter currently in effect.
 
         """
-        return self._cdf_meta['compress']
+        if args or kwargs:
+            return super(VarCopy, self).compress(*args, **kwargs)
+        else:
+            return self._cdf_meta['compress']
 
     def dv(self):
         """Gets dimension variance of the variable this was copied from.

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -856,8 +856,7 @@ def format(v, use_scaleminmax=False, dryrun=False):
             fmt = 'G10.2E3'
     elif cdftype in (spacepy.pycdf.const.CDF_CHAR.value,
                      spacepy.pycdf.const.CDF_UCHAR.value):
-        #This is a bit weird but pycdf consider nelems private. Should change.
-        fmt = 'A{}'.format(v._nelems())
+        fmt = 'A{}'.format(v.nelems())
     else:
         raise ValueError("Couldn't find FORMAT for {} of type {}".format(
             v.name(),

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1300,8 +1300,8 @@ class ReadCDF(CDFTests):
 
     def testnElems(self):
         """Read number of elements in a string variable"""
-        self.assertEqual(2, self.cdf['SpinNumbers']._nelems())
-        self.assertEqual(2, self.cdf['SectorNumbers']._nelems())
+        self.assertEqual(2, self.cdf['SpinNumbers'].nelems())
+        self.assertEqual(2, self.cdf['SectorNumbers'].nelems())
 
     def testSubscriptString(self):
         """Refer to a string array by subscript"""
@@ -2397,7 +2397,7 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual([], self.cdf['newvar']._dim_sizes())
 
         self.cdf.new('newvar2', None, const.CDF_CHAR, dims=[])
-        self.assertEqual(1, self.cdf['newvar2']._nelems())
+        self.assertEqual(1, self.cdf['newvar2'].nelems())
 
     def testNewVarEmptyArray(self):
         """Create a variable with an empty numpy array"""
@@ -2511,7 +2511,7 @@ class ChangeCDF(ChangeCDFBase):
             self.assertEqual(oldvar._n_dims(), newvar._n_dims(), msg)
             self.assertEqual(oldvar._dim_sizes(), newvar._dim_sizes(), msg)
             self.assertEqual(oldvar.type(), newvar.type(), msg)
-            self.assertEqual(oldvar._nelems(), newvar._nelems(), msg)
+            self.assertEqual(oldvar.nelems(), newvar.nelems(), msg)
             self.assertEqual(oldvar.compress(), newvar.compress(), msg)
             self.assertEqual(oldvar.rv(), newvar.rv(), msg)
             self.assertEqual(oldvar.dv(), newvar.dv(), msg)
@@ -2536,7 +2536,7 @@ class ChangeCDF(ChangeCDFBase):
             self.assertEqual(oldvar._n_dims(), newvar._n_dims(), msg)
             self.assertEqual(oldvar._dim_sizes(), newvar._dim_sizes(), msg)
             self.assertEqual(oldvar.type(), newvar.type(), msg)
-            self.assertEqual(oldvar._nelems(), newvar._nelems(), msg)
+            self.assertEqual(oldvar.nelems(), newvar.nelems(), msg)
             self.assertEqual(oldvar.compress(), newvar.compress(), msg)
             self.assertEqual(oldvar.rv(), newvar.rv(), msg)
             self.assertEqual(oldvar.dv(), newvar.dv(), msg)
@@ -2693,7 +2693,7 @@ class ChangeCDF(ChangeCDFBase):
         """make a zvar from a numpy string array and get the size right"""
         inarray = numpy.array(['hi', 'there'], dtype='|S6')
         self.cdf['string6'] = inarray
-        self.assertEqual(6, self.cdf['string6']._nelems())
+        self.assertEqual(6, self.cdf['string6'].nelems())
         expected = numpy.require(inarray, dtype=str)
         outarray = numpy.char.rstrip(self.cdf['string6'][...])
         numpy.testing.assert_array_equal(expected, outarray)
@@ -2704,7 +2704,7 @@ class ChangeCDF(ChangeCDFBase):
             return
         inarray = numpy.array(['hi', 'there'], dtype='U6')
         self.cdf['string62'] = inarray
-        self.assertEqual(6, self.cdf['string62']._nelems())
+        self.assertEqual(6, self.cdf['string62'].nelems())
         out = self.cdf['string62'][...]
         numpy.testing.assert_array_equal(inarray, numpy.char.rstrip(out))
 

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1742,6 +1742,15 @@ class ReadCDF(CDFTests):
         varcopy = self.cdf['MeanCharge'].copy()
         self.assertRaises(KeyError, varcopy.set, 'foo', 'bar')
 
+    def testVarCopyCompressThunk(self):
+        """Check that compress overloading works"""
+        varcopy = self.cdf['MeanCharge'].copy()
+        actual = varcopy.compress()
+        self.assertEqual(0, actual[0].value)
+        self.assertEqual(0, actual[1])
+        foo = varcopy.compress([False] * 17 + [True], axis=0)
+        numpy.testing.assert_allclose(foo, self.cdf['MeanCharge'][17:18, :])
+
     def testVarCopyPickle(self):
         """Pickling a VarCopy preserves information"""
         varcopy = self.cdf['RateScalerNames'].copy()

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1721,6 +1721,27 @@ class ReadCDF(CDFTests):
             cdf.lib.set_backward(True)
             shutil.rmtree(testdir)
 
+    def testVarCopyMungeCDFType(self):
+        """Change CDF type of VarCopy before assignment"""
+        varcopy = self.cdf['MeanCharge'].copy()
+        varcopy.set('type', const.CDF_DOUBLE)
+        testdir = tempfile.mkdtemp()
+        try:
+            with cdf.CDF(os.path.join(testdir, 'temp.cdf'), create=True) as f:
+                f.new('newvar', data=varcopy)
+                self.assertEqual(const.CDF_DOUBLE.value,
+                                 f['newvar'].type())
+                f['newvar2'] = varcopy
+                self.assertEqual(const.CDF_DOUBLE.value,
+                                 f['newvar2'].type())
+        finally:
+            shutil.rmtree(testdir)
+
+    def testVarCopyBadAssign(self):
+        """Assign to invalid CDF metadata"""
+        varcopy = self.cdf['MeanCharge'].copy()
+        self.assertRaises(KeyError, varcopy.set, 'foo', 'bar')
+
     def testVarCopyPickle(self):
         """Pickling a VarCopy preserves information"""
         varcopy = self.cdf['RateScalerNames'].copy()


### PR DESCRIPTION
This PR adds information about original CDF type, record and dimension variance, compression, etc. to VarCopy so that new CDF variables made from it will match.

I thought about exposing the information as in the Var objects but there are two problems. One is that the `compress` method already exists in ndarray/dmarray so including it sort of messes things up. I suppose this is workable by a super call if any args are called. The other problem is that things can get a little bit weird if you do really bizarre stuff and then expect it to still work...so for instance slicing out a dimension doesn't update the dimension variance. This isn't trying to be perfect, just carry some information.

I'm a little conflicted on this, as it would be nice to be able to have the same interface for Var and VarCopy for stuff like checking record variance.
