### PR TITLE
test_toolbox: additional tests for quaternion math

### DIFF
--- a/Doc/source/toolbox.rst
+++ b/Doc/source/toolbox.rst
@@ -11,6 +11,7 @@ toolbox - Toolbox of various functions and generic utilities
 - `Array binning`_
 - `Array creation`_
 - `Array searching and masking`_
+- `Quaternion math`_
 - `Other functions`_
 - `Multithreading and multiprocessing`_
 - `System tools`_
@@ -45,6 +46,16 @@ Array searching and masking
     tCommon
     tOverlap
     tOverlapHalf
+
+Quaternion math
+---------------
+.. autosummary::
+    :toctree: autosummary
+
+    quaternionRotateVector
+    quaternionNormalize
+    quaternionMultiply
+    quaternionConjugate
 
 Other functions
 ---------------

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -78,7 +78,8 @@ __all__ = ['tOverlap', 'tOverlapHalf', 'tCommon', 'loadpickle', 'savepickle', 'a
            'windowMean', 'medAbsDev', 'binHisto', 'bootHisto',
            'logspace', 'geomspace', 'linspace', 'arraybin', 'mlt2rad',
            'rad2mlt', 'pmm', 'getNamedPath', 'query_yes_no',
-           'interpol', 'normalize', 'intsolve', 'dist_to_list',
+           'quaternionNormalize', 'quaternionRotateVector', 'quaternionMultiply',
+           'quaternionConjugate', 'interpol', 'normalize', 'intsolve', 'dist_to_list',
            'bin_center_to_edges', 'bin_edges_to_center', 'thread_job', 'thread_map',
            'eventTimer', 'isview', 'interweave', 'indsFromXrange', 'hypot',
            'do_with_timeout', 'TimeoutError', 'timeout_check_call', 'unique_columns']

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -119,6 +119,43 @@ class SimpleFunctionTests(unittest.TestCase):
         ans = [ 0.69337122,  0.        ,  0.69337122,  0.19614462]
         numpy.testing.assert_array_almost_equal(ans, tst)
 
+    def test_quaternionNormalize_2(self):
+        """quaternionNormalize should have known result and magnitude 1"""
+        tst1 = tb.quaternionNormalize([1, 0, 1, 0], scalarPos='first')
+        tst2 = tb.quaternionNormalize([1, 0, 1, 0], scalarPos='last')
+        ans = [0.70710678, 0.0, 0.70710678, 0]
+        numpy.testing.assert_array_almost_equal(ans, tst1)
+        numpy.testing.assert_array_almost_equal(ans, tst2)
+        numpy.testing.assert_almost_equal(1.0, numpy.linalg.norm(tst1))
+        numpy.testing.assert_almost_equal(1.0, numpy.linalg.norm(tst2))
+
+    def test_quaternionNormalize_small(self):
+        """test quaternionNormalize for very small values"""
+        tst1 = tb.quaternionNormalize([1e-15, 0, 1e-15, 0], scalarPos='first')
+        tst2 = tb.quaternionNormalize([1e-15, 0, 1e-15, 0], scalarPos='last')
+        ans1 = [1.0, 0.0, 0.0, 0.0]
+        ans2 = [0.0, 0.0, 0.0, 1.0]
+        numpy.testing.assert_array_almost_equal(ans1, tst1)
+        numpy.testing.assert_array_almost_equal(ans2, tst2)
+
+    def test_quaternionMultiply(self):
+        """quaternionMultiply should have known results"""
+        q1 = [1.0, 0.0, 0.0, 0.0]
+        q2 = [0.0, 0.0, 0.0, 1.0]
+        ans = [0.0, 0.0, 0.0, 1.0]
+        tst = tb.quaternionMultiply(q2, q1, scalarPos='first')
+        numpy.testing.assert_array_almost_equal(ans, tst)
+
+    def test_quaternionConjugate_last(self):
+        tst = tb.quaternionConjugate([0.707, 0, 0.707, 0.2], scalarPos='last')
+        ans = [ -0.707,  -0.        ,  -0.707,  0.2]
+        numpy.testing.assert_array_almost_equal(ans, tst)
+
+    def test_quaternionConjugate_first(self):
+        tst = tb.quaternionConjugate([0.2, 0.707, 0, 0.707], scalarPos='first')
+        ans = [ 0.2,  -0.707,  -0.        ,  -0.707]
+        numpy.testing.assert_array_almost_equal(ans, tst)
+
     def test_indsFromXrange(self):
         """indsFromXrange should have known result"""
         foo = xrange(23, 39)


### PR DESCRIPTION
Expands test coverage for quaternion math.

This was motivated by issue #184. That issue is invalid, and should be closed, but to ensure/demonstrate correctness I've added more unit tests.

These tests are:
- quaternion conjugation (for both scalar positions)
- quaternion multiplication (for a simple case)
- quaternion normalization, testing for
  - known case, both scalar positions
  - near-zero case, both scalar positions

The reason #184 is invalid is that, in essence, the norm of the quaternion (w, i, j, k) is simply (w/n, i/n, j/n, k/n) where n is sqrt(w^2 + i^2 + j^2 + k^2). So the position of the scalar is generally irrelevant in the normalization and the reported behaviour is expected.

The reason that the `scalarPos` kwarg is still present is for handling the case where the quaternion magnitude is very small (which we take as 1e-12). In this case we define the quaternion as the identity quaternion (scalar: 1, vector (0,0,0)) such that no rotation is performed. To ensure a valid quaternion we need to know which position to write the scalar to.

