### PR TITLE
setup: use std=legacy for f2py on gnu95

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -630,6 +630,9 @@ class build(_build):
             f2py_flags.append('--f77flags=-fno-second-underscore,-mno-align-double')
             if bit == 64:
                 f2py_flags[-1] += ',-m64'
+        if fcompiler == 'gnu95':
+            f2py_flags.extend(['--f77flags=-std=legacy',
+                               '--f90flags=-std=legacy'])
         if self.compiler:
             f2py_flags.append('--compiler={0}'.format(self.compiler))
         if self.f77exec:


### PR DESCRIPTION
We were using `std=legacy` for the actual irbem compile on gnu95 but not for the f2py calls. This caused issues e.g. #190 and #204.

This PR adds std=legacy to the f2py calls when using gnu95 in hopes of avoiding these issues in the future.

Ideally we do want to fix irbem code to work without `std=legacy` but in the meantime this PR 1) makes us consistent between library compile and f2py and 2) keeps things ticking along.
