### PR TITLE
toolbox: handle object arrays in pmm (closes #183)

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1624,7 +1624,7 @@ def pmm(a, *b):
         ans = [[ np.min(a[ind]), np.max(a[ind]) ]]
     except TypeError:
         a_tmp = np.asarray(a)
-        if np.issubdtype(a_tmp.dtype, 'S') or np.issubdtype(a_tmp.dtype, 'U'):
+        if a_tmp.dtype.type in [np.dtype('S').type, np.dtype('U').type]:
             a_tmp = np.require(a_tmp, dtype=object)
         ans = [[ np.min(a_tmp[ind]), np.max(a_tmp[ind]) ]]
     for val in b:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1624,6 +1624,8 @@ def pmm(a, *b):
         ans = [[ np.min(a[ind]), np.max(a[ind]) ]]
     except TypeError:
         a_tmp = np.asarray(a)
+        if np.issubdtype(a_tmp.dtype, 'S') or np.issubdtype(a_tmp.dtype, 'U'):
+            a_tmp = np.require(a_tmp, dtype=object)
         ans = [[ np.min(a_tmp[ind]), np.max(a_tmp[ind]) ]]
     for val in b:
         ind = np.isfinite(val)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1619,7 +1619,7 @@ def pmm(a, *b):
     except TypeError:
         ind = np.arange(len(a)).astype(int)
         import warnings
-        warnings.warn('Check for finite values failed', RuntimeWarning)
+        warnings.warn('pmm: Unable to exclude non-finite values, results may be incorrect', RuntimeWarning)
     try:
         ans = [[ np.min(a[ind]), np.max(a[ind]) ]]
     except TypeError:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1591,16 +1591,14 @@ def rad2mlt(rad, midnight=False):
     mlt_arr=rad_arr*(12/np.pi) + 12
     return mlt_arr
 
-def pmm(a, *b):
+def pmm(*args):
     """
     print min and max of input arrays
 
     Parameters
     ==========
-    a : numpy array
-        input array
-    b : list arguments
-        some additional number of arrays
+    a : array-like
+        arbitrary number of input arrays (or lists)
 
     Returns
     =======
@@ -1614,26 +1612,21 @@ def pmm(a, *b):
     >>> tb.pmm(arange(10), arange(10)+3)
     [[0, 9], [3, 12]]
     """
-    try:
-        ind = np.isfinite(a)
-    except TypeError:
-        ind = np.arange(len(a)).astype(int)
-        import warnings
-        warnings.warn('pmm: Unable to exclude non-finite values, results may be incorrect', RuntimeWarning)
-    try:
-        ans = [[ np.min(a[ind]), np.max(a[ind]) ]]
-    except TypeError:
-        a_tmp = np.asarray(a)
-        if a_tmp.dtype.type in [np.dtype('S').type, np.dtype('U').type]:
-            a_tmp = np.require(a_tmp, dtype=object)
-        ans = [[ np.min(a_tmp[ind]), np.max(a_tmp[ind]) ]]
-    for val in b:
-        ind = np.isfinite(val)
+    ans = []
+    for a in args:
         try:
-            ans.append( [np.min(val[ind]), np.max(val[ind])] )
+            ind = np.isfinite(a)
         except TypeError:
-            val_tmp = np.asarray(val)
-            ans.append( [np.min(val_tmp[ind]), np.max(val_tmp[ind])] )
+            ind = np.arange(len(a)).astype(int)
+            import warnings
+            warnings.warn('pmm: Unable to exclude non-finite values, results may be incorrect', RuntimeWarning)
+        try:
+            ans.append([np.min(a[ind]), np.max(a[ind])])
+        except TypeError:
+            a_tmp = np.asarray(a)
+            if a_tmp.dtype.type in [np.dtype('S').type, np.dtype('U').type]:
+                a_tmp = np.require(a_tmp, dtype=object)
+            ans.append([np.min(a_tmp[ind]), np.max(a_tmp[ind])])
     return ans
 
 def getNamedPath(name):

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1614,7 +1614,12 @@ def pmm(a, *b):
     >>> tb.pmm(arange(10), arange(10)+3)
     [[0, 9], [3, 12]]
     """
-    ind = np.isfinite(a)
+    try:
+        ind = np.isfinite(a)
+    except TypeError:
+        ind = np.arange(len(a)).astype(int)
+        import warnings
+        warnings.warn('Check for finite values failed', RuntimeWarning)
     try:
         ans = [[ np.min(a[ind]), np.max(a[ind]) ]]
     except TypeError:

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -421,6 +421,16 @@ class SimpleFunctionTests(unittest.TestCase):
             self.assertEqual(val, tb.pmm(data[i]))
         self.assertEqual([[1, 6], [5, 24], [6.0, 67.340000000000003]], tb.pmm(*data) )
 
+    def test_pmm_object(self):
+        """Test pmm handling of object arrays"""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            data = [array([5,9,23,24,6]).astype(object),
+                    [datetime.datetime(2000, 3, 1, 0, 1), datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1)] ]
+            real_ans = [[[5, 24]], [[datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1, 0, 1)]]]
+            for i, val in enumerate(real_ans):
+                self.assertEqual(val, tb.pmm(data[i]))
+
     def test_rad2mlt(self):
         """rad2mlt should give known answers (regression)"""
         real_ans = array([ -6.        ,  -4.10526316,  -2.21052632,  -0.31578947,

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -426,8 +426,13 @@ class SimpleFunctionTests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
             data = [array([5,9,23,24,6]).astype(object),
-                    [datetime.datetime(2000, 3, 1, 0, 1), datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1)] ]
-            real_ans = [[[5, 24]], [[datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1, 0, 1)]]]
+                    [datetime.datetime(2000, 3, 1, 0, 1), datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1)],
+                    numpy.array(['foo', 'bar', 'baz'], dtype=object),
+                    ]
+            real_ans = [[[5, 24]],
+                        [[datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1, 0, 1)]],
+                        [['bar', 'foo']],
+            ]
             for i, val in enumerate(real_ans):
                 self.assertEqual(val, tb.pmm(data[i]))
 


### PR DESCRIPTION
Closes #183

This PR provides:
- a test for the failures raised in issue #183
- a trap/workaround for the failure mode (objects can't be determined as finite or not)
- a warning on hitting the trap so the user knows that non-finite values may be present

Any suggestions for wording on the warning? Or other implementation issues?
