### PR TITLE
omni.py: updated calls to `h5py.File()`, closes #322

### DIFF
--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -245,7 +245,7 @@ def get_omni(ticks, dbase='QDhourly', **kwargs):
         else:
             ldb = 'Test'
             fln = testfln
-        with h5.File(fln, 'r') as hfile:
+        with h5.File(fln, mode='r') as hfile:
             QDkeylist = [kk for kk in hfile if kk not in ['Qbits', 'UTC']]
             st, en = ticks[0].RDT, ticks[-1].RDT
             ##check that requested requested times are within range of data
@@ -271,7 +271,7 @@ def get_omni(ticks, dbase='QDhourly', **kwargs):
 
     if dbase_options[dbase] == 2 or dbase_options[dbase] == 3:
         ldb = 'OMNI2hourly'
-        with h5.File(omni2fln) as hfile:
+        with h5.File(omni2fln, mode='r') as hfile:
             O2keylist = [kk for kk in hfile if kk not in ['Epoch','RDT']]
             st, en = ticks[0].RDT, ticks[-1].RDT
             ##check that requested requested times are within range of data
@@ -373,7 +373,7 @@ def omnirange(dbase='QDhourly'):
               'Test': testfln}
     if dbase not in infile:
         raise NotImplementedError('')
-    with h5.File(infile[dbase]) as hfile:
+    with h5.File(infile[dbase], mode='r') as hfile:
         start, end = hfile['RDT'][0], hfile['RDT'][-1]
         start = spt.Ticktock(start, 'RDT').UTC[0]
         end = spt.Ticktock(end, 'RDT').UTC[0]


### PR DESCRIPTION
Very minor update to get rid of a deprecation warning, added a `mode=` to each `h5py.File()` call. Closes #322. 

- [ X] Pull request has descriptive title
- [X ] Pull request gives overview of changes
- [ X] New code has inline comments where necessary
- [ n/a] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ n/a] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ n/a] New features and bug fixes should have unit tests
- [ X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
