### PR TITLE
Rename test_spacepy.py to test_all.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 
 script:
  - python setup.py install
- - cd tests; . /home/travis/bin/definitions.B; xvfb-run python test_spacepy.py
+ - cd tests; . /home/travis/bin/definitions.B; xvfb-run python test_all.py
 
 notifications:
  webhooks: https://www.travisbuddy.com/

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -4,10 +4,8 @@
 """
 Master test suite for SpacePy
 
-version: V1: 28-May-2011
-
-
-Copyright 2010-2014 Los Alamos National Security, LLC.
+Copyright 2010-2014 Triad National Security, LLC.
+Copyright 2015-2020 the contributors
 """
 
 import sys


### PR DESCRIPTION
#300 is going to require having some actual tests against the top-level `spacepy/__init__.py`. It would make sense to name that `test_spacepy.py` except we're already using the name for our "run all tests" script. This PR renames to `test_all.py` to open up the script name for future tests. (Also updates the copyright line since I was in there anyway.)

I haven't made a CHANGELOG entry because this is pretty dev-internal, but I can imagine people might find it confusing, so suggestions welcome there. (We really don't have anything about our testing in the docs right now anyhow.)

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [ ] (N/A) New code has inline comments where necessary
- [ ] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ ] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
