### PR TITLE
ImfInput now rounds sub-millisecond times on write.

### DIFF
--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1569,7 +1569,7 @@ class ImfInput(PbData):
         out.write('\n#START\n')
         for i in range(len(self['time'])):
             out.write('{:%Y %m %d %H %M %S} {:03d} '.format(
-                self['time'][i], int(round(self['time'][i].microsecond/1000.))))
+                self['time'][i], int(self['time'][i].microsecond/1000.)))
             out.write(' {}\n'.format(
                 ' '.join('{:10.2f}'.format(self[key][i]) for key in var)))
         out.close()

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1569,7 +1569,7 @@ class ImfInput(PbData):
         out.write('\n#START\n')
         for i in range(len(self['time'])):
             out.write('{:%Y %m %d %H %M %S} {:03d} '.format(
-                self['time'][i], int(self['time'][i].microsecond/1000.)))
+                self['time'][i], self['time'][i].microsecond//1000))
             out.write(' {}\n'.format(
                 ' '.join('{:10.2f}'.format(self[key][i]) for key in var)))
         out.close()

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1564,12 +1564,19 @@ class ImfInput(PbData):
             out.write('#PLANE\n{}\n'.format(
                 ''.join('{:-6.2f}\n'.format(n)
                 for n in self.attrs['plane'])))
-
+            
         # Write the data:
         out.write('\n#START\n')
         for i in range(len(self['time'])):
-            out.write('{:%Y %m %d %H %M %S} {:03d} '.format(
-                self['time'][i], self['time'][i].microsecond//1000))
+            # Round to nearest millisecond; check for rounding
+            # to nearest second:
+            t = self['time'][i]
+            ms = int(round(t.microsecond / 1000.))
+            if ms >999:
+                ms = 0
+                t += dt.timedelta(microseconds=1000)
+            # Write record to file:
+            out.write('{:%Y %m %d %H %M %S} {:03d} '.format(t, ms))
             out.write(' {}\n'.format(
                 ' '.join('{:10.2f}'.format(self[key][i]) for key in var)))
         out.close()

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -329,12 +329,32 @@ class TestImfInput(unittest.TestCase):
     knownImfRho  = [5., 15.]
     knownImfTemp = [.80E+05, 1.20E+05]
     knownImfIono = [4.99, 0.01]
+    knownSubMilli= dt.datetime(2017, 9, 6, 16, 42, 36, 999000)
 
     def tearDown(self):
         # Remove temporary files.
         for f in glob.glob('*.tmp'):
             os.remove(f)
 
+    def testSubMillisec(self):
+        '''
+        Test case where sub-millisecond time values can create problems on
+        read/write.
+        '''
+        # Create an IMF object from scratch, fill with zeros.
+        imf = pb.ImfInput()
+        for key in imf: imf[key]=[0]
+        
+        # Add a sub-millisecond time:
+        imf['time'] = [dt.datetime(2017,9,6,16,42,36,999500)]
+
+        # Write and test for non-failure on re-read:
+        imf.write('testme.tmp')
+        imf2 = pb.ImfInput('testme.tmp')
+
+        # Test for floor of sub-millisecond times:
+        self.assertEqual(self.knownSubMilli, imf2['time'][0])
+            
     def testWrite(self):
         # Test that files are correctly written to file.
         

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -329,7 +329,7 @@ class TestImfInput(unittest.TestCase):
     knownImfRho  = [5., 15.]
     knownImfTemp = [.80E+05, 1.20E+05]
     knownImfIono = [4.99, 0.01]
-    knownSubMilli= dt.datetime(2017, 9, 6, 16, 42, 36, 999000)
+    knownSubMilli= dt.datetime(2017, 9, 6, 16, 42, 37, 0)
 
     def tearDown(self):
         # Remove temporary files.
@@ -346,7 +346,7 @@ class TestImfInput(unittest.TestCase):
         for key in imf: imf[key]=[0]
         
         # Add a sub-millisecond time:
-        imf['time'] = [dt.datetime(2017,9,6,16,42,36,999500)]
+        imf['time'] = [dt.datetime(2017,9,6,16,42,36,999600)]
 
         # Write and test for non-failure on re-read:
         imf.write('testme.tmp')


### PR DESCRIPTION
Closes #291 

Repeat of previous PR that had conflicting merges.

Changes writing ImfInput objects to file: sub-millisecond values now use floor when converting micro- to millisecond values instead of round.
A new test has been added to make sure that this works using the example given in the issue.

I want to note @jtniehof's suggestion:

```
t = self.time[i]
ms = int(round(t.microsecond / 1000.))
if ms = 10000:
    ms = 0
    t += dt.timedelta(microseconds=1000)
out.write('{:%Y %m %d %H %M %S} {:03d} '.format(t, ms))
```

This is an alternative worth discussing, but I am hesitant to nest an `if` statement in a sometimes very long `for` loop.  IMF files can contain upwards of month(s) worth of data at sub-minute resolution, so writing can already be slow.  Worth discussing.

PR Checklist
[ n/a] New code has inline comments where necessary
[ n/a] Any new modules, functions or classes have docstrings consistent with SpacePy style
[ n/a] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
[ x] New features and bug fixes should have unit tests


