### PR TITLE
Updated PR template to be clearer and fix issue references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,24 @@
 ## PR Checklist
 New code is easier to review, integrate and maintain if it's
 consistent with the style of the rest of the SpacePy code.
-Please try to follow as much of this checkl;ist as you can for
+Please try to follow as much of this checklist as you can for
 your PR. If you can't hit everything, or don't know how to,
 then submit the PR and the rest can be discussed during review.
+Some additional suggestions are given below.
 
 Please also see our Code of Conduct so that the SpacePy community
 remains welcoming and inclusive.
 
+Go ahead and replace the text above (and this line!) with your
+pull request description.
+
+- [ ] Pull request has descriptive title
+- [ ] Pull request gives overview of changes
 - [ ] New code has inline comments where necessary
 - [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
 - [ ] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
 - [ ] New features and bug fixes should have unit tests
+- [ ] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
 
 <!--
 Thank you so much for your PR!  The SpacePy community appreciates your
@@ -26,7 +33,7 @@ consider the following points:
 - The PR summary should provide at least 1-2 sentences describing the pull request
   in detail (Why is this change required?  What problem does it solve?) and
   link to any relevant issues. If the PR resolves an issue, please write this in the summary
-  so that github will automatically close the issue. E.g. "This PR resolves issue #1".
+  so that github will automatically close the issue. E.g. "This PR resolves #1".
 
 We understand that working with PRs can be tricky, even for seasoned contributors.
 Please let us know if reviews are unclear or our recommendations seem like excessive work.


### PR DESCRIPTION
I didn't make an issue for this, so what does this do?
- In the old PR template the text gave an example `This PR resolves issue #1`, which doesn't link the issue because `issue` is between the magic word and the actual issue reference. This has been updated to show correct syntax.
- Experience suggests that the PR template doesn't really give clear instructions on what to write. As far as I'm concerned deviation from the template is fine as long as the information is present and the boxes have been checked (figuratively speaking), but that assumes the pull-requestor has a good idea of what we need to see in the PR description. To that end I added some of our suggestions as checklist items.
- I've given explicit direction in the updated PR template to replace the preamble text from the template with a PR description. Can't hurt to be more direct about that, right?
- Typo fixed in the old template.