### PR TITLE
Fix change of datetime dataype in writeJSONheadedASCII

### DIFF
--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1666,7 +1666,7 @@ def _dateToISO(indict):
         if isinstance(indict, datetime.datetime):
             retdict = retdict.isoformat()
         elif hasattr(indict, '__iter__'):
-            retdict = numpy.asanyarray(indict)
+            retdict = numpy.asanyarray(retdict)
             for idx, el in numpy.ndenumerate(indict):
                 if isinstance(el, datetime.datetime):
                     retdict[idx] = el.isoformat()

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -909,6 +909,25 @@ class JSONTests(unittest.TestCase):
         restype = type(data['Epoch'][0])
         self.assertEqual(exptype, restype)
 
+    def test_dateToISOunaltered_SD(self):
+        """Test to check that _dateToISO doesn't change datatypes, input SpaceData"""
+        data = dm.SpaceData()
+        data['Epoch'] = spt.tickrange('20200101', '20200102',
+                                      deltadays=datetime.timedelta(hours=1)).UTC
+        exptype = type(data['Epoch'][0])
+        newdata = dm._dateToISO(data)
+        restype = type(data['Epoch'][0])
+        self.assertEqual(exptype, restype)
+
+    def test_dateToISOunaltered_dm(self):
+        """Test to check that _dateToISO doesn't change datatypes, input dmarray"""
+        data = spt.tickrange('20200101', '20200102',
+                             deltadays=datetime.timedelta(hours=1)).UTC
+        exptype = type(data[0])
+        newdata = dm._dateToISO(data)
+        restype = type(data[0])
+        self.assertEqual(exptype, restype)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -891,6 +891,24 @@ class JSONTests(unittest.TestCase):
         np.testing.assert_array_equal(a['MVar'], dat2['MVar'])
         os.remove(t_file.name)
 
+    def test_toJSON_timeunaltered(self):
+        """Test to check that stored datetimes aren't changed on write"""
+        data = dm.SpaceData()
+        data['Epoch'] = spt.tickrange('20200101', '20200102',
+                                      deltadays=datetime.timedelta(hours=1)).UTC
+        exptype = type(data['Epoch'][0]) #datetime.datetime
+        # save to file, then immediately clean up
+        fname = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as fp:
+                fname = fp.name
+                data.toJSONheadedASCII(fname)
+        finally:
+            if fname != None:
+                os.remove(fname)
+        restype = type(data['Epoch'][0])
+        self.assertEqual(exptype, restype)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Issue #314 shows that calling `toJSONheadedASCII` can overwrite the `datetime` datatypes with the ISO strings that are generated for write.
This PR adds a test for this behaviour, plus two additional tests to ensure that the `_dateToISO` function isn't changing datatypes (which was the root cause of this bug).
This PR also fixes the issue: For non-`SpaceData` types the copy was being squelched in trying to ensure that the input was an array subtype. The coercion is now done on the copied input, not on the uncopied input.

Closes #314 

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

Note: I haven't added this to CHANGELOG. Can do if review says it warrants its own CHANGELOG entry. Updates to CHANGELOG with multiple PRs active has led to a lot of updating/fixing conflicts in PRs though, so I'm going to leave it this way unless asked...