### PR TITLE
toolbox.progressbar: Only print one newline at end.

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1240,7 +1240,8 @@ def progressbar(count, blocksize, totalsize, text='Download Progress'):
     if percent > 100:
         percent = 100.
     sys.stdout.write("\r{} ...{:.0f}%".format(text, percent))
-    if percent >= 100: print('\n')
+    if percent >= 100:
+        sys.stdout.write("\n")
     sys.stdout.flush()
 
 def windowMean(data, time=[], winsize=0, overlap=0, st_time=None, op=np.mean):

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -200,9 +200,11 @@ class SimpleFunctionTests(unittest.TestCase):
         output = StringIO.StringIO()
         sys.stdout = output
         self.assertEqual(tb.progressbar(0, 1, 100), None)
+        self.assertEqual(tb.progressbar(100, 1, 100), None)
         result = output.getvalue()
         output.close()
-        self.assertEqual(result, "\rDownload Progress ...0%")
+        self.assertEqual(result, "\rDownload Progress ...0%"
+                         "\rDownload Progress ...100%\n")
         sys.stdout = realstdout
 
     def test_progressbar_bigblock(self):
@@ -223,7 +225,7 @@ class SimpleFunctionTests(unittest.TestCase):
             "\rDownload Progress ...49%"
             "\rDownload Progress ...98%"
             "\rDownload Progress ...100%"
-            "\n\n"
+            "\n"
         )
 
     def test_query_yes_no(self):


### PR DESCRIPTION
Right now progressbar forces an extra newline after the output, so if you do:
```
print("About to do stuff")
for i in really_big_iterator:
    spacepy.toolbox.progressbar(c, b, t, "Doing cool stuff")
print("Cool stuff completed")
```
You get:
```
About to do stuff
Doing cool stuff ...100%

Cool stuff completed
```

This makes the mutli-part downloads of #338 confusing. This PR removes the extra empty line.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
