### PR TITLE
Document py2k EOL plan (Closes #211)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-Changes in Version 0.2.2 (2019-xx-xx)
+Changes in Version 0.2.2 (2020-xx-xx)
 =====================================
+- Document end of support for Python 2
 plot
  - utils.EventClicker support for non-line plots (e.g. pcolor)
 pycdf

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -14,15 +14,13 @@ Hard Dependencies
 =================
 Without these packages installed, SpacePy will not function.
 
-Python 2.6+
+Python 2.7+
 -----------
 
 `Python <http://www.python.org/>`_ is the core language for SpacePy.
-Python 2.6 or later is required. SpacePy works under Python 3, but
-Python 2 is still recommended for most users.  *Python 3 is not simply
-a "newer" Python 2; there are substantial differences in the
-language*. See `Should I use Python 2 or Python 3?
-<http://wiki.python.org/moin/Python2orPython3>`_.
+Python 3 is strongly recommended; while SpacePy currently supports
+Python 2.7, this support will be phased out over the course
+of 2020. See :doc:`py2k_eol`.
 
 Required to install SpacePy.
 

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -57,6 +57,7 @@ SpacePy Documents
 
     help
     install
+    py2k_eol
     quickstart
     doc_standard
     tips

--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -5,7 +5,7 @@ Installing SpacePy
 The simplest way from zero to a working SpacePy setup is:
 
   1. Install the `Anaconda <https://docs.anaconda.com/anaconda/>`_ Python
-     environment. Python 3 is recommended (as is, usually, 64-bit).
+     environment. Python 3 is strongly recommended (64-bit is recommended).
   2. ``pip install --upgrade spacepy``
 
 If you are familiar with installing Python packages, have particular

--- a/Doc/source/py2k_eol.rst
+++ b/Doc/source/py2k_eol.rst
@@ -1,0 +1,62 @@
+=======================
+Python 2 End of Support
+=======================
+
+Python 3 is fully supported by SpacePy and used in daily work by most
+of the SpacePy team.
+
+On January 1, 2020, Python 2 reached `end of life
+<https://www.python.org/doc/sunset-python-2/>`_. Most of the
+scientific Python stack has committed to ending Python 2 support `by
+2020 <https://python3statement.org/>`_. This includes `numpy
+<https://numpy.org/neps/nep-0014-dropping-python2.7-proposal.html>`_.
+
+As a result, the SpacePy team will phase out Python 2 support over the
+course of 2020. This process is managed through SpacePy `issue 26
+<https://github.com/spacepy/spacepy/issues/26>`_.
+
+0.2 series: full support
+========================
+
+The last release of the SpacePy 0.2 series will be in quarter 1 of
+2020, likely 0.2.2. This will be the last release where all
+functionality works with Python 2 and that has binary installers
+provided for Python 2. 0.2 will *not* be supported past this release
+(this will not be a "long-term support" release.)
+
+0.3 series: no feature support
+==============================
+
+Starting with 0.3.0, quarter 2 of 2020, the SpacePy team will:
+
+ * Provide no prebuilt packages for Python 2. We will attempt to
+   ensure the last 0.2.x version will still install from pip on
+   Python 2.
+ * Allow new features that do not support Python 2 as long as they do
+   not break existing functionality.
+ * Provide no workarounds for dependencies that no longer support
+   Python 2.
+
+SpacePy 0.3.x will still function on Python 2 for those who install
+"by hand".
+
+0.4 series: no bugfix support
+=============================   
+
+Starting with 0.4.0, in the second half of 2020, the SpacePy team will
+provide no fixes for bugs that cannot be reproduced on Python 3.
+
+SpacePy 0.4.x will still function on Python 2 for those who install
+"by hand".
+
+0.5 series: remove support
+==========================
+
+Starting with 0.5.0, in Q4 of 2020, SpacePy developers will begin
+removing code that exists only to support Python 2. SpacePy 0.5.x will
+not function on Python 2.
+
+--------------------------
+
+:Release: |version|
+:Doc generation date: |today|


### PR DESCRIPTION
This PR documents the plan for ending Python 2 support in SpacePy as in #26. The document is linked from the dependencies page (which now recommends Python 3 instead of 2). The install page is updated to more strongly recommend Python 3.

I think we all need to be on board with this so I'm explicitly requesting review from everybody...that can be a review of the plan and/or its presentation in this PR.

