### PR TITLE
pycdf.istp: Checks for null string Entries in attributes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ pycdf
  - Fix "minimum value" calculation for TT2000 types
  - istp.VariableChecks adds check for VALID/SCALE MIN/MAX Entry types
  - istp.VariableChecks adds check for DELTA attributes
+ - istp.VariableChecks and FileChecks add check for empty attribute Entries
  - istp.VarBundle class to copy variables, slices, and depends between CDFs
 
 Changes in Version 0.2.1 (2019-10-02)

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -39,6 +39,15 @@ class ISTPTestsBase(unittest.TestCase):
 class VariablesTests(ISTPTestsBase):
     """Tests of variable-checking functions"""
 
+    def testEmptyEntries(self):
+        """Are there any CHAR entries of empty string"""
+        self.cdf['var1'] = [1, 2, 3]
+        self.cdf['var1'].attrs['attribute'] = ''
+        errs = spacepy.pycdf.istp.VariableChecks.empty_entry(self.cdf['var1'])
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Empty CHAR entry for attribute attribute.',
+                         errs[0])
+
     def testDepends(self):
         """Dependencies, valid and not"""
         self.cdf['var1'] = [1, 2, 3]
@@ -507,6 +516,15 @@ class FileTests(ISTPTestsBase):
         errs = spacepy.pycdf.istp.FileChecks.all(self.cdf)
         self.assertEqual(1, len(errs))
         self.assertEqual('var1: DEPEND_0 variable var2 missing', errs[0])
+
+    def testEmptyEntries(self):
+        """Are there any CHAR gEntries of empty string"""
+        self.cdf['var1'] = [1, 2, 3]
+        self.cdf.attrs['attribute'] = ''
+        errs = spacepy.pycdf.istp.FileChecks.empty_entry(self.cdf)
+        self.assertEqual(1, len(errs))
+        self.assertEqual('Empty CHAR entry 0 for attribute attribute.',
+                         errs[0])
 
     def testFilename(self):
         """Compare filename to global attrs"""


### PR DESCRIPTION
CDAWeb has asked that character entries not have the null string, e.g. if something is truly unitless it should have a single space for UNITS. This PR adds checks for that in the global and variable attributes.
