### PR TITLE
toolbox.bootHisto: fix formatting of example

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1272,21 +1272,15 @@ def bootHisto(data, inter=90., n=1000, seed=None,
 
     Examples
     ========
-    >>> import numpy.random
-    >>> import spacepy.toolbox
-    >>> numpy.random.seed(0)
-    >>> data = numpy.random.randn(1000)
-    >>> bin_edges, ci_low, ci_high, sample, bars = spacepy.toolbox.bootHisto(
-            data, plot=True)
-
     .. plot::
+        :include-source:
 
-       import numpy.random
-       import spacepy.toolbox
-       numpy.random.seed(0)
-       data = numpy.random.randn(1000)
-       bin_edges, ci_low, ci_high, sample, bars = spacepy.toolbox.bootHisto(
-            data, plot=True)
+        >>> import numpy.random
+        >>> import spacepy.toolbox
+        >>> numpy.random.seed(0)
+        >>> data = numpy.random.randn(1000)
+        >>> bin_edges, low, high, sample, bars = spacepy.toolbox.bootHisto(
+        ...     data, plot=True)
 
     See Also
     ========


### PR DESCRIPTION
The bootHisto example had an improperly formatted line continuation, so using the "hide prompts" button (`>>>`) removed a continued line. In fixing this, it seemed to make more sense just to use the `include-source` argument of the `plot` directive rather than having the example and then repeating the same code to make the plot.

This also involved renaming the return values in the example to match the documentation (and make them a bit shorter to keep the line continuation in the middle of the arguments, as `\` line continuation is a bit weird in the plot directive.)
