### PR TITLE
Docs: conf.py: update to python intersphinx, closes 263

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -284,7 +284,7 @@ epub_copyright = u'2011, The SpacePy Team'
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('https://matplotlib.org/', None),


### PR DESCRIPTION
This was a very simple update to close #263. Python intersphinx moved. Numpy and scipy have not moved. Matplotlib that was shown to timeout worked fine for me today, so maybe just the day. 


- [X ] New code has inline comments where necessary
- [ N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ N/A] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ N/A] New features and bug fixes should have unit tests

