### PR TITLE
Get OMNI2 data from CDAWeb

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ pycdf
  - istp.VariableChecks adds check for DELTA attributes
  - istp.VariableChecks and FileChecks add check for empty attribute Entries
  - istp.VarBundle class to copy variables, slices, and depends between CDFs
+ - istp.nanfill function to replace fill values with NaN
 pybats
  - Updated gitm.GitmBin reader to fix failures in Python 3.x.
 toolbox

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@ pycdf
  - istp.VarBundle class to copy variables, slices, and depends between CDFs
 pybats
  - Updated gitm.GitmBin reader to fix failures in Python 3.x.
+toolbox
+ - New function get_url to retrieve data from a URL
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ pybats
  - Updated gitm.GitmBin reader to fix failures in Python 3.x.
 toolbox
  - New function get_url to retrieve data from a URL
+ - Change update to retrieve OMNI2 data from SPDF not ViRBO
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/Doc/source/toolbox.rst
+++ b/Doc/source/toolbox.rst
@@ -82,6 +82,7 @@ System tools
     :toctree: autosummary
 
     do_with_timeout
+    get_url
     loadpickle
     progressbar
     query_yes_no

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -237,7 +237,7 @@ def _read_config(rcfile):
     defaults = {'enable_deprecation_warning': str(True),
                 'ncpus': str(multiprocessing.cpu_count()),
                 'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip',
-                'omni2_url': 'http://virbo.org/ftp/OMNI/OMNI2/merged/latest/OMNI_OMNI2-latest.cdf.zip',
+                'omni2_url': 'https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hourly/',
                 'leapsec_url': 'http://maia.usno.navy.mil/ser7/tai-utc.dat',
                 'psddata_url': 'http://spacepy.lanl.gov/repository/psd_dat.sqlite',
                 'support_notice': str(True),

--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -82,7 +82,7 @@ def get_omni(ticks, dbase='QDhourly', **kwargs):
         time values for desired output
 
     dbase : str (optional)
-        Select data source, options are 'QDhourly', 'OMNI2', 'Mergedhourly'
+        Select data source, options are 'QDhourly', 'OMNI2hourly', 'Mergedhourly'
         Note - Custom data sources can be specified in the spacepy config file
         as described in the module documentation.
 

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -909,6 +909,14 @@ def get_url(url, outfile=None, reporthook=None):
     See Also
     ========
     progressbar
+
+    Notes
+    =====
+    This function honors proxy settings as described in
+    :func:`urllib.request.getproxies`. Cryptic error messages (such as
+    ``Network is unreachable``) may indicate that proxy settings
+    should be defined as appropriate for your environment (e.g. with
+    ``HTTP_PROXY`` or ``HTTPS_PROXY`` environment variables).
     """
     r = urllib.request.Request(url)
     if spacepy.config.get('user_agent', ''):
@@ -942,6 +950,9 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
     """
     Download and update local database for omni, leapsecs etc
 
+    Web access is via :func:`get_url`; notes there may be helpful in
+    debugging errors.
+
     Parameters
     ==========
     all : boolean (optional)
@@ -959,6 +970,10 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
     =======
     out : string
         data directory where things are saved
+
+    See Also
+    ========
+    get_url
 
     Examples
     ========

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -753,6 +753,7 @@ def _get_cdaweb_omni2(omni2url=None):
         if there are no new data.
     """
     import spacepy.pycdf
+    import spacepy.pycdf.istp
     if omni2url is None:
         omni2url = spacepy.config['omni2_url']
     #Find all the files to download
@@ -874,6 +875,14 @@ def _get_cdaweb_omni2(omni2url=None):
     #The CDAWeb Epochs are erroneously tagged as START of collection,
     #not midpoint. So fix that
     data['Epoch'] = data['Epoch'] + datetime.timedelta(minutes=30)
+    #Castings to match ViRBO: everything is an int, and fill turns to NaN
+    for k, v in data.items():
+        if v.dtype == np.object: #Skip epoch
+            continue
+        if v.dtype == np.int32:
+            data[k] = v.astype(np.float32)
+            v = data[k]
+        spacepy.pycdf.istp.nanfill(v)
     return data
 
 

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -753,10 +753,11 @@ def _get_cdaweb_omni2(omni2url=None):
         if there are no new data.
     """
     import spacepy.pycdf
-    print("Retrieving OMNI2 files ...")
     if omni2url is None:
         omni2url = spacepy.config['omni2_url']
     #Find all the files to download
+    print("Finding OMNI2 files to download ...")
+    progressbar(0, 1, 1, text='Listing files')
     data = get_url(omni2url)
     if str is not bytes:
         data = data.decode('utf-8')
@@ -765,7 +766,7 @@ def _get_cdaweb_omni2(omni2url=None):
     p.close()
     yearlist = [y[0:4] for y in p.links if re.match(r'\d{4}/', y)]
     downloadme = {}
-    for y in yearlist:
+    for i, y in enumerate(yearlist):
         yearurl = '{}{}/'.format(omni2url, y)
         data = get_url(yearurl)
         if str is not bytes:
@@ -777,6 +778,8 @@ def _get_cdaweb_omni2(omni2url=None):
             if not re.match(r'omni2_h0_mrg1hr_\d{8}_v\d+\.cdf', f):
                 continue
             downloadme[f] = yearurl + f
+        progressbar(i + 1, 1, len(yearlist), text='Listing files')
+    print("Retrieving OMNI2 files ...")
     filenames = sorted(list(downloadme.keys()))
     datadir = os.path.join(spacepy.DOT_FLN, 'data', 'omni2cdfs')
     if not os.path.exists(datadir):

--- a/tests/integration_all.py
+++ b/tests/integration_all.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+"""Integration tests for SpacePy
+
+These are heavier tests than the unit tests that may e.g. temporarily
+affect the state of the machine, rather than the fully isolated unit
+tests.
+
+Copyright 2019 SpacePy contributors
+"""
+
+
+import unittest
+
+from integration_toolbox import *
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration_all.py
+++ b/tests/integration_all.py
@@ -12,6 +12,7 @@ Copyright 2019 SpacePy contributors
 
 import unittest
 
+from integration_omni import *
 from integration_toolbox import *
 
 

--- a/tests/integration_omni.py
+++ b/tests/integration_omni.py
@@ -26,7 +26,7 @@ class OMNIIntegration(unittest.TestCase):
         expected = spacepy.dmarray([0.305, 0.295, numpy.nan, numpy.nan, 0.295])
         #There is a very small difference resulting from float/double mismatch
         numpy.testing.assert_array_almost_equal(
-            omni['Proton_flux_gt_10_MeV'], expected, decimal=15)
+            omni['Proton_flux_gt_10_MeV'], expected, decimal=8)
 
 
 if __name__ == "__main__":

--- a/tests/integration_omni.py
+++ b/tests/integration_omni.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+"""Integration tests for omni
+
+Copyright 2019 SpacePy contributors
+"""
+
+import unittest
+
+import numpy.testing
+import spacepy
+import spacepy.omni
+import spacepy.time
+
+
+class OMNIIntegration(unittest.TestCase):
+    """Tests of OMNI data assuming up-to-date database"""
+
+    def testFillValues(self):
+        """Test that expected fill values are nan"""
+        #This is a check that, after reading the CDF from SPDF, fill is
+        #replaced with nan to match usage in ViRBO
+        #In order to be accurate, it should be run after an update()
+        tt = spacepy.time.tickrange('2004-12-02T12:00:00', '2004-12-03', 3./24)
+        omni = spacepy.omni.get_omni(tt, dbase='OMNI2hourly')
+        expected = spacepy.dmarray([0.305, 0.295, numpy.nan, numpy.nan, 0.295])
+        #There is a very small difference resulting from float/double mismatch
+        numpy.testing.assert_array_almost_equal(
+            omni['Proton_flux_gt_10_MeV'], expected, decimal=15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -93,6 +93,19 @@ class WebGettingIntegration(unittest.TestCase):
         self.assertEqual(
             b"This is a test\n", data)
 
+    def testGetUrlToFileCached(self):
+        """Call get_url, write to file with cache"""
+        with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
+            f.write('This is a test\n')
+        outfile = os.path.join(self.td, 'output.txt')
+        data = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port),
+            outfile=outfile)
+        data = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port),
+            outfile=outfile, cached=True)
+        self.assertTrue(data is None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -72,8 +72,8 @@ class WebGettingIntegration(unittest.TestCase):
 
     def testGetUrlReturn(self):
         """Call get_url, return data directly"""
-        with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
-            f.write('This is a test\n')
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'This is a test\n')
         data = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port))
         self.assertEqual(
@@ -81,8 +81,8 @@ class WebGettingIntegration(unittest.TestCase):
 
     def testGetUrlToFile(self):
         """Call get_url, write to file"""
-        with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
-            f.write('This is a test\n')
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'This is a test\n')
         #Set its modification time to the distant past
         os.utime(os.path.join(self.td, 'foo.txt'),
                  (0, 0))
@@ -100,8 +100,8 @@ class WebGettingIntegration(unittest.TestCase):
 
     def testGetUrlToFileCached(self):
         """Call get_url, write to file with cache"""
-        with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
-            f.write('This is a test\n')
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'This is a test\n')
         outfile = os.path.join(self.td, 'output.txt')
         data = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port),

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -83,6 +83,9 @@ class WebGettingIntegration(unittest.TestCase):
         """Call get_url, write to file"""
         with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
             f.write('This is a test\n')
+        #Set its modification time to the distant past
+        os.utime(os.path.join(self.td, 'foo.txt'),
+                 (0, 0))
         data = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port),
             outfile=os.path.join(self.td, 'output.txt'))
@@ -92,6 +95,8 @@ class WebGettingIntegration(unittest.TestCase):
             data = f.read()
         self.assertEqual(
             b"This is a test\n", data)
+        self.assertEqual(
+            0, os.path.getmtime(os.path.join(self.td, 'output.txt')))
 
     def testGetUrlToFileCached(self):
         """Call get_url, write to file with cache"""

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+"""Integration tests for toolbox
+
+Copyright 2019 SpacePy contributors
+"""
+
+try:
+    import http.server
+    requesthandlerclass = http.server.SimpleHTTPRequestHandler
+except ImportError: #py2k
+    import SimpleHTTPServer
+    requesthandlerclass = SimpleHTTPServer.SimpleHTTPRequestHandler
+    import SocketServer
+import os
+import shutil
+import socket
+import tempfile
+import threading
+import unittest
+
+import spacepy.toolbox
+
+
+class SilentLoggingHTTPRequestHandler(requesthandlerclass):
+    """HTTP request handler that doesn't log to stderr"""
+    def log_message(self, *args):
+        """Suppress the message"""
+        pass
+
+
+class WebGettingIntegration(unittest.TestCase):
+    """Tests of functions that get data from the web"""
+
+    def setUp(self):
+        """Set up an HTTP server on a test directory"""
+        self.td = tempfile.mkdtemp()
+        """Root directory for HTTP server"""
+        self.oldwd = os.getcwd()
+        """Working directory before running this test"""
+        #The server handles requests from the current directory
+        try: #py3k
+            serverclass = http.server.HTTPServer
+        except NameError: #Py2k
+            serverclass = SocketServer.TCPServer
+        os.chdir(self.td)
+        for port in range(8080, 8089):
+            try:
+                self.server = serverclass(
+                    ('localhost', port), SilentLoggingHTTPRequestHandler)
+            except (OSError, socket.error): #Port in use, try another
+                continue
+            self.port = port
+            break
+        else:
+            raise RuntimeError('Unable to find a free port for http server.')
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.setDaemon(True)
+        self.server_thread.start()
+
+    def tearDown(self):
+        """Quit HTTP server and remove test directory"""
+        self.server.shutdown()
+        self.server_thread.join()
+        self.server.server_close()
+        #This is a bit redundant, and doesn't necessarily do the job:
+        #the socket will stay in WAIT for awhile regardless, seems to be
+        #worse on Python 2
+        self.server.socket.close()
+        os.chdir(self.oldwd) #Back to old working directory
+        shutil.rmtree(self.td)
+
+    def testGetUrlReturn(self):
+        """Call get_url, return data directly"""
+        with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
+            f.write('This is a test\n')
+        data = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port))
+        self.assertEqual(
+            b"This is a test\n", data)
+
+    def testGetUrlToFile(self):
+        """Call get_url, write to file"""
+        with open(os.path.join(self.td, 'foo.txt'), 'wt') as f:
+            f.write('This is a test\n')
+        data = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port),
+            outfile=os.path.join(self.td, 'output.txt'))
+        self.assertEqual(
+            b"This is a test\n", data)
+        with open(os.path.join(self.td, 'output.txt'), 'rb') as f:
+            data = f.read()
+        self.assertEqual(
+            b"This is a test\n", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR is a step towards closing #233:

- Completely reworks our downloading in toolbox.update to avoid deprecations. Ultimately this should be replaced by a more robust general downloading infrastructure.
- Switches to the 6-month OMNI2 CDFs from CDAWeb/SPDF instead of the combined from ViRBO
- Fixes a little problem in the omni documentation in specifying OMNI2 database.
