### PR TITLE
time.Ticktock: better error if can't guess type (Closes #132)

### DIFF
--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -235,6 +235,9 @@ class Ticktock(MutableSequence):
                     dtype = 'UTC'
                 elif self.data[0] > 1e13:
                     dtype = 'CDF'
+                elif dtype is None:
+                    raise ValueError('Unable to guess dtype from data; '
+                                     'please specify dtype.')
                 if dtype.upper() not in Ticktock._keylist_upper:
                     raise ValueError("data type " + dtype + " not provided, only " + str(Ticktock._keylist))
             else:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -277,6 +277,11 @@ class TimeClassTests(unittest.TestCase):
         """Ticktock init has a raise or two"""
         self.assertRaises(ValueError, t.Ticktock, 12345, 'BOGUS')
 
+    def test_notypeguess(self):
+        """Raise a reasonable error if can't guess type"""
+        self.assertRaises(ValueError, t.Ticktock,
+                          [6.36485472e+10, 3.89393000e+11])
+
     def test_sliceTicktock(self):
         """a ticktock sliced returns a ticktock"""
         n1 = t.Ticktock(['2002-03-01T11:23:11',


### PR DESCRIPTION
Quick error message in Ticktock constructor if can't guess dtype.
