### PR TITLE
pycdf istp check enhancements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ pycdf
  - Newly-public method nelems to get number of elements in zVar
  - Fix assignment of "raw" values to EPOCH16 Attribute
  - Fix "minimum value" calculation for TT2000 types
+ - istp.VariableChecks adds check for VALID/SCALE MIN/MAX Entry types
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ pycdf
  - Fix assignment of "raw" values to EPOCH16 Attribute
  - Fix "minimum value" calculation for TT2000 types
  - istp.VariableChecks adds check for VALID/SCALE MIN/MAX Entry types
+ - istp.VariableChecks adds check for DELTA attributes
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ pycdf
  - VarCopy objects now carry information to help reproduce original
  - Newly-public method nelems to get number of elements in zVar
  - Fix assignment of "raw" values to EPOCH16 Attribute
+ - Fix "minimum value" calculation for TT2000 types
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1186,7 +1186,8 @@ class Library(object):
                 datetime.datetime(9999, 12, 31, 23, 59, 59))
         elif cdftype == spacepy.pycdf.const.CDF_TIME_TT2000.value:
             inf = numpy.iinfo(numpy.int64)
-            return (self.tt2000_to_datetime(inf.min),
+            #Using actual min results in invalid/fill value
+            return (self.tt2000_to_datetime(inf.min + 2),
                     self.tt2000_to_datetime(inf.max))
         dtype = spacepy.pycdf.lib.numpytypedict.get(cdftype, None)
         if dtype is None:

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -305,6 +305,12 @@ class VariableChecks(object):
         for which in (whichmin, whichmax):
             if not which in v.attrs:
                 continue
+            if v.attrs.type(which) != v.type():
+                errs.append(
+                    '{} type {} does not match variable type {}.'.format(
+                        which,
+                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
+                        spacepy.pycdf.lib.cdftypenames[v.type()]))
             attrval = v.attrs[which]
             multidim = bool(numpy.shape(attrval)) #multi-dimensional
             if multidim: #Compare shapes, require only 1D var

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -599,6 +599,15 @@ class NoCDF(unittest.TestCase):
             self.assertEqual(t, cdf._Hyperslice.types(s),
                              msg='Input ' + str(s))
 
+    @unittest.skipIf(cdf.lib.version[0] < 3,
+                     "Not supported with CDF library < 3")
+    def testMinMaxTT2000(self):
+        """Get min/max values for TT2000 types"""
+        minval, maxval = cdf.lib.get_minmax(const.CDF_TIME_TT2000)
+        #Make sure the minimum isn't just plain invalid
+        self.assertTrue(minval < datetime.datetime(9999, 1, 1))
+
+
 class MakeCDF(unittest.TestCase):
     def setUp(self):
         self.testdir = tempfile.mkdtemp()

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -847,6 +847,20 @@ class MakeCDF(unittest.TestCase):
             self.assertEqual(const.CDF_INT2.value,
                              f['three'].attrs.type('foo'))
 
+    def testEntryType4(self):
+        """Another case where Entry type should match variable type"""
+        with cdf.CDF(self.testfspec, create=True) as f:
+            v = f.new('newvar', data=[1, 2, 3])
+            v.attrs['foo'] = 5
+            self.assertEqual(v.type(), v.attrs.type('foo'))
+
+    def testEntryType4MultiElements(self):
+        """Entry with multiple elements, type should match variable type"""
+        with cdf.CDF(self.testfspec, create=True) as f:
+            v = f.new('newvar', data=[1, 2, 3])
+            v.attrs['foo'] = [5, 3]
+            self.assertEqual(v.type(), v.attrs.type('foo'))
+
     def testEmptyNRV(self):
         """Read an empty NRV variable, should be empty"""
         #This is strictly a READ test, but creating a new CDF and
@@ -3158,6 +3172,18 @@ class ChangeAttr(ChangeCDFBase):
         self.assertEqual(attrs['new_attr'], 'abc')
         self.assertEqual(const.CDF_CHAR.value,
                          attrs.type('new_attr'))
+
+    def testzEntryTypeGuessing(self):
+        """Guess the type of a zEntry"""
+        v = self.cdf.new('newvar', data=[1, 2, 3])
+        v.attrs['foo'] = 5
+        self.assertEqual(v.type(), v.attrs.type('foo'))
+
+    def testzEntryTypeGuessingMultiElements(self):
+        """Guess the type of a zEntry with mulitple elements"""
+        v = self.cdf.new('newvar', data=[1, 2, 3])
+        v.attrs['foo'] = [5, 3]
+        self.assertEqual(v.type(), v.attrs.type('foo'))
 
     def testgAttrNewEntry(self):
         """Create a new gEntry using Attr.new()"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -46,6 +46,31 @@ class VariablesTests(ISTPTestsBase):
         self.cdf['var2'] = [1, 2, 3]
         self.assertEqual(
             0, len(spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])))
+        self.cdf['var1'].attrs['DELTA_PLUS_VAR'] = 'foobar'
+        errs = spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])
+        self.assertEqual(1, len(errs))
+        self.assertEqual('DELTA_PLUS_VAR variable foobar missing', errs[0])
+
+    def testDeltas(self):
+        """DELTA variables"""
+        self.cdf['var1'] = [1, 2, 3]
+        self.cdf['var1'].attrs['DELTA_PLUS_VAR'] = 'var2'
+        self.cdf['var2'] = [1., 1, 1]
+        errs = spacepy.pycdf.istp.VariableChecks.deltas(self.cdf['var1'])
+        self.assertEqual(1, len(errs))
+        self.assertEqual([
+            'DELTA_PLUS_VAR type CDF_FLOAT does not match variable type '
+            'CDF_BYTE.'], errs)
+        del self.cdf['var2']
+        self.cdf['var2'] = [1, 1, 1]
+        self.cdf['var1'].attrs['UNITS'] = 'smoots'
+        errs = spacepy.pycdf.istp.VariableChecks.deltas(self.cdf['var1'])
+        self.assertEqual(1, len(errs))
+        self.assertEqual([
+            'DELTA_PLUS_VAR units do not match variable units.'], errs)
+        self.cdf['var2'].attrs['UNITS'] = 'smoots'
+        errs = spacepy.pycdf.istp.VariableChecks.deltas(self.cdf['var1'])
+        self.assertEqual(0, len(errs))
 
     def testValidRangeDimensioned(self):
         """Validmin/validmax with multiple elements"""


### PR DESCRIPTION
This PR makes a few enhancements to the checks in the ISTP module, and one related bugfix

- The "minimum value" calculation for TT2000 was wrong; it returned fill. This is fixed.
- Checks for VALID/SCALE MIN/MAX now check that the type is the same as the variable type (CDAWeb specifically asked for this in some files I was submitting.)
- References to DELTA variables are now checked for existence, match of variable type, and match of units.