### PR TITLE
test_ae9ap9.py: small deprication update with a py2/py3 issue (closes #179)

### DIFF
--- a/tests/test_ae9ap9.py
+++ b/tests/test_ae9ap9.py
@@ -38,7 +38,9 @@ class ae9ap9Tests(unittest.TestCase):
     def test_setUnits_error(self):
         """Invalid units raise the correct error and message"""
         ans = ae9ap9.readFile(self.datafiles[0])
-        self.assertRaisesRegexp(ValueError, '^(Units of FeV)', ans.setUnits, 'FeV')
+        if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
+            unittest.TestCase.assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegexp')
+        self.assertRaisesRegex(ValueError, '^(Units of FeV)', ans.setUnits, 'FeV')
 
     def test_setUnits_convert(self):
         """Conversion correctly changes flux/fluence values, energy values and units"""

--- a/tests/test_ae9ap9.py
+++ b/tests/test_ae9ap9.py
@@ -38,9 +38,10 @@ class ae9ap9Tests(unittest.TestCase):
     def test_setUnits_error(self):
         """Invalid units raise the correct error and message"""
         ans = ae9ap9.readFile(self.datafiles[0])
-        if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
-            unittest.TestCase.assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegexp')
-        self.assertRaisesRegex(ValueError, '^(Units of FeV)', ans.setUnits, 'FeV')
+        if hasattr(self, 'assertRaisesRegex'):
+            self.assertRaisesRegex(ValueError, '^(Units of FeV)', ans.setUnits, 'FeV')
+        else: #Py2k
+            self.assertRaisesRegexp(ValueError, '^(Units of FeV)', ans.setUnits, 'FeV')
 
     def test_setUnits_convert(self):
         """Conversion correctly changes flux/fluence values, energy values and units"""


### PR DESCRIPTION
test_ae9ap9.py: small deprication update with a py2/py3 issue around `unittest.TestCase.assertRaisesRegex` (Closes #179)


- [x ] Pull request has descriptive title
- [x ] Pull request gives overview of changes
- [x ] New code has inline comments where necessary
- [n/a ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [n/a ] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ x] New features and bug fixes should have unit tests
- [ x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

This is a very minor change @drsteve even said in #179 how to fix this. 