### PR TITLE
Warn if create CDF without making explicit backward-compat or not.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,8 @@ pycdf
  - istp.VariableChecks and FileChecks add check for empty attribute Entries
  - istp.VarBundle class to copy variables, slices, and depends between CDFs
  - istp.nanfill function to replace fill values with NaN
+ - Warn if make CDF without explicitly setting backward compatible mode
+   (either true or false); default will change to NOT backward compatible.
 pybats
  - Updated gitm.GitmBin reader to fix failures in Python 3.x.
  - Fix for incorrect Kyoto Kp plots.

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -461,6 +461,8 @@ class Library(object):
 
         #Default to V2 CDF
         self.set_backward(True)
+        # User has not explicitly called set_backward
+        self._explicit_backward = False
 
     @staticmethod
     def _find_lib():
@@ -650,6 +652,8 @@ class Library(object):
         ======
         ValueError : if backward=False and underlying CDF library is V2
         """
+        # User has explicitly chosen backward compat or not
+        self._explicit_backward = True
         if self.version[0] < 3:
             if not backward:
                 raise ValueError(
@@ -1917,7 +1921,12 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             Not intended for direct call; pass parameters to
             :py:class:`pycdf.CDF` constructor.
         """
-
+        if not lib._explicit_backward:
+            warnings.warn(
+                'spacepy.pycdf.lib.set_backward not called;'
+                ' making backward-compatible CDF.'
+                ' This default will change in the future.',
+                DeprecationWarning)
         lib.call(const.CREATE_, const.CDF_, self.pathname, ctypes.c_long(0),
                               (ctypes.c_long * 1)(0), ctypes.byref(self._handle))
         self._opened = True


### PR DESCRIPTION
This is the first step towards #198, warning the user that the default for backward-compatible CDFs is about to change. Basically if the user hasn't explicitly set backward-compatible one way or the other, this will warn when making a new CDF (if made from a master, the master's backward-compatible carries over.)

The real nastiness is in the test suite, because there's a bug in Python 2.7 that requires some work-arounds to make sure the deprecation warning is really raised. And then the test suite needs to quiet all the places where the tests are assuming the default--thus a second commit to separate that out.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [ ] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
