### PR TITLE
Add conversion for non-IRBEM-supported coordinates in prep_irbem (closes #330)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ coordinates
 irbempy
  - Update IRBEMlib to rev620
  - Rev620 adds IGRF13 coefficients
+ - Add conversion so all systems supported by coordinates can be passed
+   to IRBEMlib routines
 plot
  - utils.EventClicker support for non-line plots (e.g. pcolor)
  - New method for adding arrows to lines in utils

--- a/spacepy/irbempy/irbempy.py
+++ b/spacepy/irbempy/irbempy.py
@@ -1810,18 +1810,26 @@ def prep_irbem(ticks=None, loci=None, alpha=[], extMag='T01STORM', options=[1,0,
 
     # copy coordinates into array
     # prepare coordinates
-    d['sysaxes'] = loci.sysaxes
+    if loci.sysaxes is None:
+        # System type not supported by IRBEM
+        # Convert car -> sph or vice versa as required
+        newcarsph = [key for (key, val) in SYSAXES_TYPES[loci.dtype].items()
+                     if val is not None][0]
+        posi = loci.convert(loci.dtype, newcarsph)
+    else:
+        posi = loci
+    d['sysaxes'] = posi.sysaxes
     xin1 = np.zeros(ntime_max, dtype=float)
     xin2 = np.zeros(ntime_max, dtype=float)
     xin3 = np.zeros(ntime_max, dtype=float) 
-    if loci.carsph == 'sph':
-        xin1[0:nTAI] = loci.radi[:]
-        xin2[0:nTAI] = loci.lati[:]
-        xin3[0:nTAI] = loci.long[:]
+    if posi.carsph == 'sph':
+        xin1[0:nTAI] = posi.radi[:]
+        xin2[0:nTAI] = posi.lati[:]
+        xin3[0:nTAI] = posi.long[:]
     else:
-        xin1[0:nTAI] = loci.x[:]
-        xin2[0:nTAI] = loci.y[:]
-        xin3[0:nTAI] = loci.z[:]
+        xin1[0:nTAI] = posi.x[:]
+        xin2[0:nTAI] = posi.y[:]
+        xin3[0:nTAI] = posi.z[:]
     d['xin1'] = xin1
     d['xin2'] = xin2
     d['xin3'] = xin3

--- a/tests/test_irbempy.py
+++ b/tests/test_irbempy.py
@@ -159,11 +159,25 @@ class IRBEMTestsWithoutOMNI(unittest.TestCase):
         self.assertEqual(expected, ib.get_dtype(sysaxes))
 
     def test_get_sysaxes(self):
+        """Test that expected value is returned for sysaxes query"""
         dtype = 'GSE'
-        carsph = 'car'
-        expected = 3
-        self.assertEqual(expected, ib.get_sysaxes(dtype, carsph))
-        
+        self.assertEqual(3, ib.get_sysaxes(dtype, 'car'))
+        self.assertEqual(None, ib.get_sysaxes(dtype, 'sph'))
+
+    def test_prep_irbem_sysaxesnone(self):
+        """prep_irbem should handle 'car' and 'sph' version of systems identically"""
+        locc = spacepy.coordinates.Coords([[3,0,0],[2,0,0]], 'GSM', 'car')
+        out1 = ib.prep_irbem(ticks=self.ticks, loci=locc,
+                             extMag='0', options=[1, 0, 0, 0, 1])
+        pos = ib.car2sph(locc.data)
+        locs = spacepy.coordinates.Coords(pos, 'GSM', 'sph')
+        out2 = ib.prep_irbem(ticks=self.ticks, loci=locs,
+                             extMag='0', options=[1, 0, 0, 0, 1])
+        self.assertEqual(out1['sysaxes'], out2['sysaxes'])
+        numpy.testing.assert_almost_equal(out1['xin1'], out2['xin1'])
+        numpy.testing.assert_almost_equal(out1['xin2'], out2['xin2'])
+        numpy.testing.assert_almost_equal(out1['xin3'], out2['xin3'])
+
     def test_sph2car(self):
         loc = [1,45,45]
         expected = array([ 0.5,  0.5,  0.70710678])	


### PR DESCRIPTION
Issue #330 identifies an untrapped error when using non-IRBEM-supported coordinate systems.
IRBEM assumes that GSE, GSM, etc. are cartesian. `spacepy.coordinates` allows representation of all systems in both cartesian and spherical.

This PR checks whether the system/representation combination is supported by IRBEM, and if not, performs a spherical to cartesian (or vice versa) transform in the preparation of the data structure to pass to IRBEM.
A test has been added to ensure that spherical and cartesian representations give the same answer (and don't raise exceptions).

Closes #330 
- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to