### PR TITLE
Write config file default comments on two lines (Closes #18)

### DIFF
--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -220,8 +220,9 @@ def _write_defaults(rcfile, defaults, section='spacepy'):
             f.seek(0, 2)
         #Write default values for anything not read
         for k in sorted(writeme):
-            f.write("#{key}: {value} #default in SpacePy {ver}\n".format(
-                key=k, value=defaults[k], ver=__version__))
+            f.write(("#SpacePy {ver} default {key}: {value}\n"
+                     "#{key}: {value}\n").format(
+                         key=k, value=defaults[k], ver=__version__))
         #And write all the remaining lines from the section header to end
         if writeme:
             f.writelines(rclines[thissec+1:])


### PR DESCRIPTION
See #18 for rationale. I took a slightly different tack; the comment line now includes the SpacePy version, the key, and the value. That way if people uncomment and edit any particular item in the config file, they have the default above specifically for reference.

So this:
```
#SpacePy 0.2.0 default ncpus: 8
#ncpus: 8
```

then can become:
```
#SpacePy 0.2.0 default ncpus: 8
ncpus: 16
```