### PR TITLE
Remove case sensitivity of coordinate type check

### DIFF
--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -94,6 +94,9 @@ class Coords(object):
         else:
             self.data = np.array(data)
 
+        dtype = dtype.upper()
+        carsph = carsph.lower()
+
         assert dtype in list(typedict.keys()), 'This dtype='+dtype+' is not supported. Only '+str(list(typedict.keys()))
         assert carsph in ['car','sph'], 'This carsph='+str(carsph)+' is not supported. Only "car" or "sph"'
         onerawarn = """Coordinate conversion to an ONERA-compatible system is required for any ONERA calls."""


### PR DESCRIPTION
Currently the type check in spacepy.coordinate.py is case sensitive. This means that the following coordinate definitions are valid:
```python
from spacepy.coordinates import Coords

p1 = Coords([1,2,3],'GEO','car')
p2 = Coords([4,5,6],'GSM','sph')
```
but the following produce an error
```python
p1 = Coords([1,2,3],'geo','car')
p2 = Coords([4,5,6],'GSM','SPH')
```
which, as far as I can tell, is an arbitrary restriction. By forcing `dtype` to upper case and `carsph` to lowercase early within in `Coord` constructor, this error is avoided without affecting the functionality of the class. Following this change, all of the above examples are valid.

I realise this is a cosmetic change, however it represents a small QoL improvement for those of us who can never remember which way around the cases go.
