### PR TITLE
Expose plot submodule documentation (Closes #242)

### DIFF
--- a/spacepy/plot/__init__.py
+++ b/spacepy/plot/__init__.py
@@ -62,6 +62,7 @@ through the *plot* namespace. However, the plot module does contain
 several submodules listed below
 
 .. autosummary::
+    :toctree: autosummary
     :template: clean_module.rst
 
     carrington


### PR DESCRIPTION
Duelling implementation to #259 . I hadn't realized we already had the submodule list, it just needed to be put into a toctree so it was actually swept up.

Lots of the docs don't build cleanly, but at least they're there. In particular the business of pulling everything into the root plot namespace makes for a huge mess; most of it is probably manageable but the spectrogram module can't be documented because it's smashed by importing the spectrogram class.