### PR TITLE
pycdf.istp.VarBundle: py3k fix for complicated variable-conflict test

### DIFF
--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1651,10 +1651,13 @@ class VarBundle(object):
                 #Check for variable renaming from the input to output
                 newval = namemap.get(oldval, oldval)
                 if preexist:
-                    if newvar.attrs[a] != newval:
+                    existingval = newvar.attrs[a]
+                    if str is not bytes and isinstance(existingval, bytes):
+                        existingval = existingval.decode('ascii')
+                    if existingval != newval:
                         raise RuntimeError(
                             'Incompatible {} already exists in output.'
-                            .format(outvar.name()))
+                            .format(newvar.name()))
                 else:
                     newvar.attrs[a] = newval
             else:
@@ -1664,7 +1667,7 @@ class VarBundle(object):
                     if a in newvar.attrs:
                         raise RuntimeError(
                             'Incompatible {} already exists in output.'
-                            .format(outvar.name()))
+                            .format(newvar.name()))
                 else:
                     del newvar.attrs[a]
 

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1182,6 +1182,15 @@ class VarBundleChecksEPILo(VarBundleChecksBase):
             self.assertFalse(v in self.outcdf)
             self.assertFalse(v + '_TS' in self.outcdf)
 
+    def testConflictingEpoch(self):
+        """Regression test for complicated name conflict"""
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['H_CountRate_ChanT'])
+        bundle.sum(1).slice(2, 1).output(self.outcdf, suffix='_SP')
+        #Still summed on 1!
+        bundle.slice(2, 18, 32).sum(2).output(self.outcdf, suffix='_TS')
+        self.assertIn('H_CountRate_ChanT_SP', self.outcdf)
+        self.assertIn('H_CountRate_ChanT_TS', self.outcdf)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I can reproduce this but it's hard to describe. When using a single source variable and slicing it two different ways for the output, VarBundle is supposed to detect when a variable needs to be renamed and when it conflicts. In this particular case (which might be connected to the fact that one of the dependencies depends on something else), on Python 3 it erroneously thinks that the Epochs conflict between the two output variables even when there's no slicing on the record dimension.

The path that gets there is complicated but the cause is simple: bytes and strings don't compare equal, so it has to be decoded.

EDIT: To be explicit, this PR fixes the problem. (As well as testing for it.)