### PR TITLE
[BUGFIX]: clean up extracted file

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -888,8 +888,8 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         fh_zip = zipfile.ZipFile(omni2_fname_zip)
         fh_zip.extractall();
         fh_zip.close()
-        file_to_convert = fh_zip.namelist()[0]
-        omnicdf = fromCDF(file_to_convert)
+        file_to_read = fh_zip.namelist()[0]
+        omnicdf = fromCDF(file_to_read)
         #add RDT
         omnicdf['RDT'] = spt.Ticktock(omnicdf['Epoch'],'UTC').RDT
         #remove keys that get in the way
@@ -902,7 +902,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
 
         # delete left-overs
         os.remove(omni2_fname_zip)
-        os.remove(file_to_convert)
+        os.remove(file_to_read)
 
     if leapsecs == True:
         print("Retrieving leapseconds file ... ")

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -888,7 +888,8 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         fh_zip = zipfile.ZipFile(omni2_fname_zip)
         fh_zip.extractall();
         fh_zip.close()
-        omnicdf = fromCDF(fh_zip.namelist()[0])
+        file_to_convert = fh_zip.namelist()[0]
+        omnicdf = fromCDF(file_to_convert)
         #add RDT
         omnicdf['RDT'] = spt.Ticktock(omnicdf['Epoch'],'UTC').RDT
         #remove keys that get in the way
@@ -901,6 +902,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
 
         # delete left-overs
         os.remove(omni2_fname_zip)
+        os.remove(file_to_convert)
 
     if leapsecs == True:
         print("Retrieving leapseconds file ... ")


### PR DESCRIPTION
This fixes https://github.com/spacepy/spacepy/issues/218, where it was found that the extracted zip file contents for OMNI2 data download were not cleaned up.

Testing this PR can be done as follows:
1) using the `master` branch, run the command `python -c "import spacepy.toolbox; spacepy.toolbox.update(omni2=True)"` and verify that a file named `OMNI_OMNI2_merged_20120213-v1.cdf` appears, but isn't cleaned up
2) using this PR, run the same command as above and notice that the file is cleaned up

This works in both python 2 and python 3.