### PR TITLE
Fix toolbox.progressbar going over 100%

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1236,8 +1236,10 @@ def progressbar(count, blocksize, totalsize, text='Download Progress'):
     >>> import urllib
     >>> urllib.urlretrieve(config['psddata_url'], PSDdata_fname, reporthook=tb.progressbar)
     """
-    percent = int(count*blocksize*100/totalsize)
-    sys.stdout.write("\r" + text + " " + "...%d%%" % percent)
+    percent = count * blocksize * 100. / totalsize
+    if percent > 100:
+        percent = 100.
+    sys.stdout.write("\r{} ...{:.0f}%".format(text, percent))
     if percent >= 100: print('\n')
     sys.stdout.flush()
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -205,6 +205,27 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertEqual(result, "\rDownload Progress ...0%")
         sys.stdout = realstdout
 
+    def test_progressbar_bigblock(self):
+        """progressbar should not go over 100% with big blocks"""
+        realstdout = sys.stdout
+        output = StringIO.StringIO()
+        sys.stdout = output
+        try:
+            for i in range(4):
+                self.assertEqual(tb.progressbar(i, 100, 205), None)
+            result = output.getvalue()
+        finally:
+            sys.stdout = realstdout
+            output.close()
+        self.assertEqual(
+            result,
+            "\rDownload Progress ...0%"
+            "\rDownload Progress ...49%"
+            "\rDownload Progress ...98%"
+            "\rDownload Progress ...100%"
+            "\n\n"
+        )
+
     def test_query_yes_no(self):
         '''query_yes_no should return known strings for known input'''
         realstdout = sys.stdout


### PR DESCRIPTION
#338 discussion mentioned that the progressbar occasionally goes over 100%. This PR fixes that. The main change is pretty straightforward (just clamp the value) but there's some other cleanup, which includes rounding the output (but only on display, it won't trigger the 100% line-clear for 99.9%).

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A, minor) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

