### PR TITLE
pycdf.Attr: Fix writing an EPOCH16 Entry in raw mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Changes in Version 0.2.2 (2019-xx-xx)
 pycdf
  - VarCopy objects now carry information to help reproduce original
  - Newly-public method nelems to get number of elements in zVar
+ - Fix assignment of "raw" values to EPOCH16 Attribute
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4965,20 +4965,23 @@ class Attr(MutableSequence):
         @param elements: number of elements in L{data}, 1 unless it is a string
         @type elements: int
         """
-        if len(dims) == 0:
-            n_write = 1
-        else:
-            n_write = dims[0]
+        n_write = 1 if len(dims) == 0 else dims[0]
         if cdf_type in (const.CDF_CHAR.value, const.CDF_UCHAR.value):
             data = numpy.require(data, requirements=('C', 'A', 'W'),
                                  dtype=numpy.dtype('S' + str(elements)))
             n_write = elements
         elif cdf_type == const.CDF_EPOCH16.value:
+            raw_in = True #Assume each element is pair of floats
             if not self._raw:
                 try:
                     data = lib.v_datetime_to_epoch16(data)
+                    raw_in = False #Nope, not raw, was datetime
                 except AttributeError:
                     pass
+            if raw_in: #Floats passed in, extra dim of (2,)
+                dims = dims[:-1]
+                if len(dims) == 0:
+                    n_write = 1
             data = numpy.require(data, requirements=('C', 'A', 'W'),
                                  dtype=numpy.float64)
         elif cdf_type == const.CDF_EPOCH.value:

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2698,6 +2698,18 @@ class ChangeCDF(ChangeCDFBase):
                          datetime.datetime(1996, 1, 2)]),
             self.cdf['epochtest'][:])
 
+    def testAttrsRawEpoch16(self):
+        """Assign float attribute to Epoch16"""
+        self.cdf.new('epochtest', type=const.CDF_EPOCH16)
+        data = numpy.array([[62987673600.0, 0.0],
+                            [62987760000.0, 0.0]], dtype=numpy.float64)
+        self.cdf['epochtest'][:] = data
+        self.cdf.raw_var('epochtest').attrs.new(
+            'FILLVAL', numpy.array([-1e31, -1e31]), const.CDF_EPOCH16)
+        numpy.testing.assert_array_equal(
+            numpy.array([-1e31, -1e31], dtype=numpy.float64),
+            self.cdf.raw_var('epochtest').attrs['FILLVAL'])
+
     def testInt8TT2000(self):
         """Write integers to a TT2000 variable"""
         if not cdf.lib.supports_int8:


### PR DESCRIPTION
This PR fixes a rather esoteric bug. pycdf accepts writing of "raw" values, most commonly converted Epoch values rather than datetime. With EPOCH16, each value in the CDF requires two numbers on the input, picking up an extra axis of length 2 (in numpy parlance). Most of this is handled properly but, in writing to an attribute, the extra axis wasn't appropriately handled and twice as much data was written.

This fixes the bug. The new test case should be a pretty good illustration of the problem.
