### PR TITLE
plot.utils documentation: Link plot.utils to plot docs so it can be viewed (and other plot module doc fixes)

### DIFF
--- a/Doc/source/plot.rst
+++ b/Doc/source/plot.rst
@@ -7,3 +7,12 @@ plot - Plot, various specialized plotting functions and associated utilities
 .. currentmodule:: spacepy.plot
 .. automodule:: spacepy.plot
 
+Submodules
+----------
+
+.. autosummary::
+    :toctree: autosummary  
+    :template: clean_module.rst
+
+    utils
+    spectrogram


### PR DESCRIPTION
This applies the changes discussed in #242.  However, after taking a closer look, this doesn't actually fix all the problems with the plot module documentation.  Specifically, there seems to be a problem generating the docs for plot.spectrogram (the submodule) and plot.spectrogram.spectrogram (the class).

Additionally, there seem to be some inconsistencies within all the submodules, (some things that are functions are called classes or modules, and vice versa (in all ways)).

I tried quite a few things but couldn't quite fix it.  I don't know how easy it is for you to checkout, (or maybe just make the same changes in your local checkout) but I think it'd make sense to fix all the documentation for the plot module now.

So, any ideas on how to get the correct linking for plot.spectrogram and its members and any other changes?