### PR TITLE
VarBundle inspection functions

### DIFF
--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1200,6 +1200,12 @@ class VarBundle(object):
                 continue
             thisname = attrs[a]
             if thisname in self._varinfo: #Already handled
+                if self._varinfo[thisname]['sortorder'] == 3 \
+                   and a.startswith('DEPEND_'):
+                    #Processed before as a LABL, but also is a DEPEND.
+                    #Technically ISTP violation, but have the DEPEND take
+                    #priority
+                    self._varinfo[thisname]['sortorder'] = 1
                 continue
             thisvar = self.cdf[thisname]
             #Dimension of main var that corresponds to this var

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1801,10 +1801,6 @@ class VarBundle(object):
             vinfo = self._varinfo[vname]
             #Dim of main var that depends on this (None if main var or delta)
             maindim = vinfo.get('thisdim', None)
-            if maindim is not None and max(
-                    self._degenerate[maindim],
-                    self._summed[maindim], self._mean[maindim]):
-                continue #Variable went away, don't copy it
             #Degeneracy of dimensions in this variable's "frame"
             degen = [self._degenerate[d] for d in vinfo['dims']]
             #And whether the dim was summed
@@ -1817,7 +1813,6 @@ class VarBundle(object):
             #Dimension size/variance for original variable
             #(0 index is CDF dimension 1)
             dv = invar.dv()
-            dims = invar.shape[int(invar.rv()):] #starting from dim 1
             rv = invar.rv() #and record variance
             #Scrub degenerate dimensions from the post-indexing
             #(record is never degenerate)

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1039,14 +1039,14 @@ class VarBundle(object):
     >>> outfile = spacepy.pycdf.CDF('output.cdf', create=True)
     >>> b.slice(1, 2, single=True).output(outfile)
     <VarBundle:
-    FPDU CDF_FLOAT [3228, 72]
-    Epoch_Ion CDF_EPOCH [3228]
-        Epoch_Ion_DELTA CDF_REAL4 [3228]
-    PITCH_ANGLE CDF_FLOAT ---
-        Pitch_LABL CDF_CHAR*5 ---
-    HOPE_ENERGY_Ion CDF_FLOAT [3228, 72]
-        ENERGY_Ion_DELTA CDF_FLOAT [3228, 72]
-        Energy_LABL CDF_CHAR*3 [72] NRV
+    FPDU: CDF_FLOAT [3228, 72]
+    Epoch_Ion: CDF_EPOCH [3228]
+        Epoch_Ion_DELTA: CDF_REAL4 [3228]
+    PITCH_ANGLE: CDF_FLOAT ---
+        Pitch_LABL: CDF_CHAR*5 ---
+    HOPE_ENERGY_Ion: CDF_FLOAT [3228, 72]
+        ENERGY_Ion_DELTA: CDF_FLOAT [3228, 72]
+        Energy_LABL: CDF_CHAR*3 [72] NRV
     >
     >>> outfile['FPDU']
     <Var:
@@ -1986,7 +1986,7 @@ class VarBundle(object):
             Brief string description of the bundle.
         """
         return '\n'.join([
-            '{}{} {} {}{}'.format(
+            '{}{}: {} {}{}'.format(
                 ' ' * 4 if self._varinfo[vname]['sortorder'] > 1 else '',
                 vname,
                 str(self.cdf[vname]).split(' ')[0], #Grab type from Var str

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1753,7 +1753,7 @@ class VarBundle(object):
         if not rv: #Remove record dimension
             slices = slices[1:]
         #Make a fake array the size of the input, and slice it
-        return numpy.empty(shape=shape)[slices].shape
+        return numpy.empty(shape=shape)[tuple(slices)].shape
 
     def variables(self):
         """Description of variable output from the bundle

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1780,8 +1780,10 @@ class VarBundle(object):
         >>> b.slice(1, 2, single=True).variables()
         [[('FPDU', (100, 72))],
          [('Epoch_Ion', (100,)), ('Epoch_Ion_DELTA', (100,))],
-         [('PITCH_ANGLE', None)],
-         [('HOPE_ENERGY_Ion', (72,)), ('ENERGY_Ion_DELTA', (72,))]]
+         [('PITCH_ANGLE', None), ('Pitch_LABL', None],
+         [('HOPE_ENERGY_Ion', (100, 72)),
+          ('ENERGY_Ion_DELTA', (100, 72)),
+          ('Energy_LABL', (72,))]]
         """
         #List of every variable in each dimension
         v_by_dim = functools.reduce(

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1462,36 +1462,12 @@ class VarBundle(object):
         list of str
             Names of variables to include in the output.
         """
-        tokeep = [self.mainvar.name()]
-        #What dims of the main variable disappear?
+        #What dims of main var disappear?
         deleted = [i for i in range(len(self._degenerate))
-                   if any((self._degenerate[i],
-                           self._summed[i],
+                   if any((self._degenerate[i], self._summed[i],
                            self._mean[i]))]
-        i = 0
-        while i < len(tokeep):
-            thisvar = tokeep[i]
-            #Get dependency information for this variable
-            attrlist = self.cdf[tokeep[i]].attrs
-            attrs = { a: attrlist[a] for a in attrlist
-                     if a.startswith(('DEPEND_', 'LABL_PTR_', 'DELTA_')) }
-            deps_by_dim = collections.defaultdict(list)
-            for a in attrs:
-                depname = attrs[a]
-                if depname in tokeep:
-                    continue
-                #DELTAs do not disappear unless their variable does
-                if a in ('DELTA_PLUS_VAR', 'DELTA_MINUS_VAR'):
-                    tokeep.append(depname)
-                else:
-                    deps_by_dim[int(a.split('_')[-1])].append(depname)
-            for dim, vnames in deps_by_dim.items():
-                if self._varinfo[tokeep[i]]['dims'][dim] not in deleted:
-                    for v in vnames:
-                        if not v in tokeep: #Handles dupes WITHIN a variable too
-                            tokeep.append(v)
-            i += 1
-        return tokeep
+        return [v for v, i in self._varinfo.items()
+                if i.get('thisdim', None) not in deleted]
 
     def _same(self, newvar, invar, dv, dims, data):
         """Checks if an existing variable matches a proposed new variable

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1795,7 +1795,7 @@ class VarBundle(object):
         >>> b.slice(1, 2, single=True).variables()
         [[('FPDU', (100, 72))],
          [('Epoch_Ion', (100,)), ('Epoch_Ion_DELTA', (100,))],
-         [('PITCH_ANGLE', None), ('Pitch_LABL', None],
+         [('PITCH_ANGLE', None), ('Pitch_LABL', None)],
          [('HOPE_ENERGY_Ion', (100, 72)),
           ('ENERGY_Ion_DELTA', (100, 72)),
           ('Energy_LABL', (72,))]]

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1227,6 +1227,7 @@ class VarBundle(object):
                 self._varinfo[deltaname] \
                     = self._process_delta(thisvar, deltaname)
                 self._varinfo[deltaname]['vartype'] = 'D' #just like other deps
+                self._varinfo[deltaname]['thisdim'] = dim
         for a in ('DELTA_PLUS_VAR', 'DELTA_MINUS_VAR'): #Process DELTA vars
             if not a in attrs:
                 continue

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1038,7 +1038,7 @@ class VarBundle(object):
     >>> b = spacepy.pycdf.istp.VarBundle(infile['FPDU'])
     >>> outfile = spacepy.pycdf.CDF('output.cdf', create=True)
     >>> b.slice(1, 2, single=True).output(outfile)
-    <spacepy.pycdf.istp.VarBundle at 0xdeadbeefffff>
+    <VarBundle: FPDU Epoch_Ion Epoch_Ion_DELTA [PITCH_ANGLE] [Pitch_LABL] HOPE_ENERGY_Ion ENERGY_Ion_DELTA Energy_LABL>
     >>> outfile['FPDU']
     <Var:
     CDF_FLOAT [3228, 72]
@@ -1957,3 +1957,33 @@ class VarBundle(object):
 
             self._repoint_depend(invar, newvar, preexist, namemap, degen)
         return self
+
+    def __str__(self):
+        """String representation of the bundle
+
+        Returns a string representation of the bundle, which is all the
+        variables that are involved on the input. Variables which are
+        not included on the output are in []
+
+        Returns
+        -------
+        str
+            Brief string description of the bundle.
+        """
+        return ' '.join([
+            vname if shape is not None else '[{}]'.format(vname)
+            for dimvars in self.variables() for vname, shape in dimvars])
+
+    def __repr__(self):
+        """Representation of bundle
+
+        Cannot return anything that can be evaluated to create a copy
+        of the CDF, so this is just the informal str representation in
+        angle brackets.
+
+        Returns
+        -------
+        str
+            Informal representation of bundle contents.
+        """
+        return '<VarBundle: {}>'.format(str(self))

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1144,11 +1144,11 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
         numpy.testing.assert_allclose(
             self.outcdf['Counts_P'], expected)
 
-    def testInspectOperations(self):
+    def testOperations(self):
         """Get operations of a bundle"""
         bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
         bundle.slice(1, 1, single=True).slice(2, 0, 10).mean(2)
-        ops = bundle.inspect()['operations']
+        ops = bundle.operations()
         self.assertEqual(
             [('slice', (1, 1), {'single': True}),
              ('slice', (2, 0, 10), {}),
@@ -1157,7 +1157,7 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
         #Check fancy index
         bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
         bundle.slice(1, [5, 6])
-        ops = bundle.inspect()['operations']
+        ops = bundle.operations()
         self.assertEqual([('slice', (1, [5, 6]), {})], ops)
 
     def testSumRecord(self):
@@ -1199,11 +1199,11 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
         self.assertEqual(
             'PITCH_ANGLE', self.outcdf['Counts_P'].attrs['DEPEND_1'])
 
-    def testInspectVars(self):
+    def testVars(self):
         """Get variables of a bundle"""
         bundle = spacepy.pycdf.istp.VarBundle(self.incdf['FPDU'])
         bundle.slice(1, 1, single=True).slice(2, 0, 10)
-        variables = bundle.inspect()['vars']
+        variables = bundle.variables()
         self.assertEqual([
             [('FPDU', (100, 10))],
             [('Epoch_Ion', (100,)), ('Epoch_Ion_DELTA', (100,))],

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -653,6 +653,7 @@ class VarBundleChecksBase(unittest.TestCase):
 class VarBundleChecks(VarBundleChecksBase):
     """Checks for VarBundle class, CAMMICE sample file"""
     testfile = 'po_l1_cam_test.cdf'
+    longMessage = True
 
     def testGetVarInfo(self):
         """Get dependencies, dims, etc. for a variable"""
@@ -695,6 +696,17 @@ class VarBundleChecks(VarBundleChecksBase):
             'D', bundle._varinfo['ATC']['vartype'])
         self.assertEqual(
             'D', bundle._varinfo['SectorNumbers']['vartype'])
+        for varname, dimension in {
+                'ATC': 0,
+                'SectorNumbers': 2,
+                'SectorRateScalerNames': 3,
+                'SectorRateScalersCounts': None,
+                'SectorRateScalersCountsSigma': None,
+                'SpinNumbers': 1,
+                }.items():
+            self.assertEqual(
+                dimension, bundle._varinfo[varname].get('thisdim', None),
+                varname)
 
     def testOutputSimple(self):
         """Copy a single variable and deps with no slicing"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -824,12 +824,28 @@ class VarBundleChecks(VarBundleChecksBase):
         SectorRateScalersCounts CDF_FLOAT [18, 32, 9] NRV
             SectorRateScalersCountsSigma CDF_FLOAT [18, 32, 9] NRV
         ATC CDF_EPOCH16 ---
-            SpinNumbers CDF_CHAR*2 [18] NRV
-            SectorNumbers CDF_CHAR*2 [32] NRV
-            SectorRateScalerNames CDF_CHAR*9 [9] NRV
+        SpinNumbers CDF_CHAR*2 [18] NRV
+        SectorNumbers CDF_CHAR*2 [32] NRV
+        SectorRateScalerNames CDF_CHAR*9 [9] NRV
         """
         expected = inspect.cleandoc(expected).split('\n')
         self.assertEqual(expected, str(bundle).split('\n'))
+
+    def testCAMMICESortOrder(self):
+        """More tests of sort order"""
+        bundle = spacepy.pycdf.istp.VarBundle(
+            self.incdf['SectorRateScalersCounts'])
+        for varname, sortorder in {
+                'SectorRateScalersCounts': 0,
+                'SectorRateScalersCountsSigma': 2,
+                'ATC': 1,
+                'SpinNumbers': 1,
+                'SectorNumbers': 1,
+                'SectorRateScalerNames': 1,
+                }.items():
+            self.assertEqual(
+                sortorder, bundle._varinfo[varname].get('sortorder', None),
+                varname)
 
     def testSliceMultiIDX(self):
         """Slice multiple indices"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1141,6 +1141,45 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
         ops = bundle.inspect()['operations']
         self.assertEqual([('slice', (1, [5, 6]), {})], ops)
 
+    def testSumRecord(self):
+        """Sum on the record dimension"""
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
+        bundle.sum(0).output(self.outcdf)
+        expected = numpy.sum(self.incdf['Counts_P'][...], axis=0)
+        numpy.testing.assert_array_equal(
+            self.outcdf['Counts_P'][...], expected)
+        self.assertFalse(self.outcdf['Counts_P'].rv())
+        self.assertFalse('DEPEND_0' in self.outcdf['Counts_P'].attrs)
+        self.assertFalse('Epoch' in self.outcdf)
+        self.assertEqual(
+            'PITCH_ANGLE', self.outcdf['Counts_P'].attrs['DEPEND_1'])
+
+    def testAvgRecord(self):
+        """Average on the record dimension"""
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
+        bundle.mean(0).output(self.outcdf)
+        expected = numpy.mean(self.incdf['Counts_P'][...], axis=0)
+        numpy.testing.assert_array_equal(
+            self.outcdf['Counts_P'][...], expected)
+        self.assertFalse(self.outcdf['Counts_P'].rv())
+        self.assertFalse('Epoch' in self.outcdf)
+        self.assertFalse('DEPEND_0' in self.outcdf['Counts_P'].attrs)
+        self.assertEqual(
+            'PITCH_ANGLE', self.outcdf['Counts_P'].attrs['DEPEND_1'])
+
+    def testSliceSingleRecord(self):
+        """Slice single element on the record dimension"""
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
+        bundle.slice(0, 0, single=True).output(self.outcdf)
+        expected = self.incdf['Counts_P'][0, ...]
+        numpy.testing.assert_array_equal(
+            self.outcdf['Counts_P'][...], expected)
+        self.assertFalse(self.outcdf['Counts_P'].rv())
+        self.assertFalse('DEPEND_0' in self.outcdf['Counts_P'].attrs)
+        self.assertFalse('Epoch' in self.outcdf)
+        self.assertEqual(
+            'PITCH_ANGLE', self.outcdf['Counts_P'].attrs['DEPEND_1'])
+
     def testSliceNRVScalar(self):
         """Slice when the EPOCH_DELTA is NRV"""
         #Modify the input first

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1212,6 +1212,19 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
              ('Energy_LABL', (10,))]],
             variables)
 
+    def testStrRepr(self):
+        """Get string representation of bundle"""
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['FPDU'])
+        bundle.slice(1, 1, single=True).slice(2, 0, 10)
+        self.assertEqual(
+            'FPDU Epoch_Ion Epoch_Ion_DELTA [PITCH_ANGLE] [Pitch_LABL] '
+            'HOPE_ENERGY_Ion ENERGY_Ion_DELTA Energy_LABL',
+            str(bundle))
+        self.assertEqual(
+            '<VarBundle: FPDU Epoch_Ion Epoch_Ion_DELTA [PITCH_ANGLE] '
+            '[Pitch_LABL] HOPE_ENERGY_Ion ENERGY_Ion_DELTA Energy_LABL>',
+            repr(bundle))
+
     def testOutshape(self):
         """Get the output shape of variables"""
         bundle = spacepy.pycdf.istp.VarBundle(self.incdf['FPDU'])

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1113,6 +1113,22 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
         numpy.testing.assert_allclose(
             self.outcdf['Counts_P'], expected)
 
+    def testInspectOperations(self):
+        """Get operations of a bundle"""
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
+        bundle.slice(1, 1, single=True).slice(2, 0, 10).mean(2)
+        ops = bundle.inspect()['operations']
+        self.assertEqual(
+            [('slice', (1, 1), {'single': True}),
+             ('slice', (2, 0, 10), {}),
+             ('mean', (2,), {})],
+            ops)
+        #Check fancy index
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['Counts_P'])
+        bundle.slice(1, [5, 6])
+        ops = bundle.inspect()['operations']
+        self.assertEqual([('slice', (1, [5, 6]), {})], ops)
+
     def testSliceNRVScalar(self):
         """Slice when the EPOCH_DELTA is NRV"""
         #Modify the input first

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -821,12 +821,12 @@ class VarBundleChecks(VarBundleChecksBase):
             self.incdf['SectorRateScalersCounts'])
         bundle.slice(0, 2, 20).mean(0)
         expected = """
-        SectorRateScalersCounts CDF_FLOAT [18, 32, 9] NRV
-            SectorRateScalersCountsSigma CDF_FLOAT [18, 32, 9] NRV
-        ATC CDF_EPOCH16 ---
-        SpinNumbers CDF_CHAR*2 [18] NRV
-        SectorNumbers CDF_CHAR*2 [32] NRV
-        SectorRateScalerNames CDF_CHAR*9 [9] NRV
+        SectorRateScalersCounts: CDF_FLOAT [18, 32, 9] NRV
+            SectorRateScalersCountsSigma: CDF_FLOAT [18, 32, 9] NRV
+        ATC: CDF_EPOCH16 ---
+        SpinNumbers: CDF_CHAR*2 [18] NRV
+        SectorNumbers: CDF_CHAR*2 [32] NRV
+        SectorRateScalerNames: CDF_CHAR*9 [9] NRV
         """
         expected = inspect.cleandoc(expected).split('\n')
         self.assertEqual(expected, str(bundle).split('\n'))
@@ -1250,14 +1250,14 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
         bundle = spacepy.pycdf.istp.VarBundle(self.incdf['FPDU'])
         bundle.slice(1, 1, single=True).slice(2, 0, 10)
         expected = """
-        FPDU CDF_FLOAT [100, 10]
-        Epoch_Ion CDF_EPOCH [100]
-            Epoch_Ion_DELTA CDF_REAL4 [100]
-        PITCH_ANGLE CDF_FLOAT ---
-            Pitch_LABL CDF_CHAR*5 ---
-        HOPE_ENERGY_Ion CDF_FLOAT [100, 10]
-            ENERGY_Ion_DELTA CDF_FLOAT [100, 10]
-            Energy_LABL CDF_CHAR*3 [10] NRV
+        FPDU: CDF_FLOAT [100, 10]
+        Epoch_Ion: CDF_EPOCH [100]
+            Epoch_Ion_DELTA: CDF_REAL4 [100]
+        PITCH_ANGLE: CDF_FLOAT ---
+            Pitch_LABL: CDF_CHAR*5 ---
+        HOPE_ENERGY_Ion: CDF_FLOAT [100, 10]
+            ENERGY_Ion_DELTA: CDF_FLOAT [100, 10]
+            Energy_LABL: CDF_CHAR*3 [10] NRV
         """
         expected = inspect.cleandoc(expected).split('\n')
         #Split on linebreak to get a better diff


### PR DESCRIPTION
This PR addresses #227 with several functions for examining the bundle:

- ``operations`` lists the operations to be performed
- ``variables`` gives the information on the variables involved and their shape on output
- ``__str__`` and ``__repr__`` give a brief view of the variables

I'd be amenable to having ``__str__`` act more like ``CDF``, i.e. include the output size of the variable and print one variable per line. Matter of taste.

Originally ``operations`` and ``variables`` were going to be a single ``inspect`` function but that didn't seem to give any real advantage. A few other things are slightly different from the original description in #227 and unfortunately the commit history does include a few false starts relating to these changes.

In the course of doing this, I also added one feature: the ability to eliminate the record dimension through a single-indexing or averaging. So if for some reason there's a record-varying (say) flux in the input file and there's a desire to have a NRV average for the whole day in the output, that's now possible. There were also a few cleanups of affected corners of the code.

## PR Checklist
- [x] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature (N/A, addition to code that has not been included in release yet).
- [X] New features and bug fixes should have unit tests
