### PR TITLE
pycdf.concatCDF: function to concatenate data from several CDFs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Changes in Version 0.2.2 (2019-xx-xx)
 pycdf
  - VarCopy objects now carry information to help reproduce original
  - Newly-public method nelems to get number of elements in zVar
+ - New function concatCDF to read data from multiple CDFs
  - Fix assignment of "raw" values to EPOCH16 Attribute
  - Fix "minimum value" calculation for TT2000 types
  - istp.VariableChecks adds check for VALID/SCALE MIN/MAX Entry types

--- a/Doc/source/pycdf.rst
+++ b/Doc/source/pycdf.rst
@@ -15,8 +15,10 @@ Contents
     - `Modify a CDF`_
     - `Non record-varying`_
     - `Slicing and indexing`_
-- `Class reference`_
+- `Classes`_
+- `Functions`_
 - `Submodules`_
+- `Data`_
 
 Quickstart
 ----------
@@ -237,8 +239,8 @@ available in the :mod:`~spacepy.pycdf.const` module.
 The underlying C library is represented by the :attr:`~spacepy.pycdf.lib`
 variable.
 
-Class reference
----------------
+Classes
+-------
 
 .. autosummary::
     :template: clean_class.rst
@@ -260,16 +262,14 @@ Class reference
     CDFWarning
     EpochError
 
-.. attribute:: lib
+Functions
+---------
 
-    Module global :class:`Library` object.
+.. autosummary::
+    :template: clean_function.rst
+    :toctree: autosummary
 
-    Initalized at :mod:`~spacepy.pycdf` load time so all classes have ready
-    access to the CDF library and a common state. E.g:
-
-    >>> from spacepy import pycdf
-    >>> pycdf.lib.version
-        (3, 3, 0, ' ')
+    concatCDF
 
 Submodules
 ----------
@@ -280,3 +280,17 @@ Submodules
 
     const
     istp
+
+Data
+----
+
+.. attribute:: lib
+
+    Module global :class:`Library` object.
+
+    Initalized at :mod:`~spacepy.pycdf` load time so all classes have ready
+    access to the CDF library and a common state. E.g:
+
+    >>> from spacepy import pycdf
+    >>> pycdf.lib.version
+        (3, 3, 0, ' ')


### PR DESCRIPTION
This adds a function to pycdf to read data from several CDFs and present it as if it were from one (essentially like a VarCopy from multiple CDFs). It also rearranges the pycdf docs a little bit, since this is the first top-level function. This would be part of the #233 fix.

Definitely open to suggestions on if this should be named something else or put somewhere else.