### PR TITLE
pybats: Fix sub-millisecond issues with ImfInput.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Changes in Version 0.2.2 (2020-xx-xx)
 - Document end of support for Python 2
 plot
  - utils.EventClicker support for non-line plots (e.g. pcolor)
+ - New method for adding arrows to lines in utils
 pycdf
  - VarCopy objects now carry information to help reproduce original
  - Newly-public method nelems to get number of elements in zVar
@@ -20,6 +21,8 @@ pybats
  - Updated gitm.GitmBin reader to fix failures in Python 3.x.
  - Fix for incorrect Kyoto Kp plots.
  - Fixed open/closed tolerance kwarg not working in add_b_magsphere.
+ - Added new stream trace visualization method for Bats2d objects: add_stream_scatter
+ - Bats2d.add_b_magsphere and add_stream_scatter now have kwargs for adding arrows on ray traces
 toolbox
  - New function get_url to retrieve data from a URL
  - Change update to retrieve OMNI2 data from SPDF not ViRBO

--- a/spacepy/plot/__init__.py
+++ b/spacepy/plot/__init__.py
@@ -56,6 +56,7 @@ Copyright 2011-2016 Los Alamos National Security, LLC.
    spectrogram
    style
    timestamp
+   add_arrows
 
 Most of the functionality in the plot module is made available directly 
 through the *plot* namespace. However, the plot module does contain

--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -36,6 +36,7 @@ Functions
     show_used
     smartTimeTicks
     timestamp
+    add_arrows
 """
 
 __contact__ = 'Jonathan Niehof: jniehof@lanl.gov'
@@ -57,7 +58,7 @@ import numpy
 
 __all__ = ['add_logo', 'annotate_xaxis', 'applySmartTimeTicks', 'collapse_vertical', 'filter_boxes', 
            'smartTimeTicks', 'get_biggest_clear', 'get_clear', 'get_used_boxes', 'EventClicker', 
-           'set_target', 'shared_ylabel', 'show_used', 'timestamp']
+           'set_target', 'shared_ylabel', 'show_used', 'timestamp', 'add_arrows']
 
 class EventClicker(object):
     """
@@ -1413,7 +1414,9 @@ def add_arrows(lines, n=3, size=12, style='->', dorestrict=False,
     For each line, arrows will be added using 
     :method:`~matplotlib.axes.Axes.annotate`.  Arrows will be spread evenly
     over the line using the number of points in the line as the metric for
-    spacing.  Arrow color and alpha is obtained from the parent line.
+    spacing.  For example, if a line has 120 points and 3 arrows are requested,
+    an arrow will be added at point number 30, 60, and 90.
+    Arrow color and alpha is obtained from the parent line.
 
     Parameters
     ==========
@@ -1447,6 +1450,18 @@ def add_arrows(lines, n=3, size=12, style='->', dorestrict=False,
     Returns
     =======
     None
+
+    Notes
+    =====
+    The algorithm works by dividing the line in to *n*+1 segements and 
+    placing an arrow between each segement, endpoints excluded.  Arrows span
+    the shortest distance possible, i.e., two adjacent points along a line.
+    For lines that are long spatially but sparse in points, the arrows will
+    have long tails that may extend beyond axes bounds.  For explicit positions,
+    the arrow is placed at the point on the curve closest to that position
+    and the exact position is not always attainable.  A maximum number of arrows
+    equal to one-half of the number of points in a line per line will be
+    created, so not all lines will receive *n* arrows.
 
     Example
     =======
@@ -1495,17 +1510,23 @@ def add_arrows(lines, n=3, size=12, style='->', dorestrict=False,
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
 
     if type(positions) != bool:
-        # Explicitly set positions:
+        # Explicitly set positions of arrows, one per line.
         for l, c, a, p in zip(data, cols, alph, positions):
+            # Get x-y points of line:
             x, y = l[:,0], l[:,1]
+            # Get point on line closest to desired position:
             i, j = argmin(abs(x - p[0])), argmin(abs(y - p[1]))
+            # Annotate, matching color/alpha:
             ax.annotate('',xytext=(x[i], y[j]), xy=(x[i+1], y[j+1]), alpha=a,
                         arrowprops=dict(arrowstyle=style,color=c),size=size)
+        # Nothing else to do at this point.
         return
-    
+
+    # Get positions for arrows and add them:
     for l, c, a in zip(data, cols, alph):
-        # Get info about line:
+        # Get x-y points of line:
         x, y = l[:,0], l[:,1]
+        # Restrict to axes limits as necessary:
         if dorestrict:
             loc = (x>=xlim[0])&(x<=xlim[1])&(y>=ylim[0])&(y<=ylim[1])
             x, y = x[loc], y[loc]

--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -1509,7 +1509,7 @@ def add_arrows(lines, n=3, size=12, style='->', dorestrict=False,
     # Grab plot limits (sometimes needed):
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
 
-    if type(positions) != bool:
+    if not isinstance(positions, bool):
         # Explicitly set positions of arrows, one per line.
         for l, c, a, p in zip(data, cols, alph, positions):
             # Get x-y points of line:

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1569,7 +1569,7 @@ class ImfInput(PbData):
         out.write('\n#START\n')
         for i in range(len(self['time'])):
             out.write('{:%Y %m %d %H %M %S} {:03d} '.format(
-                self['time'][i], int(round(self['time'][i].microsecond/1000.))))
+                self['time'][i], int(self['time'][i].microsecond/1000.)))
             out.write(' {}\n'.format(
                 ' '.join('{:10.2f}'.format(self[key][i]) for key in var)))
         out.close()

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -455,7 +455,7 @@ def _read_idl_ascii(pbdat, header='units', keep_case=True):
     if nSkip<0: nSkip=0
           
     # Save grid names (e.g. 'x' or 'r') and save associated params.
-    pbdat['grid'].attrs['dims']=names[0:ndim]
+    pbdat['grid'].attrs['dims']=tuple(names[0:ndim])
     for name, para in zip(names[(nvar+ndim):], para):
         pbdat.attrs[name]=para
         
@@ -725,7 +725,7 @@ def _read_idl_bin(pbdat, header='units', keep_case=True, headeronly=False):
         if nSkip<0: nSkip = 0
         
         # Save grid names (e.g. 'x' or 'r') and save associated params.
-        pbdat['grid'].attrs['dims']=names[0:ndim]
+        pbdat['grid'].attrs['dims']=tuple(names[0:ndim])
         for name, para in zip(names[(nvar+ndim):], para):
             pbdat.attrs[name]=para
                 

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -571,9 +571,14 @@ class Stream(Extraction):
             if xbwd.size>maxPoints: 
                 block=False
 
+        # Trim duplicate points created when backwards tracing.
+        # There's always at least 1 duplicate.
+        for i in range(1, xbwd.size):
+            if xbwd[-(i+1)]-xfwd[0] != 0: break
+        
         # Combine foward and backward traces.
-        self.x = np.append(xbwd[:-1],xfwd)
-        self.y = np.append(ybwd[:-1],yfwd)
+        self.x = np.append(xbwd[:-i],xfwd)
+        self.y = np.append(ybwd[:-i],yfwd)
 
         # If planetary run w/ body:
         # 1) Check if line is closed to body.

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1532,13 +1532,13 @@ class Bats2d(IdlFile):
 
         # Extract stream traces, organize x and y coords:
         lines = []
-        for i in range(nlines):
+        for xstart, ystart in start_points:
             # Some index errors crop up from time to time.
             # While a better solution is dug up, we use a try
             # block for the time being.
             try:
-                stream = self.get_stream(start_points[i, 0], start_points[i, 1],
-                                         xcomp,ycomp,method=method)
+                stream = self.get_stream(xstart, ystart, xcomp, ycomp,
+                                         method=method)
             except IndexError:
                 continue
             

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1436,7 +1436,8 @@ class Bats2d(IdlFile):
         a non-empty axes object) **OR** over the entire object domain (in that
         order).  
 
-        Extra keyword args are handed to matplotlib's LineCollection object.
+        Extra keyword args are handed to matplotlib's LineCollection object:
+        :class:`matplotlib.collections.LineCollection`.  
 
         Parameters
         ==========
@@ -1516,8 +1517,14 @@ class Bats2d(IdlFile):
         # Extract stream traces, organize x and y coords:
         lines = []
         for i in range(nlines):
-            stream = self.get_stream(start_points[i, 0], start_points[i, 1],
-                                     xcomp,ycomp,method=method)
+            # Some index errors crop up from time to time.
+            # While a better solution is dug up, we use a try
+            # block for the time being.
+            try:
+                stream = self.get_stream(start_points[i, 0], start_points[i, 1],
+                                         xcomp,ycomp,method=method)
+            except IndexError:
+                continue
             
             lines.append(array([stream.x, stream.y][::1-2*flip]).transpose())
 

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1430,8 +1430,9 @@ class Bats2d(IdlFile):
         return fig, ax
 
     def add_stream_scatter(self, xcomp, ycomp, nlines=100, target=None, loc=111,
-                           method='rk4', xlim=None, ylim=None,
-                           start_points=None,**kwargs):
+                           method='rk4', xlim=None, ylim=None, narrow=0,
+                           arrsize=12, arrstyle='->', start_points=None,
+                           **kwargs):
         '''
         Add a set of stream traces to a figure or axes that are distributed
         evenly but randomly throughout the plot domain.
@@ -1467,6 +1468,15 @@ class Bats2d(IdlFile):
             Set start_points to define starting location of traces instead of
             using random points.  This is useful for creating timeseries of
             plots.
+        narrow : int
+            Add "n" arrows to each line to indicate direction.  Default is 
+            zero, or no lines.  If narrow=1, arrows will be placed at 
+            *start_points*.
+        arrstyle : string
+            Set the arrow style in the same manner as Matplotlib's 
+            annotate function.  Default is '->'.
+        arrsize : int
+            Set the size, in points, of each directional arrow.  Default is 12.
 
         Returns:
         ========
@@ -1479,6 +1489,7 @@ class Bats2d(IdlFile):
         from numpy import array
         from numpy.random import sample
         from matplotlib.collections import LineCollection
+        from spacepy.plot import add_arrows
         
         # Set ax and fig based on given target.
         fig, ax = set_target(target, figsize=(10,10), loc=loc)
@@ -1540,6 +1551,10 @@ class Bats2d(IdlFile):
         # Set the plot limits to match
         ax.set_xlim(xlim)
         ax.set_ylim(ylim)
+
+        # Add arrows if requested:
+        if narrow > 0:
+            add_arrows(collect, n=narrow, size=arrsize, style=arrstyle)
         
         return fig, ax, collect, start_points
                          
@@ -1688,9 +1703,9 @@ class Bats2d(IdlFile):
     
     def add_b_magsphere(self, target=None, loc=111,  style='mag', 
                         DoLast=True, DoOpen=True, DoTail=True,
-                        compX='bx',compY='bz',
-                        method='rk4', tol=np.pi/360., DoClosed=True,
-                        nOpen=5, nClosed=15, **kwargs):
+                        compX='bx',compY='bz', narrow=0, arrsize=12,
+                        method='rk4', tol=np.pi/720., DoClosed=True,
+                        nOpen=5, nClosed=15, arrstyle='->', **kwargs):
         '''
         Create an array of field lines closed to the central body in the
         domain.  Add these lines to Matplotlib target object *target*.
@@ -1723,6 +1738,12 @@ class Bats2d(IdlFile):
                    Defaults to 5.
         nClosed    Number of open field lines to trace per hemisphere.
                    Defaults to 15.
+        narrow     Add "n" arrows to each line to indicate direction.
+                   Default is zero, or no lines.
+        arrstyle   Set the arrow style in the same manner as Matplotlib's 
+                   annotate function.  Default is '->'.
+        arrsize    Set the size, in points, of each directional arrow.
+                   Default is 12.
         method     The tracing method; defaults to 'rk4'.   See 
                    :class:`spacepy.pybats.bats.Stream`.
         tol        Tolerance for finding open-closed boundary; see
@@ -1741,6 +1762,7 @@ class Bats2d(IdlFile):
         from matplotlib.collections import LineCollection
         from numpy import (arctan, cos, sin, where, pi, log, 
                            arange, sqrt, linspace, array)
+        from spacepy.plot import add_arrows
         
         # Set ax and fig based on given target.
         fig, ax = set_target(target, figsize=(10,10), loc=111)
@@ -1801,6 +1823,10 @@ class Bats2d(IdlFile):
         collect = LineCollection(lines, colors=colors, **kwargs)
         ax.add_collection(collect)
 
+        # Add lines if required:
+        if narrow>0:
+            add_arrows(collect, n=narrow, size=arrsize, style=arrstyle)
+        
         return fig, ax, collect
 
     def add_b_magsphere_new(self, *args, **kwargs):

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1552,8 +1552,12 @@ class Bats2d(IdlFile):
         ax.set_xlim(xlim)
         ax.set_ylim(ylim)
 
-        # Add arrows if requested:
-        if narrow > 0:
+        # Add arrows if requested.  If one point per line, use starting points.
+        # Otherwise, distribute arrows along lines.
+        if narrow == 1:
+            add_arrows(collect, n=narrow, size=arrsize,
+                       positions=start_points, style=arrstyle)
+        elif narrow > 1:
             add_arrows(collect, n=narrow, size=arrsize, style=arrstyle)
         
         return fig, ax, collect, start_points

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -163,6 +163,25 @@ class TestBats2d(unittest.TestCase):
 
         mhd.calc_all(exclude=['calc_gradP', 'calc_vort'])
 
+    def testPlotting(self):
+        '''
+        Create a contour plot, add stream traces with arrows, 
+        close plot, pass if no Exceptions.  This is a basic test that
+        ensures that all methods and functions underlying contours and
+        field line tracing are at least operating to completion.
+        '''
+
+        import matplotlib.pyplot as plt
+
+        # Test adding a basic contour:
+        fig, ax, cnt, cbar = self.mhd.add_contour('x', 'z', 'p', add_cbar=True)
+
+        # Test adding field lines via "add_b_magsphere":
+        self.mhd.add_b_magsphere(target=ax, narrow=5)
+
+        # Test adding streams via "add_stream_scatter":
+        self.mhd.add_stream_scatter('ux','uz',target=ax,narrow=1)
+        
 class TestMagGrid(unittest.TestCase):
     '''
     Test the class :class:`spacepy.pybats.bats.MagGridFile` to ensure opening,

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -348,12 +348,32 @@ class TestImfInput(unittest.TestCase):
     knownImfRho  = [5., 15.]
     knownImfTemp = [.80E+05, 1.20E+05]
     knownImfIono = [4.99, 0.01]
+    knownSubMilli= dt.datetime(2017, 9, 6, 16, 42, 36, 999000)
 
     def tearDown(self):
         # Remove temporary files.
         for f in glob.glob('*.tmp'):
             os.remove(f)
 
+    def testSubMillisec(self):
+        '''
+        Test case where sub-millisecond time values can create problems on
+        read/write.
+        '''
+        # Create an IMF object from scratch, fill with zeros.
+        imf = pb.ImfInput()
+        for key in imf: imf[key]=[0]
+        
+        # Add a sub-millisecond time:
+        imf['time'] = [dt.datetime(2017,9,6,16,42,36,999500)]
+
+        # Write and test for non-failure on re-read:
+        imf.write('testme.tmp')
+        imf2 = pb.ImfInput('testme.tmp')
+
+        # Test for floor of sub-millisecond times:
+        self.assertEqual(self.knownSubMilli, imf2['time'][0])
+            
     def testWrite(self):
         # Test that files are correctly written to file.
         


### PR DESCRIPTION
Closes #291 

Changes writing ImfInput objects to file: sub-millisecond values now use `floor` when converting micro- to millisecond values instead of round.  
A new test has been added to make sure that this works using the example given in the issue.

## PR Checklist
- [ n/a] New code has inline comments where necessary
- [ n/a] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ n/a] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ x] New features and bug fixes should have unit tests

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves issue #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

