### PR TITLE
Update CDF location in Travis YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
  - pip install networkx
  - pip install ffnet
  - pip freeze #summarize what we have for debug purposes
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_0/linux/cdf37_0-dist-cdf.tar.gz; tar xzf cdf37_0-dist-cdf.tar.gz; cd cdf37_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz; tar xzf cdf37_1-dist-cdf.tar.gz; cd cdf37_1-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
 script:
  - python setup.py install


### PR DESCRIPTION
The CI is currently failing to complete as the link location for the NASA CDF library is no longer valid.
This PR addresses that failure by updating the link locations.
Until this is resolved, other PRs will not be testable.

This PR resolves #287 

