### PR TITLE
Added Coords methods to convert to/from Astropy SkyCoord instances

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
 - Installs numpy before build on newer versions of pip (thanks Michael Hirsch)
+coordinates
+ - Added Coords methods to convert to/from Astropy SkyCoord instances
 irbempy
  - Update IRBEMlib to git commit a4759c0 (2021-06-30)
  - This update fixes an uninitialized GSM to SM transform that would return NaN

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -145,8 +145,11 @@ f2py) must be installed before SpacePy.
 
 Astropy 1.0+
 ------------
-:mod:`~spacepy.time` requires AstroPy if conversion to/from
-AstroPy :class:`~astropy.time.Time` is desired.
+:mod:`~spacepy.time` requires Astropy if conversion to/from
+Astropy :class:`~astropy.time.Time` is desired.
+
+:mod:`~spacepy.coordinates` requires Astropy if conversion to/from
+Astropy :class:`~astropy.coordinates.SkyCoord` is desired.
 
 Soft Dependency Summary
 =======================

--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -459,7 +459,7 @@ class Coords(object):
             raise e.__class__("This method requires Astropy to be installed.")
 
         skycoord = astropy.coordinates.SkyCoord(skycoord).itrs  # Astropy ITRS is GEO
-        data = (skycoord.cartesian.xyz.to_value('m') / cls.Re).T  # convert Cartesian to Re units
+        data = (skycoord.cartesian.xyz.to('m').value / cls.Re).T  # convert Cartesian to Re units
         ticks = spacepy.time.Ticktock(skycoord.obstime)
 
         return cls(data, 'GEO', 'car', ticks=ticks)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -76,7 +76,7 @@ class coordsTest(unittest.TestCase):
         np.testing.assert_allclose(sc_data, self.cvals.data * self.cvals.Re, rtol=1e-10)
 
         # Check that the time was loaded correctly
-        assert np.all(sc.obstime.isclose(self.cvals.ticks.APT))
+        np.testing.assert_allclose((sc.obstime - self.cvals.ticks.APT).to('s').value, 0)
 
     @unittest.skipUnless(HAVE_ASTROPY, 'requires Astropy')
     def test_to_skycoord_with_ticks_and_conversion(self):
@@ -95,7 +95,7 @@ class coordsTest(unittest.TestCase):
         np.testing.assert_allclose(sc_data, self.cvals.data * self.cvals.Re, rtol=1e-10)
 
         # Check that the time was loaded correctly
-        assert np.all(sc.obstime.isclose(self.cvals.ticks.APT))
+        np.testing.assert_allclose((sc.obstime - self.cvals.ticks.APT).to('s').value, 0)
 
     @unittest.skipUnless(HAVE_ASTROPY, 'requires Astropy')
     def test_from_skycoord(self):
@@ -110,7 +110,7 @@ class coordsTest(unittest.TestCase):
         np.testing.assert_allclose(coords.data * coords.Re, sc_data, rtol=1e-10)
 
         # Check that the time was loaded correctly
-        assert np.all(sc.obstime.isclose(coords.ticks.APT))
+        np.testing.assert_allclose((sc.obstime - coords.ticks.APT).to('s').value, 0)
 
     @unittest.skipUnless(HAVE_ASTROPY, 'requires Astropy')
     def test_from_skycoord_with_conversion(self):
@@ -126,7 +126,7 @@ class coordsTest(unittest.TestCase):
         np.testing.assert_allclose(coords.data * coords.Re, sc_data, rtol=1e-10)
 
         # Check that the time was loaded correctly
-        assert np.all(sc.obstime.isclose(coords.ticks.APT))
+        np.testing.assert_allclose((sc.obstime - coords.ticks.APT).to('s').value, 0)
 
 
 class QuaternionFunctionTests(unittest.TestCase):

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -72,7 +72,7 @@ class coordsTest(unittest.TestCase):
         assert sc.frame.name == 'itrs'
 
         # Check that the data was loaded correctly
-        sc_data = sc.cartesian.xyz.to_value('m').T
+        sc_data = sc.cartesian.xyz.to('m').value.T
         np.testing.assert_allclose(sc_data, self.cvals.data * self.cvals.Re, rtol=1e-10)
 
         # Check that the time was loaded correctly
@@ -91,7 +91,7 @@ class coordsTest(unittest.TestCase):
         assert sc.frame.name == 'itrs'
 
         # Check that the data converts back correctly
-        sc_data = sc.cartesian.xyz.to_value('m').T
+        sc_data = sc.cartesian.xyz.to('m').value.T
         np.testing.assert_allclose(sc_data, self.cvals.data * self.cvals.Re, rtol=1e-10)
 
         # Check that the time was loaded correctly
@@ -106,7 +106,7 @@ class coordsTest(unittest.TestCase):
         coords = spc.Coords.from_skycoord(sc)
 
         # Check that the data was loaded correctly
-        sc_data = sc.cartesian.xyz.to_value('m').T
+        sc_data = sc.cartesian.xyz.to('m').value.T
         np.testing.assert_allclose(coords.data * coords.Re, sc_data, rtol=1e-10)
 
         # Check that the time was loaded correctly
@@ -122,7 +122,7 @@ class coordsTest(unittest.TestCase):
         coords = spc.Coords.from_skycoord(sc.gcrs)
 
         # Check that the data was loaded correctly
-        sc_data = sc.cartesian.xyz.to_value('m').T
+        sc_data = sc.cartesian.xyz.to('m').value.T
         np.testing.assert_allclose(coords.data * coords.Re, sc_data, rtol=1e-10)
 
         # Check that the time was loaded correctly


### PR DESCRIPTION
For your consideration, this PR enables interacting back and forth with the Astropy coordinates framework (which is also used by SunPy).  It adds the following methods to `Coords`:

- `to_skycoord()` is a regular method which creates an Astropy `SkyCoord` instance from a `Coords` instance
- `from_skycoord()` is a class method which creates a `Coords` instance from an Astropy `SkyCoord` instance

The conversion utilizes the GEO coordinate frame, which is common to both libraries.