### PR TITLE
Retrieve Qin-Denton and leapseconds from new source (Closes #233)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ pybats
 toolbox
  - New function get_url to retrieve data from a URL
  - Change update to retrieve OMNI2 data from SPDF not ViRBO
+ - Change update to supplement ViRBO Qin-Denton files with NMC daily files
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ toolbox
  - New function get_url to retrieve data from a URL
  - Change update to retrieve OMNI2 data from SPDF not ViRBO
  - Change update to supplement ViRBO Qin-Denton files with NMC daily files
+ - Change update to get leapseconds from NASA MODIS instead of USNO
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/Doc/source/configuration.rst
+++ b/Doc/source/configuration.rst
@@ -38,7 +38,6 @@ If you change the default location, make sure you add the environment
 variable ``$SPACEPY`` to your ``.cshrc, .tcshrc,`` or ``.bashrc``
 script.
 
-
 Available configuration options
 ===============================
 enable_deprecation_warning
@@ -48,6 +47,13 @@ enable_deprecation_warning
   deprecated function is called. Set this option to False to retain the default
   Python behavior. (See :py:mod:`warnings` module for details on custom warning
   filters.)
+
+keepalive
+  True to attempt to use HTTP keepalives when downloading data in
+  :py:func:`~spacepy.toolbox.update` (default). This is faster when
+  downloading many small files but may be fragile (e.g. if a proxy
+  server is required). Set to False for a more robust and flexible,
+  but slower, codepath.
 
 leapsec_url
   URL of the leapsecond database used by time conversions.

--- a/Doc/source/configuration.rst
+++ b/Doc/source/configuration.rst
@@ -76,9 +76,15 @@ omni2_url
   The default should almost always be acceptable.
 
 qindenton_url
-  URL containing Qin-Denton packaging of OMNI data.
+  URL containing Qin-Denton packaging of OMNI data as as single file.
   :py:func:`~spacepy.toolbox.update` will download from the URL.
   The default should almost always be acceptable.
+
+qd_daily_url
+  URL containing Qin-Denton packaging of OMNI data in daily files,
+  supplemental to ``qindenton_url``. :py:func:`~spacepy.toolbox.update`
+  will download from the URL. The default should almost always be
+  acceptable.
 
 psddata_url
   URL containing PSD data.

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -236,7 +236,7 @@ def _read_config(rcfile):
     global config
     defaults = {'enable_deprecation_warning': str(True),
                 'ncpus': str(multiprocessing.cpu_count()),
-                'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip',
+                'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip', # Future: https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/
                 'omni2_url': 'https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hourly/',
                 'leapsec_url': 'http://maia.usno.navy.mil/ser7/tai-utc.dat',
                 'psddata_url': 'http://spacepy.lanl.gov/repository/psd_dat.sqlite',

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -235,6 +235,7 @@ def _read_config(rcfile):
     """Read configuration information from a file"""
     global config
     defaults = {'enable_deprecation_warning': str(True),
+                'keepalive': str(True),
                 'ncpus': str(multiprocessing.cpu_count()),
                 'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip', # Future: https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/
                 'omni2_url': 'https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hourly/',
@@ -246,6 +247,7 @@ def _read_config(rcfile):
     #Functions to cast a config value; if not specified, value is a string
     str2bool = lambda x: x.lower() in ('1', 'yes', 'true', 'on')
     caster = {'enable_deprecation_warning': str2bool,
+              'keepalive': str2bool,
               'ncpus': int,
               'support_notice': str2bool,
               'apply_plot_styles': str2bool,

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -237,7 +237,8 @@ def _read_config(rcfile):
     defaults = {'enable_deprecation_warning': str(True),
                 'keepalive': str(True),
                 'ncpus': str(multiprocessing.cpu_count()),
-                'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip', # Future: https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/
+                'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip',
+                'qd_daily_url': 'https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/',
                 'omni2_url': 'https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hourly/',
                 'leapsec_url': 'http://maia.usno.navy.mil/ser7/tai-utc.dat',
                 'psddata_url': 'http://spacepy.lanl.gov/repository/psd_dat.sqlite',

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -240,7 +240,7 @@ def _read_config(rcfile):
                 'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip',
                 'qd_daily_url': 'https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/',
                 'omni2_url': 'https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hourly/',
-                'leapsec_url': 'http://maia.usno.navy.mil/ser7/tai-utc.dat',
+                'leapsec_url': 'https://oceandata.sci.gsfc.nasa.gov/Ancillary/LUTs/modis/leapsec.dat',
                 'psddata_url': 'http://spacepy.lanl.gov/repository/psd_dat.sqlite',
                 'support_notice': str(True),
                 'apply_plot_styles': str(True),

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1403,6 +1403,9 @@ class Ticktock(MutableSequence):
             fname = os.path.join(DOT_FLN, 'data', 'tai-utc.dat')
             with open(fname) as fh:
                 text = fh.readlines()
+            # Some files have a "last checked" line at the top
+            if text[0].startswith('Checked'):
+                del text[0]
 
             secs = np.zeros(len(text))
             year = np.zeros(len(text))

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -831,12 +831,12 @@ def _crawl_yearly(base_url, pattern, datadir, name=None):
     return filenames if newdata else None
 
 
-def _get_qindenton(qindenton_url=None):
-    """Download the Qin-Denton OMNI-like data
+def _get_qindenton_daily(qd_daily_url=None):
+    """Download the Qin-Denton OMNI-like daily files
     
     Parameters
     ==========
-    qindenton_url : str (optional)
+    qd_daily_url : str (optional)
         Base of the Qin-Denton data, in hourly JSON-headed ASCII. This URL
         should point to the directory containing the yearly directories.
         Default from ``qindenton_url`` in config file.
@@ -847,11 +847,11 @@ def _get_qindenton(qindenton_url=None):
         The data extracted from the Q-D dataset, fully processed for saving
         as SpacePy HDF5 OMNI data. Returns ``None`` if there are no new data.
     """
-    if qindenton_url is None:
-        qindenton_url = spacepy.config['qindenton_url']
-    datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_files')
-    _crawl_yearly(qindenton_url, r'QinDenton_\d{8}_hour.txt',
-                  datadir, name='Q-D')
+    if qd_daily_url is None:
+        qd_daily_url = spacepy.config['qd_daily_url']
+    datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_daily_files')
+    _crawl_yearly(qd_daily_url, r'QinDenton_\d{8}_hour.txt',
+                  datadir, name='Q-D daliy')
     #Read and process
     print("Reading Q-D files ...")
 

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1075,10 +1075,13 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
             #Timestamp is truncated to second, so do same for local
             local_mod = int(os.path.getmtime(outfile))
             if modified <= local_mod:
-                if not keepalive:
+                if keepalive:
+                    r.read()
+                else:
                     r.close()
                 return (None, conn) if keepalive else None
         if keepalive: # Replace previous header request with full get
+            r.read()
             conn.request('GET', path, headers=clheaders)
             r, headers= checkresponse(conn)
     size = int(headers.get('Content-Length', 0))
@@ -1093,7 +1096,8 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         count += 1
         if reporthook:
             reporthook(count, blocksize, size)
-    r.close()
+    if not keepalive:
+        r.close()
     if outfile:
         with open(outfile, 'wb') as f:
             for d in data:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -807,6 +807,31 @@ def _crawl_yearly(base_url, pattern, datadir, name=None):
     return filenames if newdata else None
 
 
+def _get_qindenton(qindenton_url=None):
+    """Download the Qin-Denton OMNI-like data
+    
+    Parameters
+    ==========
+    qindenton_url : str (optional)
+        Base of the Qin-Denton data, in hourly JSON-headed ASCII. This URL
+        should point to the directory containing the yearly directories.
+        Default from ``qindenton_url`` in config file.
+
+    Returns
+    =======
+    SpaceData
+        The data extracted from the Q-D dataset, fully processed for saving
+        as SpacePy HDF5 OMNI data. Returns ``None`` if there are no new data.
+    """
+    if qindenton_url is None:
+        qindenton_url = spacepy.config['qindenton_url']
+    datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_files')
+    _crawl_yearly(qindenton_url, r'QinDenton_\d{8}_hour.txt',
+                  datadir, name='Q-D')
+    #Read and process
+    print("Reading Q-D files ...")
+
+
 def _get_cdaweb_omni2(omni2url=None):
     """Download the OMNI2 data from SPDF
 

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -998,7 +998,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         the URL is newer than the file.
     keepalive : bool (optional)
         Attempt to keep the connection open to retrieve more URLs.
-        The return becomes a tuple of (conn, data) to return the
+        The return becomes a tuple of (data, conn) to return the
         connection used so it can be used again. This mode does not
         support proxies. (Default False)
     conn : http.client.HTTPConnection (optional)
@@ -1077,7 +1077,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
             if modified <= local_mod:
                 if not keepalive:
                     r.close()
-                return (conn, None) if keepalive else None
+                return (None, conn) if keepalive else None
         if keepalive: # Replace previous header request with full get
             conn.request('GET', path, headers=clheaders)
             r, headers= checkresponse(conn)
@@ -1101,7 +1101,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         if modified is not None: #Copy web mtime to file
             os.utime(outfile, (int(time.time()), modified))
     data = b''.join(data)
-    return (conn, data) if keepalive else data
+    return (data, conn) if keepalive else data
 
 
 def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDdata=False):

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -772,10 +772,12 @@ def _crawl_yearly(base_url, pattern, datadir, name=None):
     #Find all the files to download
     print("Finding {}files to download ...".format(name))
     progressbar(0, 1, 1, text='Listing files')
-    try:
-        data, conn = get_url(base_url, keepalive=True)
-    except socket.error: #Give up on keepalives
-        conn = None
+    conn = None
+    if spacepy.config['keepalive']:
+        try:
+            data, conn = get_url(base_url, keepalive=True)
+        except socket.error: #Give up on keepalives
+            pass
     if conn is None:
         data = get_url(base_url)
     if str is not bytes:
@@ -1129,7 +1131,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
     Download and update local database for omni, leapsecs etc
 
     Web access is via :func:`get_url`; notes there may be helpful in
-    debugging errors.
+    debugging errors. See also the ``keepalive`` configuration option.
 
     Parameters
     ==========

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1037,7 +1037,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         if conn is None:
             ctype = http.client.HTTPConnection if scheme == 'http:'\
                     else http.client.HTTPSConnection
-            conn = ctype(host, timeout=1)
+            conn = ctype(host)
         clheaders = {
             "Connection": "keep-alive",
         }

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -743,7 +743,7 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
     return None
 
 
-def _crawl_yearly(base_url, pattern, datadir, name=None):
+def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True):
     """Crawl files in a directory-by-year structure
 
     Parameters
@@ -760,6 +760,10 @@ def _crawl_yearly(base_url, pattern, datadir, name=None):
         directories.
     name : str (optional)
         Name of the data set, used only in status messages.
+    cached : boolean (optional)
+        Only update files if timestamp on server is newer than
+        timestamp on local file (default). Set False to always
+        download files.
 
     Returns
     =======
@@ -819,10 +823,10 @@ def _crawl_yearly(base_url, pattern, datadir, name=None):
     for i, fname in enumerate(filenames):
         if conn is None:
             res = get_url(downloadme[fname], os.path.join(datadir, fname),
-                          cached=True)
+                          cached=cached)
         else:
             res, conn = get_url(downloadme[fname], os.path.join(datadir, fname),
-                                cached=True, keepalive=True, conn=conn)
+                                cached=cached, keepalive=True, conn=conn)
         if res is not None:
             newdata = True
         progressbar(i + 1, 1, len(filenames))
@@ -831,7 +835,7 @@ def _crawl_yearly(base_url, pattern, datadir, name=None):
     return filenames if newdata else None
 
 
-def _get_qindenton_daily(qd_daily_url=None):
+def _get_qindenton_daily(qd_daily_url=None, cached=True):
     """Download the Qin-Denton OMNI-like daily files
     
     Parameters
@@ -840,6 +844,10 @@ def _get_qindenton_daily(qd_daily_url=None):
         Base of the Qin-Denton data, in hourly JSON-headed ASCII. This URL
         should point to the directory containing the yearly directories.
         Default from ``qd_daily_url`` in config file.
+    cached : boolean (optional)
+        Only update files if timestamp on server is newer than
+        timestamp on local file (default). Set False to always
+        download files.
 
     Returns
     =======
@@ -851,7 +859,7 @@ def _get_qindenton_daily(qd_daily_url=None):
         qd_daily_url = spacepy.config['qd_daily_url']
     datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_daily_files')
     _crawl_yearly(qd_daily_url, r'QinDenton_\d{8}_hour.txt',
-                  datadir, name='Q-D daliy')
+                  datadir, name='Q-D daliy', cached=cached)
     #Read and process
     print("Reading/processing Q-D daily files ...")
     return _assemble_qindenton_daily(datadir)
@@ -1203,7 +1211,8 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
     return (data, conn) if keepalive else data
 
 
-def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDdata=False):
+def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False,
+           PSDdata=False, cached=True):
     """
     Download and update local database for omni, leapsecs etc
 
@@ -1222,6 +1231,10 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         if True, update OMNI2 and Qin-Denton
     leapsecs : boolean (optional)
         if True, update only leapseconds
+    cached : boolean (optional)
+        Only update files if timestamp on server is newer than
+        timestamp on local file (default). Set False to always
+        download files.
 
     Returns
     =======
@@ -1275,7 +1288,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         # retrieve omni, unzip and save as table
         print("Retrieving Qin_Denton file ...")
         get_url(config['qindenton_url'], omni_fname_zip, progressbar,
-                cached=True)
+                cached=cached)
         fh_zip = zipfile.ZipFile(omni_fname_zip)
         data = fh_zip.read(fh_zip.namelist()[0])
         fh_zip.close()
@@ -1354,7 +1367,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         del omnidata['Hr']
 
         # Supplement with daily files
-        dailyomnidata = _get_qindenton_daily()
+        dailyomnidata = _get_qindenton_daily(cached=cached)
         # Find where new files start
         idx = np.searchsorted(omnidata['UTC'], dailyomnidata['UTC'][0])
         for k in sorted(omnidata.keys()):
@@ -1375,7 +1388,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         if omni2_url.endswith('.zip'):
             # adding missing values from original omni2
             print("Retrieving OMNI2 file ...")
-            get_url(omni2_url, omni2_fname_zip, progressbar)
+            get_url(omni2_url, omni2_fname_zip, progressbar, cached=cached)
             fh_zip = zipfile.ZipFile(omni2_fname_zip)
             flist = fh_zip.namelist()
             if len(flist) != 1:
@@ -1407,11 +1420,13 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
 
     if leapsecs == True:
         print("Retrieving leapseconds file ... ")
-        get_url(config['leapsec_url'], leapsec_fname, progressbar, cached=True)
+        get_url(config['leapsec_url'], leapsec_fname, progressbar,
+                cached=cached)
 
     if PSDdata == True:
         print("Retrieving PSD sql database")
-        get_url(config['psddata_url'], PSDdata_fname, progressbar)
+        get_url(config['psddata_url'], PSDdata_fname, progressbar,
+                cached=cached)
     return datadir
 
 def indsFromXrange(inxrange):

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -736,6 +736,77 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
     return None
 
 
+def _crawl_yearly(base_url, pattern, datadir, name=None):
+    """Crawl files in a directory-by-year structure
+
+    Parameters
+    ==========
+    base_url : str
+        Base of the data. This URL should point to a directory containing
+        yearly directories (YYYY).
+    pattern : str
+        Regular expression to match filenames. Will download files in each
+        yearly directory that match the pattern.
+    datadir : str
+        Directory to store downloaded files. A mirror will be maintained in
+        this directory. Note this is a "flat" mirror without the year
+        directories.
+    name : str (optional)
+        Name of the data set, used only in status messages.
+
+    Returns
+    =======
+    list
+        All the filenames that were mirrored, in order; or None if there
+        were no updates. If there are any updates, all filenames are
+        included.
+    """
+    name = '' if name is None else '{} '.format(name)
+    #Find all the files to download
+    print("Finding {}files to download ...".format(name))
+    progressbar(0, 1, 1, text='Listing files')
+    data = get_url(base_url)
+    if str is not bytes:
+        data = data.decode('utf-8')
+    p = LinkExtracter()
+    p.feed(data)
+    p.close()
+    yearlist = [y[0:4] for y in p.links if re.match(r'\d{4}/', y)]
+    downloadme = {}
+    for i, y in enumerate(yearlist):
+        yearurl = '{}{}/'.format(base_url, y)
+        data = get_url(yearurl)
+        if str is not bytes:
+            data = data.decode('utf-8')
+        p = LinkExtracter()
+        p.feed(data)
+        p.close()
+        for f in p.links:
+            if not re.match(pattern, f):
+                continue
+            downloadme[f] = yearurl + f
+        progressbar(i + 1, 1, len(yearlist), text='Listing files')
+    print("Retrieving {}files ...".format(name))
+    filenames = sorted(list(downloadme.keys()))
+    if not os.path.exists(datadir):
+        os.makedirs(datadir)
+    newdata = False
+    #Check for existing files (delete them if no longer on server)
+    have_files = os.listdir(datadir)
+    for f in have_files:
+        if not f in filenames:
+            os.remove(os.path.join(datadir, f))
+            #File was removed, so need to reparse even if no new downloads
+            newdata = True
+    #Download
+    for i, fname in enumerate(filenames):
+        if get_url(downloadme[fname], os.path.join(datadir, fname),
+                   cached=True) is not None:
+            newdata = True
+        progressbar(i + 1, 1, len(filenames))
+    return filenames if newdata else None
+
+
 def _get_cdaweb_omni2(omni2url=None):
     """Download the OMNI2 data from SPDF
 
@@ -757,50 +828,10 @@ def _get_cdaweb_omni2(omni2url=None):
     import spacepy.pycdf.istp
     if omni2url is None:
         omni2url = spacepy.config['omni2_url']
-    #Find all the files to download
-    print("Finding OMNI2 files to download ...")
-    progressbar(0, 1, 1, text='Listing files')
-    data = get_url(omni2url)
-    if str is not bytes:
-        data = data.decode('utf-8')
-    p = LinkExtracter()
-    p.feed(data)
-    p.close()
-    yearlist = [y[0:4] for y in p.links if re.match(r'\d{4}/', y)]
-    downloadme = {}
-    for i, y in enumerate(yearlist):
-        yearurl = '{}{}/'.format(omni2url, y)
-        data = get_url(yearurl)
-        if str is not bytes:
-            data = data.decode('utf-8')
-        p = LinkExtracter()
-        p.feed(data)
-        p.close()
-        for f in p.links:
-            if not re.match(r'omni2_h0_mrg1hr_\d{8}_v\d+\.cdf', f):
-                continue
-            downloadme[f] = yearurl + f
-        progressbar(i + 1, 1, len(yearlist), text='Listing files')
-    print("Retrieving OMNI2 files ...")
-    filenames = sorted(list(downloadme.keys()))
     datadir = os.path.join(spacepy.DOT_FLN, 'data', 'omni2cdfs')
-    if not os.path.exists(datadir):
-        os.makedirs(datadir)
-    newdata = False
-    #Check for existing files (delete them if no longer on CDAWeb)
-    have_files = os.listdir(datadir)
-    for f in have_files:
-        if not f in filenames:
-            os.remove(os.path.join(datadir, f))
-            #File was removed, so need to reparse even if no new downloads
-            newdata = True
-    #Download
-    for i, fname in enumerate(filenames):
-        if get_url(downloadme[fname], os.path.join(datadir, fname),
-                   cached=True) is not None:
-            newdata = True
-        progressbar(i + 1, 1, len(filenames))
-    if not newdata:
+    filenames = _crawl_yearly(omni2url, r'omni2_h0_mrg1hr_\d{8}_v\d+\.cdf',
+                              datadir, name='OMNI2')
+    if filenames is None:
         return None
     #Read and process
     print("Reading OMNI2 files ...")

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -973,7 +973,8 @@ class LinkExtracter(html.parser.HTMLParser):
             self.links.append(value)
 
 
-def get_url(url, outfile=None, reporthook=None, cached=False):
+def get_url(url, outfile=None, reporthook=None, cached=False,
+            keepalive=False, conn=None):
     """Read data from a URL
 
     Open an HTTP URL, honoring the user agent as specified in the
@@ -995,6 +996,14 @@ def get_url(url, outfile=None, reporthook=None, cached=False):
         Compare modification time of the URL to the modification time
         of ``outfile``; do not retrieve (and return None) unless
         the URL is newer than the file.
+    keepalive : bool (optional)
+        Attempt to keep the connection open to retrieve more URLs.
+        The return becomes a tuple of (conn, data) to return the
+        connection used so it can be used again. This mode does not
+        support proxies. (Default False)
+    conn : http.client.HTTPConnection (optional)
+        An established http connection (HTTPS is also okay) to use with
+        ``keepalive``. If not provided, will attempt to make a connection.
 
     Returns
     =======
@@ -1013,28 +1022,64 @@ def get_url(url, outfile=None, reporthook=None, cached=False):
     should be defined as appropriate for your environment (e.g. with
     ``HTTP_PROXY`` or ``HTTPS_PROXY`` environment variables).
     """
-    r = urllib.request.Request(url)
-    if spacepy.config.get('user_agent', ''):
-        r.add_header('User-Agent', spacepy.config['user_agent'])
-    r = urllib.request.urlopen(r)
-    if r.getcode() >= 400:
-        r.close()
-        raise RuntimeError('HTTP status {} {}'.format(r.code, r.msg))
-    headers = r.info()
+    if not keepalive and conn is not None:
+        raise ValueError('Cannot specify connection without keepalive')
+    if keepalive:
+        scheme, _, host, path = url.split('/', 3)
+        if conn is not None and conn.sock is not None:
+            readable, writeable, _ = select.select(
+                [conn.sock], [conn.sock], [], 0)
+            # Make sure no stale data to read on socket, and can write to it
+            if readable or len(writeable) != 1:
+                conn.close()
+                conn = None
+        if conn is None:
+            ctype = http.client.HTTPConnection if scheme == 'http:'\
+                    else http.client.HTTPSConnection
+            conn = ctype(host, timeout=1)
+        clheaders = {
+            "Connection": "keep-alive",
+        }
+        if spacepy.config.get('user_agent', ''):
+            clheaders['User-Agent'] =  spacepy.config['user_agent']
+        conn.request('HEAD' if cached else 'GET', path, headers=clheaders)
+        def checkresponse(conn):
+            """Get the response on a connection, return response and headers"""
+            r = conn.getresponse()
+            if r.status >= 400:
+                raise RuntimeError(
+                    'HTTP status {} {}'.format(r.status, r.reason))
+            headers = dict(((k.title(), v) for k, v in r.getheaders()))
+            return r, headers
+        r, headers = checkresponse(conn)
+    else:
+        r = urllib.request.Request(url)
+        if spacepy.config.get('user_agent', ''):
+            r.add_header('User-Agent', spacepy.config['user_agent'])
+        r = urllib.request.urlopen(r)
+        if r.getcode() >= 400:
+            r.close()
+            raise RuntimeError('HTTP status {} {}'.format(r.code, r.msg))
+        headers = r.info()
     modified = headers.get('Last-Modified', None)
     if modified is not None:
         modified = datetime.datetime.strptime(modified, "%a, %d %b %Y %X GMT")
         modified = calendar.timegm(modified.timetuple())
     if cached:
         if outfile is None:
-            r.close()
+            if not keepalive:
+                r.close()
             raise RuntimeError('Must specify outfile if cached is True')
         if os.path.exists(outfile) and modified is not None:
             #Timestamp is truncated to second, so do same for local
             local_mod = int(os.path.getmtime(outfile))
             if modified <= local_mod:
-                r.close()
-                return None
+                if not keepalive:
+                    r.close()
+                return (conn, None) if keepalive else None
+        if keepalive: # Replace previous header request with full get
+            conn.request('GET', path, headers=clheaders)
+            r, headers= check_response(conn)
     size = int(headers.get('Content-Length', 0))
     blocksize = 1024
     count = 0
@@ -1054,116 +1099,8 @@ def get_url(url, outfile=None, reporthook=None, cached=False):
                 f.write(d)
         if modified is not None: #Copy web mtime to file
             os.utime(outfile, (int(time.time()), modified))
-    return b''.join(data)
-
-
-def _get_url_keepalive(url, conn=None, outfile=None,
-                       reporthook=None, cached=False):
-    """Read data from a URL and maintain connection
-
-    Retrieve an HTTP URL, honoring the user agent as specified in the
-    SpacePy config file. Returns the data, optionally also writing
-    out to a file.
-
-    Requires existing HTTP connection and will not work in unusual
-    circumstances, e.g. proxy servers.
-
-    This is similar to the deprecated ``urlretrieve``.
-
-    Parameters
-    ==========
-    url : str
-        The URL to open
-    conn : http.client.HTTPConnection
-        An established http connection (HTTPS is also okay). If not provided,
-        will attempt to make a connection.
-    outfile : str (optional)
-        Full path to file to write data to
-    reporthook : callable (optional)
-        Function for reporting progress; takes arguments of block
-        count, block size, and total size.
-    cached : bool (optional)
-        Compare modification time of the URL to the modification time
-        of ``outfile``; do not retrieve (and return None) unless
-        the URL is newer than the file.
-
-    Returns
-    =======
-    http.client.HTTPConnection, bytes
-        Tuple of the open connection (caller must close it with ``.close()``)
-        and the HTTP data. The connection may be a new one if the one
-        passed in has been closed. The caller must always close the connection,
-        even in an error condition.
-
-    See Also
-    ========
-    get_url
-    progressbar
-
-    Notes
-    =====
-    Cryptic error messages (such as ``Network is unreachable``) may indicate
-    that your environment requires a proxy and this function will not work
-    """
-    scheme, _, host, path = url.split('/', 3)
-    if conn is not None and conn.sock is not None:
-        readable, writeable, _ = select.select([conn.sock], [conn.sock], [], 0)
-        # Make sure no stale data to read on socket, and can write to it
-        if readable or len(writeable) != 1:
-            conn.close()
-            conn = None
-    if conn is None:
-        ctype = http.client.HTTPConnection if scheme == 'http:'\
-                else http.client.HTTPSConnection
-        conn = ctype(host, timeout=1)
-    clheaders = {
-        "Connection": "keep-alive",
-    }
-    if spacepy.config.get('user_agent', ''):
-        clheaders['User-Agent'] =  spacepy.config['user_agent']
-    conn.request('HEAD' if cached else 'GET', path, headers=clheaders)
-    def checkresponse(conn):
-        """Get the response on a connection, return response and headers"""
-        r = conn.getresponse()
-        if r.status >= 400:
-            raise RuntimeError('HTTP status {} {}'.format(r.status, r.reason))
-        headers = dict(((k.title(), v) for k, v in r.getheaders()))
-        return r, headers
-    r, headers = checkresponse(conn)
-    modified = headers.get('Last-Modified')
-    if modified is not None:
-        modified = datetime.datetime.strptime(modified, "%a, %d %b %Y %X GMT")
-        modified = calendar.timegm(modified.timetuple())
-    if cached:
-        if outfile is None:
-            raise ValueError('Must specify outfile if cached is True')
-        if os.path.exists(outfile) and modified is not None:
-            #Timestamp is truncated to second, so do same for local
-            local_mod = int(os.path.getmtime(outfile))
-            if modified <= local_mod:
-                return (conn, None)
-        conn.request('GET', path, headers=clheaders)
-        r, headers= check_response(conn)
-    size = int(headers.get('Content-Length', 0))
-    blocksize = 1024
-    count = 0
-    data = []
-    while True:
-        newdata = r.read(blocksize)
-        if not newdata:
-            break
-        data.append(newdata)
-        count += 1
-        if reporthook:
-            reporthook(count, blocksize, size)
-    r.close()
-    if outfile:
-        with open(outfile, 'wb') as f:
-            for d in data:
-                f.write(d)
-        if modified is not None: #Copy web mtime to file
-            os.utime(outfile, (int(time.time()), modified))
-    return (conn, b''.join(data))
+    data = b''.join(data)
+    return (conn, data) if keepalive else data
 
 
 def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDdata=False):

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1336,6 +1336,19 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         del omnidata['Year']
         del omnidata['Hr']
 
+        # Supplement with daily files
+        dailyomnidata = _get_qindenton_daily()
+        # Find where new files start
+        idx = np.searchsorted(omnidata['UTC'], dailyomnidata['UTC'][0])
+        for k in sorted(omnidata.keys()):
+            if k == 'Qbits':
+                for qk in sorted(omnidata[k].keys()):
+                    omnidata[k][qk] = spacepy.dmarray(np.concatenate((
+                        omnidata[k][qk][:idx, ...], dailyomnidata[k][qk])))
+            else:
+                omnidata[k] = spacepy.dmarray(np.concatenate((
+                    omnidata[k][:idx, ...], dailyomnidata[k])))
+
         print("Now saving... ")
         ##for now, make one file -- think about whether monthly/annual files makes sense
         toHDF5(omni_fname_h5, omnidata)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1197,7 +1197,8 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
     if omni == True:
         # retrieve omni, unzip and save as table
         print("Retrieving Qin_Denton file ...")
-        get_url(config['qindenton_url'], omni_fname_zip, progressbar)
+        get_url(config['qindenton_url'], omni_fname_zip, progressbar,
+                cached=True)
         fh_zip = zipfile.ZipFile(omni_fname_zip)
         data = fh_zip.read(fh_zip.namelist()[0])
         fh_zip.close()
@@ -1278,9 +1279,6 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
         print("Now saving... ")
         ##for now, make one file -- think about whether monthly/annual files makes sense
         toHDF5(omni_fname_h5, omnidata)
-
-        # delete left-overs
-        os.remove(omni_fname_zip)
 
     if omni2 == True:
         omni2_url = config['omni2_url']

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1080,7 +1080,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
                 return (conn, None) if keepalive else None
         if keepalive: # Replace previous header request with full get
             conn.request('GET', path, headers=clheaders)
-            r, headers= check_response(conn)
+            r, headers= checkresponse(conn)
     size = int(headers.get('Content-Length', 0))
     blocksize = 1024
     count = 0

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -25,6 +25,11 @@ try:
 except ImportError: #python2
     import HTMLParser as html
     html.parser = html
+try:
+    import http.client
+except ImportError: # Python2
+    import httplib as http
+    http.client = http
 import itertools
 import os
 import os.path
@@ -34,6 +39,7 @@ try:
 except ImportError: #python2
     import urllib2 as urllib
     urllib.request = urllib
+import select
 import shutil
 import subprocess
 import sys
@@ -1049,6 +1055,115 @@ def get_url(url, outfile=None, reporthook=None, cached=False):
         if modified is not None: #Copy web mtime to file
             os.utime(outfile, (int(time.time()), modified))
     return b''.join(data)
+
+
+def _get_url_keepalive(url, conn=None, outfile=None,
+                       reporthook=None, cached=False):
+    """Read data from a URL and maintain connection
+
+    Retrieve an HTTP URL, honoring the user agent as specified in the
+    SpacePy config file. Returns the data, optionally also writing
+    out to a file.
+
+    Requires existing HTTP connection and will not work in unusual
+    circumstances, e.g. proxy servers.
+
+    This is similar to the deprecated ``urlretrieve``.
+
+    Parameters
+    ==========
+    url : str
+        The URL to open
+    conn : http.client.HTTPConnection
+        An established http connection (HTTPS is also okay). If not provided,
+        will attempt to make a connection.
+    outfile : str (optional)
+        Full path to file to write data to
+    reporthook : callable (optional)
+        Function for reporting progress; takes arguments of block
+        count, block size, and total size.
+    cached : bool (optional)
+        Compare modification time of the URL to the modification time
+        of ``outfile``; do not retrieve (and return None) unless
+        the URL is newer than the file.
+
+    Returns
+    =======
+    http.client.HTTPConnection, bytes
+        Tuple of the open connection (caller must close it with ``.close()``)
+        and the HTTP data. The connection may be a new one if the one
+        passed in has been closed. The caller must always close the connection,
+        even in an error condition.
+
+    See Also
+    ========
+    get_url
+    progressbar
+
+    Notes
+    =====
+    Cryptic error messages (such as ``Network is unreachable``) may indicate
+    that your environment requires a proxy and this function will not work
+    """
+    scheme, _, host, path = url.split('/', 3)
+    if conn is not None and conn.sock is not None:
+        readable, writeable, _ = select.select([conn.sock], [conn.sock], [], 0)
+        # Make sure no stale data to read on socket, and can write to it
+        if readable or len(writeable) != 1:
+            conn.close()
+            conn = None
+    if conn is None:
+        ctype = http.client.HTTPConnection if scheme == 'http:'\
+                else http.client.HTTPSConnection
+        conn = ctype(host, timeout=1)
+    clheaders = {
+        "Connection": "keep-alive",
+    }
+    if spacepy.config.get('user_agent', ''):
+        clheaders['User-Agent'] =  spacepy.config['user_agent']
+    conn.request('HEAD' if cached else 'GET', path, headers=clheaders)
+    def checkresponse(conn):
+        """Get the response on a connection, return response and headers"""
+        r = conn.getresponse()
+        if r.status >= 400:
+            raise RuntimeError('HTTP status {} {}'.format(r.status, r.reason))
+        headers = dict(((k.title(), v) for k, v in r.getheaders()))
+        return r, headers
+    r, headers = checkresponse(conn)
+    modified = headers.get('Last-Modified')
+    if modified is not None:
+        modified = datetime.datetime.strptime(modified, "%a, %d %b %Y %X GMT")
+        modified = calendar.timegm(modified.timetuple())
+    if cached:
+        if outfile is None:
+            raise ValueError('Must specify outfile if cached is True')
+        if os.path.exists(outfile) and modified is not None:
+            #Timestamp is truncated to second, so do same for local
+            local_mod = int(os.path.getmtime(outfile))
+            if modified <= local_mod:
+                return (conn, None)
+        conn.request('GET', path, headers=clheaders)
+        r, headers= check_response(conn)
+    size = int(headers.get('Content-Length', 0))
+    blocksize = 1024
+    count = 0
+    data = []
+    while True:
+        newdata = r.read(blocksize)
+        if not newdata:
+            break
+        data.append(newdata)
+        count += 1
+        if reporthook:
+            reporthook(count, blocksize, size)
+    r.close()
+    if outfile:
+        with open(outfile, 'wb') as f:
+            for d in data:
+                f.write(d)
+        if modified is not None: #Copy web mtime to file
+            os.utime(outfile, (int(time.time()), modified))
+    return (conn, b''.join(data))
 
 
 def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDdata=False):

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1390,7 +1390,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False, PSDd
 
     if leapsecs == True:
         print("Retrieving leapseconds file ... ")
-        get_url(config['leapsec_url'], leapsec_fname, progressbar)
+        get_url(config['leapsec_url'], leapsec_fname, progressbar, cached=True)
 
     if PSDdata == True:
         print("Retrieving PSD sql database")

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -859,9 +859,9 @@ def _get_qindenton_daily(qd_daily_url=None, cached=True):
         qd_daily_url = spacepy.config['qd_daily_url']
     datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_daily_files')
     _crawl_yearly(qd_daily_url, r'QinDenton_\d{8}_hour.txt',
-                  datadir, name='Q-D daliy', cached=cached)
+                  datadir, name='Q-D daily', cached=cached)
     #Read and process
-    print("Reading/processing Q-D daily files ...")
+    print("Processing Q-D daily files ...")
     return _assemble_qindenton_daily(datadir)
 
 
@@ -1186,7 +1186,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         if keepalive: # Replace previous header request with full get
             r.read()
             conn.request('GET', path, headers=clheaders)
-            r, headers= checkresponse(conn)
+            r, headers = checkresponse(conn)
     size = int(headers.get('Content-Length', 0))
     blocksize = 1024
     count = 0
@@ -1286,7 +1286,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False,
 
     if omni == True:
         # retrieve omni, unzip and save as table
-        print("Retrieving Qin_Denton file ...")
+        print("Retrieving initial Qin-Denton file ...")
         get_url(config['qindenton_url'], omni_fname_zip, progressbar,
                 cached=cached)
         fh_zip = zipfile.ZipFile(omni_fname_zip)
@@ -1295,7 +1295,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False,
         if not str is bytes:
             data = data.decode('ascii')
         A = np.array(data.split('\n'))
-        print("Now processing (this may take a minute) ...")
+        print("Processing initial Qin-Denton file ...")
 
         # create a keylist
         keys = A[0].split()
@@ -1367,6 +1367,8 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False,
         del omnidata['Hr']
 
         # Supplement with daily files
+        print('Supplementing with latest Q-D daily files,'
+              ' this will take a while...')
         dailyomnidata = _get_qindenton_daily(cached=cached)
         # Find where new files start
         idx = np.searchsorted(omnidata['UTC'], dailyomnidata['UTC'][0])
@@ -1382,6 +1384,7 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False,
         print("Now saving... ")
         ##for now, make one file -- think about whether monthly/annual files makes sense
         toHDF5(omni_fname_h5, omnidata)
+        print('Complete.')
 
     if omni2 == True:
         omni2_url = config['omni2_url']

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1026,6 +1026,7 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         raise ValueError('Cannot specify connection without keepalive')
     if keepalive:
         scheme, _, host, path = url.split('/', 3)
+        path = '/' + path # Explicitly root on the server
         if conn is not None and conn.sock is not None:
             readable, writeable, _ = select.select(
                 [conn.sock], [conn.sock], [], 0)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -847,18 +847,34 @@ def _get_qindenton_daily(qd_daily_url=None):
         The data extracted from the Q-D dataset, fully processed for saving
         as SpacePy HDF5 OMNI data.
     """
-    import spacepy.datamodel
     if qd_daily_url is None:
         qd_daily_url = spacepy.config['qd_daily_url']
     datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_daily_files')
     _crawl_yearly(qd_daily_url, r'QinDenton_\d{8}_hour.txt',
                   datadir, name='Q-D daliy')
     #Read and process
-    print("Reading Q-D daily files ...")
-    filelist = sorted(glob.glob(os.path.join(datadir, '*_hour.txt')))
+    print("Reading/processing Q-D daily files ...")
+    return _assemble_qindenton_daily(datadir)
+
+
+def _assemble_qindenton_daily(qd_daily_dir):
+    """Assemble Qin-Denton daily files into OMNI structure
+
+    Parameters
+    ==========
+    qd_daily_dir : str
+        Directory with Qin-Denton daily files.
+
+    Returns
+    =======
+    SpaceData
+        The data extracted from the Q-D dataset, fully processed for saving
+        as SpacePy HDF5 OMNI data.
+    """
+    import spacepy.datamodel
+    filelist = sorted(glob.glob(os.path.join(qd_daily_dir, '*_hour.txt')))
     data = [spacepy.datamodel.readJSONheadedASCII(f)
             for f in filelist]
-    print("Processing ...")
     omnidata = spacepy.datamodel.SpaceData()
     for k in data[0].keys():
         if k in ('DateTime', 'Minute', 'OriginFile', 'Second'):
@@ -915,6 +931,7 @@ def _get_qindenton_daily(qd_daily_url=None):
     for k in ('Year', 'Hour', 'Month', 'Day'):
         del omnidata[k]
     return omnidata
+
 
 def _get_cdaweb_omni2(omni2url=None):
     """Download the OMNI2 data from SPDF

--- a/tests/data/qindenton_daily/QinDenton_20120901_hour.txt
+++ b/tests/data/qindenton_daily/QinDenton_20120901_hour.txt
@@ -1,0 +1,216 @@
+# {
+#  "OriginFile":       { "DESCRIPTION": "ViRBO origin file for Qin-Denton data",
+#                               "NAME": "OriginFile",
+#                             "VALUES": [""]},
+#
+#  "DateTime":         { "DESCRIPTION": "The date and time in ISO 8601 compliant format.",
+#                               "NAME": "IsoDateTime",
+#                              "TITLE": "ISO DateTime",
+#                              "LABEL": "Time",
+#                              "UNITS": "UTC",
+#                       "START_COLUMN": 0 },
+#
+#  "Year":             { "DESCRIPTION": "Year.",
+#                               "NAME": "Year",
+#                              "TITLE": "Year",
+#                              "LABEL": "Year",
+#                       "START_COLUMN": 1,
+#                              "UNITS": "Years" },
+#
+#  "Month":              { "DESCRIPTION": "Month",
+#                               "NAME": "Month",
+#                              "TITLE": "Month",
+#                              "LABEL": "Month",
+#                       "START_COLUMN": 2,
+#                              "UNITS": "Months"},
+#
+#  "Day":             { "DESCRIPTION": "Day of month.",
+#                               "NAME": "Day",
+#                              "TITLE": "Day",
+#                              "LABEL": "Day",
+#                       "START_COLUMN": 3,
+#                              "UNITS": "Days" },
+#
+#  "Hour":             { "DESCRIPTION": "Hour of current day.",
+#                               "NAME": "Hours",
+#                              "TITLE": "Hours",
+#                              "LABEL": "Hours",
+#                       "START_COLUMN": 4,
+#                              "UNITS": "Hours" },
+#
+#  "Minute":           { "DESCRIPTION": "Minute of the current hour.",
+#                               "NAME": "Minutes",
+#                              "TITLE": "Minutes",
+#                              "LABEL": "Minutes",
+#                       "START_COLUMN": 5,
+#                              "UNITS": "Minutes" },
+#
+#  "Second":           { "DESCRIPTION": "Second of the current minute.",
+#                               "NAME": "Seconds",
+#                              "TITLE": "Seconds",
+#                              "LABEL": "Seconds",
+#                       "START_COLUMN": 6,
+#                              "UNITS": "Seconds" },
+#
+#  "ByIMF":            { "DESCRIPTION": "Y-component of the interplanetary magnetic field.",
+#                               "NAME": "ByIMF",
+#                              "TITLE": "IMF By",
+#                              "LABEL": "IMF B!By!N, nT",
+#                       "START_COLUMN": 7,
+#                              "UNITS": "nT" },
+#
+#  "BzIMF":            { "DESCRIPTION": "Z-component of the interplanetary magnetic field.",
+#                               "NAME": "BzIMF",
+#                              "TITLE": "IMF Bz",
+#                              "LABEL": "IMF B!Bz!N, nT",
+#                       "START_COLUMN": 8,
+#                              "UNITS": "nT" },
+#
+#  "Vsw":             { "DESCRIPTION": "Solar wind speed.",
+#                               "NAME": "Vsw",
+#                              "TITLE": "Solar Wind Speed",
+#                              "LABEL": "V!BSW!N, km/s",
+#                       "START_COLUMN": 9,
+#                              "UNITS": "km/s" },
+#
+#  "Den_P":               { "DESCRIPTION": "Solar wind proton density.",
+#                               "NAME": "Den_P",
+#                              "TITLE": "Solar Wind Proton Density",
+#                              "LABEL": "N!Bp!N, cm!E-3!N",
+#                       "START_COLUMN": 10,
+#                              "UNITS": "cm^-3" },
+#
+#  "Pdyn":             { "DESCRIPTION": "Solar wind dynamic pressure.",
+#                               "NAME": "Pdyn",
+#                              "TITLE": "Solar Wind Dynamic Pressure",
+#                              "LABEL": "P!Bdyn!N, nPa",
+#                       "START_COLUMN": 11,
+#                              "UNITS": "nPa" },
+#
+#  "G":                { "DESCRIPTION": "Tsyganeko G parameters.",
+#                               "NAME": "G",
+#                              "TITLE": "Tsyganeko G parameters",
+#                              "LABEL": "Tsyganeko G!Bi!N",
+#                          "DIMENSION": [ 3 ],
+#                       "START_COLUMN": 12,
+#                      "ELEMENT_NAMES": [ "G1", "G2", "G3" ],
+#                     "ELEMENT_LABELS": [ "G1", "G2", "G3" ] },
+#
+#  "ByIMF_status":     { "DESCRIPTION": "Quality flag for ByIMF value.",
+#                               "NAME": "ByIMF_status",
+#                              "TITLE": "ByIMF_status",
+#                              "LABEL": "ByIMF_status",
+#                       "START_COLUMN": 15,
+#                              "UNITS": "dimless" },
+#
+#  "BzIMF_status":     { "DESCRIPTION": "Quality flag for BzIMF value.",
+#                               "NAME": "BzIMF_status",
+#                              "TITLE": "BzIMF_status",
+#                              "LABEL": "BzIMF_status",
+#                       "START_COLUMN": 16,
+#                              "UNITS": "dimless" },
+#
+#  "Vsw_status":       { "DESCRIPTION": "Quality flag for Vsw value.",
+#                               "NAME": "Vsw_status",
+#                              "TITLE": "Vsw_status",
+#                              "LABEL": "Vsw_status",
+#                       "START_COLUMN": 17,
+#                              "UNITS": "dimless" },
+#
+#  "Den_P_status":     { "DESCRIPTION": "Quality flag for Den_P value.",
+#                               "NAME": "Den_P_status",
+#                              "TITLE": "Den_P_status",
+#                              "LABEL": "Den_P_status",
+#                       "START_COLUMN": 18,
+#                              "UNITS": "dimless" },
+#
+#  "Pdyn_status":     { "DESCRIPTION": "Quality flag for Pdyn value.",
+#                               "NAME": "Pdyn_status",
+#                              "TITLE": "Pdyn_status",
+#                              "LABEL": "Pdyn_status",
+#                       "START_COLUMN": 19,
+#                              "UNITS": "dimless" },
+#
+#  "G_status":         { "DESCRIPTION": "Quality flag for G values.",
+#                               "NAME": "G_status",
+#                              "TITLE": "G_status",
+#                              "LABEL": "G_status",
+#                          "DIMENSION": [ 3 ],
+#                       "START_COLUMN": 20,
+#                      "ELEMENT_NAMES": [ "G1_status", "G2_status", "G3_status" ],
+#                     "ELEMENT_LABELS": [ "dimless", "dimless", "dimless" ] },
+#
+#
+#  "Kp":               { "DESCRIPTION": "Kp index.",
+#                               "NAME": "Kp",
+#                              "TITLE": "Kp Index",
+#                              "LABEL": "Kp",
+#                       "START_COLUMN": 23,
+#                              "UNITS": "dimless" },
+#
+#  "akp3":               { "DESCRIPTION": "akp3 index.",
+#                               "NAME": "akp3",
+#                              "TITLE": "akp3 Index",
+#                              "LABEL": "akp3",
+#                       "START_COLUMN": 24,
+#                              "UNITS": "dimless" },
+#
+#  "Dst":               { "DESCRIPTION": "Dst index.",
+#                               "NAME": "Dst",
+#                              "TITLE": "Dst Index",
+#                              "LABEL": "Dst, nT",
+#                       "START_COLUMN": 25,
+#                              "UNITS": "nT" },
+#
+#  "Bz":               { "DESCRIPTION": "Tsyganeko Bz parameters.",
+#                               "NAME": "Bz",
+#                              "TITLE": "Tsyganeko Bz parameters",
+#                              "LABEL": "Bz!Bi!N, nT",
+#                          "DIMENSION": [ 6 ],
+#                       "START_COLUMN": 26,
+#                      "ELEMENT_NAMES": [ "Bz1", "Bz2", "Bz3", "Bz4", "Bz5", "Bz6" ],
+#                      "ELEMENT_LABELS": [ "Bz1", "Bz2", "Bz3", "Bz4", "Bz5", "Bz6" ] },
+#
+#  "W":                { "DESCRIPTION": "Tsyganeko W parameters.",
+#                               "NAME": "W",
+#                              "TITLE": "Tsyganeko W parameters",
+#                              "LABEL": "Tsyganeko W!Bi!N",
+#                          "DIMENSION": [ 6 ],
+#                       "START_COLUMN": 32,
+#                      "ELEMENT_NAMES": [ "W1", "W2", "W3", "W4", "W5", "W6" ],
+#                      "ELEMENT_LABELS": [ "W1", "W2", "W3", "W4", "W5", "W6" ] },
+#
+#  "W_status":         { "DESCRIPTION": "Quality flags for Tsyganeko W parameters.",
+#                               "NAME": "W_status",
+#                              "TITLE": "Tsyganeko W_status parameters",
+#                              "LABEL": "Tsyganeko W!Bi!N_status",
+#                          "DIMENSION": [ 6 ],
+#                       "START_COLUMN": 38,
+#                      "ELEMENT_NAMES": [ "W1_status", "W2_status", "W3_status", "W4_status", "W5_status", "W6_status" ],
+#                     "ELEMENT_LABELS": [ "W1_status", "W2_status", "W3_status", "W4_status", "W5_status", "W6_status" ] }
+#
+# } End JSON
+2012-09-01T00:00:00 2012   9  1  0  0 00   -0.40  -2.00  304.0    5.80   1.01    0.70   2.97   1.64  2 2 2 2 2 2 2 2   1.70  0.22    14   -2.00  -2.00  -2.00  -2.00  -2.00  -2.00   0.276  0.512  0.029  0.204  0.380  0.414  2 2 2 2 2 2
+2012-09-01T01:00:00 2012   9  1  1  0 00   -1.30  -3.00  317.0    9.60   1.80    1.29   3.96   3.16  2 2 2 2 2 2 2 2   1.70  0.44    16   -3.00  -3.00  -3.00  -3.00  -3.00  -3.00   0.397  0.704  0.040  0.328  0.545  0.762  2 2 2 2 2 2
+2012-09-01T02:00:00 2012   9  1  2  0 00   -2.20  -2.70  321.0   13.00   2.46    1.84   4.53   5.17  2 2 2 2 2 2 2 2   1.70  0.66    18   -2.70  -2.70  -2.70  -2.70  -2.70  -2.70   0.524  0.894  0.053  0.450  0.686  1.294  2 2 2 2 2 2
+2012-09-01T03:00:00 2012   9  1  3  0 00    0.40  -0.90  315.0   16.60   3.33    0.74   2.75   4.02  2 2 2 2 2 2 2 2   1.70  0.87    17   -0.90  -0.90  -0.90  -0.90  -0.90  -0.90   0.518  0.837  0.059  0.385  0.564  1.456  2 2 2 2 2 2
+2012-09-01T04:00:00 2012   9  1  4  0 00    2.90   0.60  313.0   13.10   2.52    0.24   0.37   0.58  2 2 2 2 2 2 2 2   1.70  1.08    17    0.60   0.60   0.60   0.60   0.60   0.60   0.370  0.473  0.058  0.224  0.221  0.757  2 2 2 2 2 2
+2012-09-01T05:00:00 2012   9  1  5  0 00    3.00   0.60  309.0   13.40   2.47    0.42   0.00   0.00  2 2 2 2 2 2 2 2   1.70  1.29    12    0.60   0.60   0.60   0.60   0.60   0.60   0.251  0.235  0.056  0.125  0.070  0.314  2 2 2 2 2 2
+2012-09-01T06:00:00 2012   9  1  6  0 00    0.00  -0.60  310.0   16.30   3.00    0.16   0.27   0.43  2 2 2 2 2 2 2 2   2.00  1.54    10   -0.60  -0.60  -0.60  -0.60  -0.60  -0.60   0.201  0.225  0.055  0.087  0.124  0.438  2 2 2 2 2 2
+2012-09-01T07:00:00 2012   9  1  7  0 00    2.50   0.00  304.0   18.00   3.36    0.19   0.42   0.72  2 2 2 2 2 2 2 2   2.00  1.78    11    0.00   0.00   0.00   0.00   0.00   0.00   0.164  0.203  0.054  0.060  0.109  0.450  2 2 2 2 2 2
+2012-09-01T08:00:00 2012   9  1  8  0 00    2.90   0.20  317.0   18.50   3.60    0.45   0.00   0.00  2 2 2 2 2 2 2 2   2.00  1.82    11    0.20   0.20   0.20   0.20   0.20   0.20   0.111  0.101  0.052  0.033  0.034  0.187  2 2 2 2 2 2
+2012-09-01T09:00:00 2012   9  1  9  0 00    6.20  -1.80  327.0    9.20   1.88    2.00   1.44   1.68  2 2 2 2 2 2 2 2   1.70  1.81     4   -1.80  -1.80  -1.80  -1.80  -1.80  -1.80   0.187  0.335  0.055  0.105  0.291  0.660  2 2 2 2 2 2
+2012-09-01T10:00:00 2012   9  1 10  0 00    4.90  -4.80  327.0    6.60   1.40    5.02   5.60   4.26  2 2 2 2 2 2 2 2   1.70  1.81     0   -4.80  -4.80  -4.80  -4.80  -4.80  -4.80   0.406  0.705  0.072  0.394  0.638  0.922  2 2 2 2 2 2
+2012-09-01T11:00:00 2012   9  1 11  0 00    5.00  -4.40  324.0    5.10   1.04    6.10   7.46   4.32  2 2 2 2 2 2 2 2   1.70  1.81    -8   -4.40  -4.40  -4.40  -4.40  -4.40  -4.40   0.570  0.883  0.092  0.592  0.737  0.873  2 2 2 2 2 2
+2012-09-01T12:00:00 2012   9  1 12  0 00    6.20  -2.20  327.0    4.00   0.77    4.82   5.22   2.38  2 2 2 2 2 2 2 2   1.30  1.76   -13   -2.20  -2.20  -2.20  -2.20  -2.20  -2.20   0.571  0.792  0.101  0.525  0.585  0.644  2 2 2 2 2 2
+2012-09-01T13:00:00 2012   9  1 13  0 00    6.20  -2.50  326.0    3.20   0.60    4.30   3.86   1.37  2 2 2 2 2 2 2 2   1.30  1.70   -13   -2.50  -2.50  -2.50  -2.50  -2.50  -2.50   0.528  0.673  0.106  0.428  0.472  0.458  2 2 2 2 2 2
+2012-09-01T14:00:00 2012   9  1 14  0 00    6.20  -2.40  330.0    3.00   0.58    4.41   4.01   1.24  2 2 2 2 2 2 2 2   1.30  1.62   -12   -2.40  -2.40  -2.40  -2.40  -2.40  -2.40   0.494  0.602  0.110  0.370  0.428  0.357  2 2 2 2 2 2
+2012-09-01T15:00:00 2012   9  1 15  0 00    6.60  -1.30  331.0    2.70   0.53    3.99   2.98   0.85  2 2 2 2 2 2 2 2   1.00  1.49   -11   -1.30  -1.30  -1.30  -1.30  -1.30  -1.30   0.431  0.496  0.112  0.286  0.340  0.270  2 2 2 2 2 2
+2012-09-01T16:00:00 2012   9  1 16  0 00    6.60  -1.30  331.0    2.50   0.50    3.69   2.15   0.56  2 2 2 2 2 2 2 2   1.00  1.37    -9   -1.30  -1.30  -1.30  -1.30  -1.30  -1.30   0.366  0.409  0.111  0.215  0.278  0.209  2 2 2 2 2 2
+2012-09-01T17:00:00 2012   9  1 17  0 00    6.50  -1.90  330.0    2.50   0.49    3.93   2.68   0.67  2 2 2 2 2 2 2 2   1.00  1.28    -5   -1.90  -1.90  -1.90  -1.90  -1.90  -1.90   0.340  0.395  0.112  0.197  0.292  0.195  2 2 2 2 2 2
+2012-09-01T18:00:00 2012   9  1 18  0 00    6.70  -1.10  330.0    2.80   0.56    3.84   2.42   0.64  2 2 2 2 2 2 2 2   0.70  1.15     2   -1.10  -1.10  -1.10  -1.10  -1.10  -1.10   0.310  0.366  0.113  0.169  0.268  0.186  2 2 2 2 2 2
+2012-09-01T19:00:00 2012   9  1 19  0 00    6.60   0.00  328.0    2.70   0.54    3.10   0.83   0.23  2 2 2 2 2 2 2 2   0.70  1.03     6    0.00   0.00   0.00   0.00   0.00   0.00   0.234  0.242  0.110  0.107  0.140  0.118  2 2 2 2 2 2
+2012-09-01T20:00:00 2012   9  1 20  0 00    6.50   0.00  323.0    2.50   0.48    2.65   0.00   0.00  2 2 2 2 2 2 2 2   0.70  0.96     9    0.00   0.00   0.00   0.00   0.00   0.00   0.159  0.120  0.107  0.060  0.044  0.049  2 2 2 2 2 2
+2012-09-01T21:00:00 2012   9  1 21  0 00    6.40  -1.90  324.0    2.50   0.49    3.29   1.67   0.42  2 2 2 2 2 2 2 2   1.70  1.01     9   -1.90  -1.90  -1.90  -1.90  -1.90  -1.90   0.176  0.215  0.106  0.086  0.178  0.108  2 2 2 2 2 2
+2012-09-01T22:00:00 2012   9  1 22  0 00    6.20  -2.70  323.0    3.80   0.72    4.32   3.77   1.22  2 2 2 2 2 2 2 2   1.70  1.07    10   -2.70  -2.70  -2.70  -2.70  -2.70  -2.70   0.259  0.387  0.111  0.183  0.344  0.231  2 2 2 2 2 2
+2012-09-01T23:00:00 2012   9  1 23  0 00    6.10  -3.50  322.0    3.80   0.78    5.08   5.05   1.92  2 2 2 2 2 2 2 2   1.70  1.16     6   -3.50  -3.50  -3.50  -3.50  -3.50  -3.50   0.362  0.549  0.119  0.304  0.471  0.342  2 2 2 2 2 2

--- a/tests/data/qindenton_daily/QinDenton_20120902_hour.txt
+++ b/tests/data/qindenton_daily/QinDenton_20120902_hour.txt
@@ -1,0 +1,216 @@
+# {
+#  "OriginFile":       { "DESCRIPTION": "ViRBO origin file for Qin-Denton data",
+#                               "NAME": "OriginFile",
+#                             "VALUES": [""]},
+#
+#  "DateTime":         { "DESCRIPTION": "The date and time in ISO 8601 compliant format.",
+#                               "NAME": "IsoDateTime",
+#                              "TITLE": "ISO DateTime",
+#                              "LABEL": "Time",
+#                              "UNITS": "UTC",
+#                       "START_COLUMN": 0 },
+#
+#  "Year":             { "DESCRIPTION": "Year.",
+#                               "NAME": "Year",
+#                              "TITLE": "Year",
+#                              "LABEL": "Year",
+#                       "START_COLUMN": 1,
+#                              "UNITS": "Years" },
+#
+#  "Month":              { "DESCRIPTION": "Month",
+#                               "NAME": "Month",
+#                              "TITLE": "Month",
+#                              "LABEL": "Month",
+#                       "START_COLUMN": 2,
+#                              "UNITS": "Months"},
+#
+#  "Day":             { "DESCRIPTION": "Day of month.",
+#                               "NAME": "Day",
+#                              "TITLE": "Day",
+#                              "LABEL": "Day",
+#                       "START_COLUMN": 3,
+#                              "UNITS": "Days" },
+#
+#  "Hour":             { "DESCRIPTION": "Hour of current day.",
+#                               "NAME": "Hours",
+#                              "TITLE": "Hours",
+#                              "LABEL": "Hours",
+#                       "START_COLUMN": 4,
+#                              "UNITS": "Hours" },
+#
+#  "Minute":           { "DESCRIPTION": "Minute of the current hour.",
+#                               "NAME": "Minutes",
+#                              "TITLE": "Minutes",
+#                              "LABEL": "Minutes",
+#                       "START_COLUMN": 5,
+#                              "UNITS": "Minutes" },
+#
+#  "Second":           { "DESCRIPTION": "Second of the current minute.",
+#                               "NAME": "Seconds",
+#                              "TITLE": "Seconds",
+#                              "LABEL": "Seconds",
+#                       "START_COLUMN": 6,
+#                              "UNITS": "Seconds" },
+#
+#  "ByIMF":            { "DESCRIPTION": "Y-component of the interplanetary magnetic field.",
+#                               "NAME": "ByIMF",
+#                              "TITLE": "IMF By",
+#                              "LABEL": "IMF B!By!N, nT",
+#                       "START_COLUMN": 7,
+#                              "UNITS": "nT" },
+#
+#  "BzIMF":            { "DESCRIPTION": "Z-component of the interplanetary magnetic field.",
+#                               "NAME": "BzIMF",
+#                              "TITLE": "IMF Bz",
+#                              "LABEL": "IMF B!Bz!N, nT",
+#                       "START_COLUMN": 8,
+#                              "UNITS": "nT" },
+#
+#  "Vsw":             { "DESCRIPTION": "Solar wind speed.",
+#                               "NAME": "Vsw",
+#                              "TITLE": "Solar Wind Speed",
+#                              "LABEL": "V!BSW!N, km/s",
+#                       "START_COLUMN": 9,
+#                              "UNITS": "km/s" },
+#
+#  "Den_P":               { "DESCRIPTION": "Solar wind proton density.",
+#                               "NAME": "Den_P",
+#                              "TITLE": "Solar Wind Proton Density",
+#                              "LABEL": "N!Bp!N, cm!E-3!N",
+#                       "START_COLUMN": 10,
+#                              "UNITS": "cm^-3" },
+#
+#  "Pdyn":             { "DESCRIPTION": "Solar wind dynamic pressure.",
+#                               "NAME": "Pdyn",
+#                              "TITLE": "Solar Wind Dynamic Pressure",
+#                              "LABEL": "P!Bdyn!N, nPa",
+#                       "START_COLUMN": 11,
+#                              "UNITS": "nPa" },
+#
+#  "G":                { "DESCRIPTION": "Tsyganeko G parameters.",
+#                               "NAME": "G",
+#                              "TITLE": "Tsyganeko G parameters",
+#                              "LABEL": "Tsyganeko G!Bi!N",
+#                          "DIMENSION": [ 3 ],
+#                       "START_COLUMN": 12,
+#                      "ELEMENT_NAMES": [ "G1", "G2", "G3" ],
+#                     "ELEMENT_LABELS": [ "G1", "G2", "G3" ] },
+#
+#  "ByIMF_status":     { "DESCRIPTION": "Quality flag for ByIMF value.",
+#                               "NAME": "ByIMF_status",
+#                              "TITLE": "ByIMF_status",
+#                              "LABEL": "ByIMF_status",
+#                       "START_COLUMN": 15,
+#                              "UNITS": "dimless" },
+#
+#  "BzIMF_status":     { "DESCRIPTION": "Quality flag for BzIMF value.",
+#                               "NAME": "BzIMF_status",
+#                              "TITLE": "BzIMF_status",
+#                              "LABEL": "BzIMF_status",
+#                       "START_COLUMN": 16,
+#                              "UNITS": "dimless" },
+#
+#  "Vsw_status":       { "DESCRIPTION": "Quality flag for Vsw value.",
+#                               "NAME": "Vsw_status",
+#                              "TITLE": "Vsw_status",
+#                              "LABEL": "Vsw_status",
+#                       "START_COLUMN": 17,
+#                              "UNITS": "dimless" },
+#
+#  "Den_P_status":     { "DESCRIPTION": "Quality flag for Den_P value.",
+#                               "NAME": "Den_P_status",
+#                              "TITLE": "Den_P_status",
+#                              "LABEL": "Den_P_status",
+#                       "START_COLUMN": 18,
+#                              "UNITS": "dimless" },
+#
+#  "Pdyn_status":     { "DESCRIPTION": "Quality flag for Pdyn value.",
+#                               "NAME": "Pdyn_status",
+#                              "TITLE": "Pdyn_status",
+#                              "LABEL": "Pdyn_status",
+#                       "START_COLUMN": 19,
+#                              "UNITS": "dimless" },
+#
+#  "G_status":         { "DESCRIPTION": "Quality flag for G values.",
+#                               "NAME": "G_status",
+#                              "TITLE": "G_status",
+#                              "LABEL": "G_status",
+#                          "DIMENSION": [ 3 ],
+#                       "START_COLUMN": 20,
+#                      "ELEMENT_NAMES": [ "G1_status", "G2_status", "G3_status" ],
+#                     "ELEMENT_LABELS": [ "dimless", "dimless", "dimless" ] },
+#
+#
+#  "Kp":               { "DESCRIPTION": "Kp index.",
+#                               "NAME": "Kp",
+#                              "TITLE": "Kp Index",
+#                              "LABEL": "Kp",
+#                       "START_COLUMN": 23,
+#                              "UNITS": "dimless" },
+#
+#  "akp3":               { "DESCRIPTION": "akp3 index.",
+#                               "NAME": "akp3",
+#                              "TITLE": "akp3 Index",
+#                              "LABEL": "akp3",
+#                       "START_COLUMN": 24,
+#                              "UNITS": "dimless" },
+#
+#  "Dst":               { "DESCRIPTION": "Dst index.",
+#                               "NAME": "Dst",
+#                              "TITLE": "Dst Index",
+#                              "LABEL": "Dst, nT",
+#                       "START_COLUMN": 25,
+#                              "UNITS": "nT" },
+#
+#  "Bz":               { "DESCRIPTION": "Tsyganeko Bz parameters.",
+#                               "NAME": "Bz",
+#                              "TITLE": "Tsyganeko Bz parameters",
+#                              "LABEL": "Bz!Bi!N, nT",
+#                          "DIMENSION": [ 6 ],
+#                       "START_COLUMN": 26,
+#                      "ELEMENT_NAMES": [ "Bz1", "Bz2", "Bz3", "Bz4", "Bz5", "Bz6" ],
+#                      "ELEMENT_LABELS": [ "Bz1", "Bz2", "Bz3", "Bz4", "Bz5", "Bz6" ] },
+#
+#  "W":                { "DESCRIPTION": "Tsyganeko W parameters.",
+#                               "NAME": "W",
+#                              "TITLE": "Tsyganeko W parameters",
+#                              "LABEL": "Tsyganeko W!Bi!N",
+#                          "DIMENSION": [ 6 ],
+#                       "START_COLUMN": 32,
+#                      "ELEMENT_NAMES": [ "W1", "W2", "W3", "W4", "W5", "W6" ],
+#                      "ELEMENT_LABELS": [ "W1", "W2", "W3", "W4", "W5", "W6" ] },
+#
+#  "W_status":         { "DESCRIPTION": "Quality flags for Tsyganeko W parameters.",
+#                               "NAME": "W_status",
+#                              "TITLE": "Tsyganeko W_status parameters",
+#                              "LABEL": "Tsyganeko W!Bi!N_status",
+#                          "DIMENSION": [ 6 ],
+#                       "START_COLUMN": 38,
+#                      "ELEMENT_NAMES": [ "W1_status", "W2_status", "W3_status", "W4_status", "W5_status", "W6_status" ],
+#                     "ELEMENT_LABELS": [ "W1_status", "W2_status", "W3_status", "W4_status", "W5_status", "W6_status" ] }
+#
+# } End JSON
+2012-09-02T00:00:00 2012   9  2  0  0 00    5.90  -4.90  319.0    3.60   0.76    6.43   6.82   2.51  2 2 2 2 2 2 2 2   3.00  1.42    -2   -4.90  -4.90  -4.90  -4.90  -4.90  -4.90   0.487  0.705  0.132  0.467  0.588  0.414  2 2 2 2 2 2
+2012-09-02T01:00:00 2012   9  2  1  0 00    5.40  -4.50  316.0    4.10   0.83    6.68   7.43   2.87  2 2 2 2 2 2 2 2   3.00  1.68    -8   -4.50  -4.50  -4.50  -4.50  -4.50  -4.50   0.586  0.809  0.146  0.580  0.641  0.471  2 2 2 2 2 2
+2012-09-02T02:00:00 2012   9  2  2  0 00    4.90  -4.10  314.0    5.50   1.06    5.60   6.74   3.27  2 2 2 2 2 2 2 2   3.00  1.96   -11   -4.10  -4.10  -4.10  -4.10  -4.10  -4.10   0.656  0.885  0.160  0.636  0.671  0.582  2 2 2 2 2 2
+2012-09-02T03:00:00 2012   9  2  3  0 00    4.00  -5.70  315.0    4.80   0.98    6.11   7.81   3.99  2 2 2 2 2 2 2 2   2.70  2.21   -11   -5.70  -5.70  -5.70  -5.70  -5.70  -5.70   0.751  0.992  0.177  0.760  0.752  0.667  2 2 2 2 2 2
+2012-09-02T04:00:00 2012   9  2  4  0 00    1.00  -6.70  315.0    7.00   1.57    7.23   9.83   5.92  2 2 2 2 2 2 2 2   2.70  2.45   -12   -6.70  -6.70  -6.70  -6.70  -6.70  -6.70   0.911  1.198  0.205  1.006  0.925  0.923  2 2 2 2 2 2
+2012-09-02T05:00:00 2012   9  2  5  0 00    0.90  -6.70  315.0    7.10   1.53    7.65  10.55   7.44  2 2 2 2 2 2 2 2   2.70  2.57   -20   -6.70  -6.70  -6.70  -6.70  -6.70  -6.70   1.059  1.363  0.235  1.215  1.032  1.144  2 2 2 2 2 2
+2012-09-02T06:00:00 2012   9  2  6  0 00    3.40  -6.20  315.0    7.20   1.60    7.53  10.13   7.24  2 2 2 2 2 2 2 2   2.30  2.64   -27   -6.20  -6.20  -6.20  -6.20  -6.20  -6.20   1.143  1.424  0.263  1.293  1.043  1.228  2 2 2 2 2 2
+2012-09-02T07:00:00 2012   9  2  7  0 00    2.20  -5.50  312.0    8.90   1.61    6.51   9.12   7.39  2 2 2 2 2 2 2 2   2.30  2.70   -29   -5.50  -5.50  -5.50  -5.50  -5.50  -5.50   1.183  1.453  0.287  1.289  1.032  1.366  2 2 2 2 2 2
+2012-09-02T08:00:00 2012   9  2  8  0 00    4.90  -5.10  316.0    6.60   1.22    6.12   8.30   6.36  2 2 2 2 2 2 2 2   2.30  2.62   -26   -5.10  -5.10  -5.10  -5.10  -5.10  -5.10   1.164  1.383  0.305  1.203  0.955  1.262  2 2 2 2 2 2
+2012-09-02T09:00:00 2012   9  2  9  0 00    4.60  -4.00  317.0    7.20   1.30    5.65   7.13   4.93  2 2 2 2 2 2 2 2   2.30  2.53   -22   -4.00  -4.00  -4.00  -4.00  -4.00  -4.00   1.093  1.260  0.317  1.049  0.851  1.129  2 2 2 2 2 2
+2012-09-02T10:00:00 2012   9  2 10  0 00    2.80  -5.30  321.0    6.90   1.31    5.24   7.51   5.28  2 2 2 2 2 2 2 2   2.30  2.44   -17   -5.30  -5.30  -5.30  -5.30  -5.30  -5.30   1.077  1.246  0.332  1.025  0.879  1.127  2 2 2 2 2 2
+2012-09-02T11:00:00 2012   9  2 11  0 00    2.90  -5.90  323.0    7.10   1.36    6.37   9.06   6.35  2 2 2 2 2 2 2 2   2.30  2.40   -22   -5.90  -5.90  -5.90  -5.90  -5.90  -5.90   1.119  1.310  0.353  1.117  0.966  1.203  2 2 2 2 2 2
+2012-09-02T12:00:00 2012   9  2 12  0 00    2.80  -5.90  324.0    8.80   1.77    6.91   9.54   7.66  2 2 2 2 2 2 2 2   2.30  2.35   -25   -5.90  -5.90  -5.90  -5.90  -5.90  -5.90   1.186  1.412  0.378  1.235  1.062  1.431  2 2 2 2 2 2
+2012-09-02T13:00:00 2012   9  2 13  0 00    2.80  -6.60  324.0    8.00   1.61    7.65  10.17   8.50  2 2 2 2 2 2 2 2   2.30  2.30   -29   -6.60  -6.60  -6.60  -6.60  -6.60  -6.60   1.263  1.504  0.405  1.366  1.133  1.561  2 2 2 2 2 2
+2012-09-02T14:00:00 2012   9  2 14  0 00    2.40  -7.00  325.0    7.30   1.47    8.68  11.06   8.43  2 2 2 2 2 2 2 2   2.30  2.30   -33   -7.00  -7.00  -7.00  -7.00  -7.00  -7.00   1.329  1.556  0.435  1.482  1.169  1.546  2 2 2 2 2 2
+2012-09-02T15:00:00 2012   9  2 15  0 00   -0.50  -7.50  322.0    8.00   1.57    9.17  11.76   9.03  2 2 2 2 2 2 2 2   2.70  2.35   -36   -7.50  -7.50  -7.50  -7.50  -7.50  -7.50   1.406  1.630  0.467  1.615  1.224  1.602  2 2 2 2 2 2
+2012-09-02T16:00:00 2012   9  2 16  0 00   -2.30  -7.40  318.0    8.80   1.73    9.57  11.91  10.04  2 2 2 2 2 2 2 2   2.70  2.40   -41   -7.40  -7.40  -7.40  -7.40  -7.40  -7.40   1.478  1.711  0.500  1.724  1.265  1.726  2 2 2 2 2 2
+2012-09-02T17:00:00 2012   9  2 17  0 00    1.30  -6.80  320.0    9.40   1.88    8.60  11.29  10.30  2 2 2 2 2 2 2 2   2.70  2.46   -47   -6.80  -6.80  -6.80  -6.80  -6.80  -6.80   1.516  1.745  0.530  1.748  1.267  1.848  2 2 2 2 2 2
+2012-09-02T18:00:00 2012   9  2 18  0 00    2.60  -7.10  317.0    9.10   1.78    8.60  11.08  10.24  2 2 2 2 2 2 2 2   3.70  2.64   -47   -7.10  -7.10  -7.10  -7.10  -7.10  -7.10   1.539  1.762  0.558  1.757  1.263  1.885  2 2 2 2 2 2
+2012-09-02T19:00:00 2012   9  2 19  0 00    2.70  -6.80  315.0    8.60   1.60    8.74  10.96   9.68  2 2 2 2 2 2 2 2   3.70  2.82   -39   -6.80  -6.80  -6.80  -6.80  -6.80  -6.80   1.537  1.740  0.583  1.726  1.224  1.805  2 2 2 2 2 2
+2012-09-02T20:00:00 2012   9  2 20  0 00    1.70  -7.10  318.0    9.30   1.69    8.61  11.02   9.90  2 2 2 2 2 2 2 2   3.70  2.99   -35   -7.10  -7.10  -7.10  -7.10  -7.10  -7.10   1.549  1.753  0.609  1.738  1.243  1.844  2 2 2 2 2 2
+2012-09-02T21:00:00 2012   9  2 21  0 00   -0.30  -8.00  313.0    8.90   1.58    9.61  11.96  10.86  2 2 2 2 2 2 2 2   4.70  3.30   -41   -8.00  -8.00  -8.00  -8.00  -8.00  -8.00   1.597  1.816  0.639  1.836  1.293  1.885  2 2 2 2 2 2
+2012-09-02T22:00:00 2012   9  2 22  0 00   -0.50  -8.10  310.0    9.80   1.70   10.52  12.54  11.77  2 2 2 2 2 2 2 2   4.70  3.60   -42   -8.10  -8.10  -8.10  -8.10  -8.10  -8.10   1.658  1.897  0.671  1.950  1.340  1.978  2 2 2 2 2 2
+2012-09-02T23:00:00 2012   9  2 23  0 00   -0.30  -7.70  311.0   10.30   1.76   10.09  12.24  12.32  2 2 2 2 2 2 2 2   4.70  3.85   -45   -7.70  -7.70  -7.70  -7.70  -7.70  -7.70   1.699  1.947  0.701  2.002  1.357  2.095  2 2 2 2 2 2

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -85,13 +85,15 @@ class WebGettingIntegration(unittest.TestCase):
         # doesn't support keepalive....
         with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
             f.write(b'This is a test\n')
-        conn, data = spacepy.toolbox._get_url_keepalive(
-            'http://localhost:{}/foo.txt'.format(self.port))
+        conn, data = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port),
+            keepalive=True)
         try:
             self.assertEqual(
                 b"This is a test\n", data)
-            conn, data = spacepy.toolbox._get_url_keepalive(
-                'http://localhost:{}/foo.txt'.format(self.port), conn)
+            conn, data = spacepy.toolbox.get_url(
+                'http://localhost:{}/foo.txt'.format(self.port),
+                conn=conn, keepalive=True)
         finally:
             conn.close()
         self.assertEqual(
@@ -134,13 +136,13 @@ class WebGettingIntegration(unittest.TestCase):
         with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
             f.write(b'This is a test\n')
         outfile = os.path.join(self.td, 'output.txt')
-        conn, data = spacepy.toolbox._get_url_keepalive(
+        conn, data = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port),
-            outfile=outfile)
+            outfile=outfile, keepalive=True)
         try:
-            conn, data = spacepy.toolbox._get_url_keepalive(
-                'http://localhost:{}/foo.txt'.format(self.port), conn=conn,
-                outfile=outfile, cached=True)
+            conn, data = spacepy.toolbox.get_url(
+                'http://localhost:{}/foo.txt'.format(self.port),
+                outfile=outfile, cached=True, conn=conn, keepalive=True)
         finally:
             conn.close()
         self.assertTrue(data is None)

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -147,6 +147,23 @@ class WebGettingIntegration(unittest.TestCase):
             conn.close()
         self.assertTrue(data is None)
 
+    def testGetUrlToFileCachedKeepaliveChanged(self):
+        """Call get_url keepalive, write to file with cache"""
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'This is a test\n')
+        outfile = os.path.join(self.td, 'output.txt')
+        data, conn = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port),
+            outfile=outfile, keepalive=True)
+        try:
+            os.utime(outfile, (0., 0.))
+            data, conn = spacepy.toolbox.get_url(
+                'http://localhost:{}/foo.txt'.format(self.port),
+                outfile=outfile, cached=True, conn=conn, keepalive=True)
+        finally:
+            conn.close()
+        self.assertEqual(b'This is a test\n', data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -85,13 +85,13 @@ class WebGettingIntegration(unittest.TestCase):
         # doesn't support keepalive....
         with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
             f.write(b'This is a test\n')
-        conn, data = spacepy.toolbox.get_url(
+        data, conn = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port),
             keepalive=True)
         try:
             self.assertEqual(
                 b"This is a test\n", data)
-            conn, data = spacepy.toolbox.get_url(
+            data, conn = spacepy.toolbox.get_url(
                 'http://localhost:{}/foo.txt'.format(self.port),
                 conn=conn, keepalive=True)
         finally:
@@ -136,11 +136,11 @@ class WebGettingIntegration(unittest.TestCase):
         with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
             f.write(b'This is a test\n')
         outfile = os.path.join(self.td, 'output.txt')
-        conn, data = spacepy.toolbox.get_url(
+        data, conn = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port),
             outfile=outfile, keepalive=True)
         try:
-            conn, data = spacepy.toolbox.get_url(
+            data, conn = spacepy.toolbox.get_url(
                 'http://localhost:{}/foo.txt'.format(self.port),
                 outfile=outfile, cached=True, conn=conn, keepalive=True)
         finally:

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -79,6 +79,24 @@ class WebGettingIntegration(unittest.TestCase):
         self.assertEqual(
             b"This is a test\n", data)
 
+    def testGetUrlKeepaliveReturn(self):
+        """Call get_url, return data directly, keep connection"""
+        # This isn't the greatest test because the Python http server
+        # doesn't support keepalive....
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'This is a test\n')
+        conn, data = spacepy.toolbox._get_url_keepalive(
+            'http://localhost:{}/foo.txt'.format(self.port))
+        try:
+            self.assertEqual(
+                b"This is a test\n", data)
+            conn, data = spacepy.toolbox._get_url_keepalive(
+                'http://localhost:{}/foo.txt'.format(self.port), conn)
+        finally:
+            conn.close()
+        self.assertEqual(
+            b"This is a test\n", data)
+
     def testGetUrlToFile(self):
         """Call get_url, write to file"""
         with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
@@ -109,6 +127,22 @@ class WebGettingIntegration(unittest.TestCase):
         data = spacepy.toolbox.get_url(
             'http://localhost:{}/foo.txt'.format(self.port),
             outfile=outfile, cached=True)
+        self.assertTrue(data is None)
+
+    def testGetUrlToFileCachedKeepalive(self):
+        """Call get_url keepalive, write to file with cache"""
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'This is a test\n')
+        outfile = os.path.join(self.td, 'output.txt')
+        conn, data = spacepy.toolbox._get_url_keepalive(
+            'http://localhost:{}/foo.txt'.format(self.port),
+            outfile=outfile)
+        try:
+            conn, data = spacepy.toolbox._get_url_keepalive(
+                'http://localhost:{}/foo.txt'.format(self.port), conn=conn,
+                outfile=outfile, cached=True)
+        finally:
+            conn.close()
         self.assertTrue(data is None)
 
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -706,7 +706,28 @@ class SimpleFunctionTests(unittest.TestCase):
         res = tb.poisson_fit(data)
         self.assertEqual(ans, numpy.round(res.x))
 
-            
+    def test_assemble_qindenton_daily(self):
+        """Assemble OMNI data structure from Qin-Denton daily files"""
+        dailydir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            'data', 'qindenton_daily')
+        omnidata = tb._assemble_qindenton_daily(dailydir)
+        self.assertEqual(
+            ['ByIMF', 'Bz1', 'Bz2', 'Bz3', 'Bz4', 'Bz5', 'Bz6', 'BzIMF',
+             'DOY', 'Dst', 'G1', 'G2', 'G3', 'Kp', 'Pdyn', 'Qbits',
+             'RDT', 'UTC', 'W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'akp3',
+             'dens', 'velo'],
+            sorted(omnidata.keys()))
+        numpy.testing.assert_array_equal(
+            [14,  16,  18,  17,  17,  12,  10,  11,  11,   4,   0,  -8, -13,
+             -13, -12, -11,  -9,  -5,   2,   6,   9,   9,  10,   6,  -2,  -8,
+             -11, -11, -12, -20, -27, -29, -26, -22, -17, -22, -25, -29, -33,
+             -36, -41, -47, -47, -39, -35, -41, -42, -45],
+            omnidata['Dst'])
+        numpy.testing.assert_array_equal(
+            2, omnidata['Qbits']['W6'])
+
+
 class TBTimeFunctionTests(unittest.TestCase):
     def setUp(self):
         super(TBTimeFunctionTests, self).setUp()


### PR DESCRIPTION
The ViRBO source for the Qin-Denton formatted OMNI files is no longer maintained (#233). This PR adds the daily files from the New Mexico Consortium (used to support Van Allen Probes) to extend up to the present; it is merged with the ViRBO file. Because these are daily files retrieved over HTTPS, and connection setup is expensive, it also adds the ability to reuse HTTP connections between requests. This isn't very simple or robust code, but it's the difference between five minutes to check all the files and thirty minutes. It will always fall back to the previous code if necessary.

This PR also retrieves the leapsecond file from NASA MODIS, as the USNO is still down.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
