### PR TITLE
Fixes/modernization of pybats.ram: plotting, python 3, etc.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,6 +23,8 @@ pybats
  - Fixed open/closed tolerance kwarg not working in add_b_magsphere.
  - Added new stream trace visualization method for Bats2d objects: add_stream_scatter
  - Bats2d.add_b_magsphere and add_stream_scatter now have kwargs for adding arrows on ray traces
+ - Updates to ram.RamSat including omnidirectional flux calculation
+ - ram.PressureFile fixed for Python 3.x failures
 toolbox
  - New function get_url to retrieve data from a URL
  - Change update to retrieve OMNI2 data from SPDF not ViRBO

--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -762,7 +762,7 @@ def set_target(target, figsize=None, loc=None, polar=False):
 
     '''
     # Is target an axes?  Make no new items.
-    if issubclass(type(target), plt.Axes):
+    if isinstance(target, plt.Axes):
         ax  = target
         fig = ax.figure
     else: # Make a new axis

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -584,8 +584,8 @@ class RamSat(SpaceData):
 
         Usage: just call this method to integrate all species.
 
-        Arguments
-        ---------
+        Other Parameters
+        ================
         check : Boolean
                 If check is True (default) then the presence of existing
                 omni variables will cause this calculation to abort cleanly.

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -1233,7 +1233,7 @@ class PressureFile(PbData):
         # Grid spacing/size:
         self.attrs['dTheta'] = self['theta'][1]-self['theta'][0]
         self.attrs['nTheta'] = int(np.round(2.*np.pi/self.attrs['dTheta'])+1)
-        self.attrs['nL'] = len(self['L'])/self.attrs['nTheta']
+        self.attrs['nL'] = len(self['L'])//self.attrs['nTheta']
         self.attrs['dL'] = self['L'][self.attrs['nTheta']] - self['L'][0]
 
         # Calculate isotropic pressures and anisotropies.
@@ -1650,10 +1650,10 @@ class LogFile(PbData):
         
         import matplotlib.pyplot as plt
         
-        if type(target) == plt.Figure:
+        if isinstance(target, plt.Figure):
             fig = target
             ax = fig.add_subplot(loc)
-        elif type(target).__base__ == plt.Axes:
+        elif isinstance(target, plt.Axes):
             ax = target
             fig = ax.figure
         else:
@@ -1666,7 +1666,7 @@ class LogFile(PbData):
         ax.hlines(0.0, self['time'][0], self['time'][-1], 
                   'k', ':', label='_nolegend_')
         applySmartTimeTicks(ax, self['time'])
-        ax.set_ylabel('Dst ($nT$)')
+        ax.set_ylabel('Dst [$nT$]')
         ax.set_xlabel('Time from '+ self['time'][0].isoformat()+' UTC')
 
         try:

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -816,14 +816,14 @@ class RamSat(SpaceData):
         time[1:]=date2num(self.time+dt.timedelta(seconds=self.dt/2.0))
         #egrid=self['energy_grid']
         ecenter, eboundary, ewidth=gen_egrid(nE=self['energy_grid'].size)
-#        print("Need better energy grid setup for pcolormesh.")
-        flx=ax.pcolormesh(time,eboundary,self[nameflux].transpose(),
-                          norm=LogNorm(),vmin=zlim[0],vmax=zlim[1])
+        #print("Need better energy grid setup for pcolormesh.")
+        flx = ax.pcolormesh(time, eboundary, np.asarray(self[nameflux]).transpose(),
+                            norm=LogNorm(), vmin=zlim[0], vmax=zlim[1])
         ax.set_yscale('log')
-        ax.set_ylim( [eboundary[0],eboundary[-1]] )
+        ax.set_ylim( [eboundary[0], eboundary[-1]] )
         if not timelim:
-            timelim=[self.time[0],self.time[-1]]
-        applySmartTimeTicks(ax,timelim,dolabel=True)
+            timelim=[self.time[0], self.time[-1]]
+        applySmartTimeTicks(ax, timelim, dolabel=True)
         if no_xlabels:
             ax.set_xlabel('')
             ax.set_xticklabels([''])

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -1627,15 +1627,7 @@ class LogFile(PbData):
         
         import matplotlib.pyplot as plt
         
-        if isinstance(target, plt.Figure):
-            fig = target
-            ax = fig.add_subplot(loc)
-        elif isinstance(target, plt.Axes):
-            ax = target
-            fig = ax.figure
-        else:
-            fig = plt.figure(figsize=(10,4))
-            ax = fig.add_subplot(loc)
+        fig, ax = set_target(target, loc=loc)
         
         ax.plot(self['time'], self['dstRam'], label='RAM Dst (DPS)')
         if 'dstBiot' in self and showBiot:

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -569,6 +569,10 @@ class RamSat(SpaceData):
             [self.starttime + dt.timedelta(seconds=float(s)) for s in secs])
         self['Time'] = self.time
 
+        # Close netcdf file and remove reference
+        self.f.close()
+        del self.f
+
         # Some other variables to keep handy:
         try:
             self.dt = self['DtWrite']

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -598,9 +598,9 @@ class RamSat(SpaceData):
         def get_species_label(keyname, omni=False):
             uvar = 'omni' if omni else 'Flux'
             if keyname.startswith(uvar + '_'):
-                return keyname[len(uvar)+1:].replace('+', '')
+                return keyname[len(uvar)+1:].replace('+', '').replace('-', '')
             elif keyname.startswith(uvar):
-                return keyname[len(uvar):].replace('+', '')
+                return keyname[len(uvar):].replace('+', '').replace('-', '')
 
         omnipresent = [True for kk in self if get_species_label(kk, omni=True)
                        is not None]

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -597,10 +597,10 @@ class RamSat(SpaceData):
         '''
         def get_species_label(keyname, omni=False):
             uvar = 'omni' if omni else 'Flux'
-            if uvar+'_' in keyname:
-                return keyname[5:].replace('+', '')
-            elif uvar in keyname:
-                return keyname[4:].replace('+', '')
+            if keyname.startswith(uvar + '_'):
+                return keyname[len(uvar)+1:].replace('+', '')
+            elif keyname.startswith(uvar):
+                return keyname[len(uvar):].replace('+', '')
 
         omnipresent = [True for kk in self if get_species_label(kk, omni=True)
                        is not None]

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -625,12 +625,8 @@ class RamSat(SpaceData):
         for omkey, fluxkey in omnikeys:
             self[omkey] = np.zeros((nTime, nEner))
             # Integrate.
-            temp = self[fluxkey].copy()
-            temp = np.ma.masked_where(temp<=0, temp)
-            for i in range(1, nPa):
-                temp[:,i,:] = temp[:,i,:] * dMu[i]
-
-            self[omkey] = temp.sum(1)
+            temp = np.ma.masked_where(self[fluxkey]<=0, self[fluxkey])
+            self[omkey] = (temp * np.reshape(dMu, (1, -1, 1))).sum(axis=1)
 
             # Mask out bad values.
             self[omkey] = np.ma.masked_where(self[omkey]<=0, self[omkey])

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -513,7 +513,8 @@ class RampyTests(unittest.TestCase):
         '''Test that start time attribute and Time variable are as expected'''
         data = ram.RamSat(self.testfile)
         self.assertEqual(data.starttime, dt.datetime(2012, 10, 29))
-        numpy.testing.assert_array_equal(data['Time'], [60., 120., 180.])
+        tst = [dt.datetime(2012, 10, 29) + dt.timedelta(seconds=sc) for sc in [60, 120, 180]]
+        numpy.testing.assert_array_equal(data['Time'], tst)
 
     def test_RamSat_contents_dims(self):
         '''Test for expected shape of loaded data array'''

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -525,8 +525,28 @@ class RampyTests(unittest.TestCase):
         '''Ensure that original flux is unchanged on calculating omni-flux'''
         data = ram.RamSat(self.testfile)
         flux_h = data['FluxH+'].copy()
-        data.create_omniflux()
+        data.create_omniflux(check=False)
         numpy.testing.assert_array_equal(flux_h, data['FluxH+'])
+
+    def test_RamSat_omnicalc_regress(self):
+        '''Regression test for omni flux calculation'''
+        data = ram.RamSat(self.testfile)
+        #remove any precalculated omniflux
+        rmkeys = [key for key in data if key.lower().startswith('omni')]
+        for rmk in rmkeys:
+            del data[rmk]
+        regrH = np.array([0.0000000e+00, 1.4857327e+07, 1.4904620e+07, 1.4523555e+07,
+                          1.3417377e+07, 1.1787100e+07, 9.8903560e+06, 8.0948140e+06,
+                          6.6876425e+06, 5.7112065e+06, 5.0520345e+06, 4.5785050e+06,
+                          4.2270450e+06, 3.9780850e+06, 3.8351362e+06, 3.7873392e+06,
+                          3.9363230e+06, 4.0524422e+06, 2.9526408e+06, 9.0399219e+05,
+                          5.2025672e+05, 2.4965306e+05, 9.1892180e+04, 3.0133383e+04,
+                          1.6105718e+04, 1.4831358e+04, 1.7809768e+04, 2.2456926e+04,
+                          2.5075262e+04, 2.3687787e+04, 1.8142951e+04, 1.0017233e+04,
+                          3.8184448e+03, 1.1123656e+03, 2.2883945e+02], dtype=np.float32)
+        data.create_omniflux(check=False)
+        testarr = np.array(data['omniH'][0].data)
+        numpy.testing.assert_array_almost_equal(regrH, testarr)
 
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Updates to the ram module in pybats. Addressing various related issues that arose when designing quicklook plotting for RAM-SCB for the CCMC.

Main changes:
- RamSat now inherits from SpaceData to get its dict-like behaviour (rather than from object and adding dict-like methods)
- Minor updates to docstrings to describe new kwargs
- Overhaul of omnidirectional flux calculation to be more flexible with species names as runs may not have particular species and new species may be added (Also, RAM-SCB has changed how species are named - this change allows for new and old files, plus future additions)
- Masking of bad values in omnidirectional flux calculation updated for robustness.
- Integer divide for finding indices for python 3 compatibility in PressureFile
- RamSat test updated to test for datetimes, not float seconds since run start -- It appears that the code was always intended to have datetimes here but this wasn't working correctly and so the test for seconds was passing. Updating the RamSat code fixed the behaviour to expected, so the test needed to be corrected.
- Broadened test in set_target to allow subclasses
- CHANGELOG updated to reflect changes in present branch

Tests pass, but I'd appreciate a closer look at:
1. Whether my update to set_target has side effects (@jtniehof)
2. Whether I've changed intended design in parts of RamSat through the changed inheritance (@spacecataz)

Any other comments, of course, welcome.

There's plenty more in ram.py that needs attention, but for that I should probably file an issue tracker so we can discuss what needs to happen.