### PR TITLE
plot.utils.EventClicker pcolormesh (and non-line object) support

### DIFF
--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -143,23 +143,29 @@ class EventClicker(object):
     >>> min(troughvals) <= -1.0 #should bottom-out at -1
     True
 
-    >>> import spacepy.plot
+    >>> import spacepy.plot.utils
+    >>> import spacepy.time
     >>> import datetime
     >>> import matplotlib.pyplot as plt
     >>> import numpy
-    >>> import pytz
-    >>> xmax = 1000
-    >>> tz = pytz.timezone('America/New_York') #get a timezone
-    >>> x, y = numpy.linspace(0, xmax, xmax + 1), numpy.linspace(0, 100, 101)
-    >>> x_like_date = numpy.array([tz.localize(
-    ... datetime.datetime(2019, 12, 1, 0, 0, 0) + datetime.timedelta(hours=i))
-    ... for i in range(0, xmax + 1)])
-    >>> xx, yy = numpy.meshgrid(x, y)
-    >>> z = 1 + numpy.exp(-(yy - 20)**2 / (25)**2)
-    ... * numpy.sin(2 * numpy.pi * xx * 3 / xmax)**2 #something like a spetrogram
-    >>> plt.pcolormesh(x_like_date, y, z)
+    >>> t = spacepy.time.tickrange('2019-01-01', #get a range of days
+    ...                            '2019-12-31',
+    ...                            deltadays=datetime.timedelta(days=1))
+    >>> y = numpy.linspace(0, 100, 1001)
+    >>> seconds = t.TAI - t.TAI[0]
+    >>> seconds = numpy.asarray(seconds) #normal ndarray so reshape (in meshgrid) works
+    >>> tt, yy = numpy.meshgrid(seconds, y) #use TAI to get seconds
+    >>> z = 1 + (numpy.exp(-(yy - 20)**2 / 625) #something like a spectrogram
+    ...          * numpy.sin(1e-7 * numpy.pi**2 * tt)**2) #pi*1e7 seconds per year
+    >>> plt.pcolormesh(t.UTC, y, z)
     >>> clicker = spacepy.plot.utils.EventClicker(n_phases=1)
-    >>> clicker.analyze()
+    >>> clicker.analyze() #double-click on center of peak; close
+    >>> events = clicker.get_events() #returns an array of the things clicked
+    >>> len(events) == 10 #10 if you click on the centers, including the last one
+    True
+    >>> clicker.get_events_data() is None #should be nothing
+    True
+
 
     .. autosummary::
          ~EventClicker.analyze

--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -332,8 +332,8 @@ class EventClicker(object):
         elif self._x_is_datetime:
             #Handle the case of no xdata but we are using a datetime, such as
             #spectrum data (that's not a line, hence no xdata):
-            self._relim(matplotlib.dates.num2date(self.ax.get_xaxis().\
-                get_view_interval()[0]).replace(tzinfo=self._tz))
+            self._relim(matplotlib.dates.num2date(self.ax.get_xaxis()\
+                .get_view_interval()[0]).replace(tzinfo=self._tz))
         else:
             self._relim(self.ax.get_xaxis().get_view_interval()[0])
         self._cids = []
@@ -425,7 +425,7 @@ class EventClicker(object):
             self._events.resize((self._events.shape[0] + 1,
                                  self.n_phases, 2
                                  ))
-            if not self._data_events is None:
+            if self._data_events is not None:
                 self._data_events.resize((self._data_events.shape[0] + 1,
                                           self.n_phases, 2
                                           ))
@@ -481,8 +481,8 @@ class EventClicker(object):
         if event.key == ' ':
             rightside = self.ax.xaxis.get_view_interval()[1]
             if self._x_is_datetime:
-                rightside = matplotlib.dates.num2date(rightside, tz=self._tz).\
-                    replace(tzinfo=self._tz)
+                rightside = matplotlib.dates.num2date(rightside, tz=self._tz)\
+                    .replace(tzinfo=self._tz)
             self._relim(rightside)
         if event.key == 'delete':
             self._delete_event_phase()


### PR DESCRIPTION
These changes add support to EventClicker for matplotlib.pyplot.pcolormesh (QuadMesh) objects, and should be extensible enough to include any pyplot object that doesn't have line data associated with it.

I've included a new example (that may need reformatting) in the doctstring for EventClicker to show how this works.  EventClicker.get_events_data does not work for a pcolormesh/non-line object, as there isn't any "event data" to grab, but get_events will still get the x-value or datetime (whichever is used for the x-axis) of wherever was clicked.

(Incidentally Github wants to include some of my previous commits from a different PR in this.  I don't know why, nor how to exclude them, but if this needs changing let me know.)