### PR TITLE
New function to rebin array by another array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ Changes in Version 0.2.2 (2020-xx-xx)
 - Document end of support for Python 2
 coordinates
  - Include upstream fix for SPH->RLL coordinate transform
+datamanager
+ - New function "rebin", rebin an axis of an array by contents of another
 irbempy
  - Update IRBEMlib to rev620
  - Rev620 adds IGRF13 coefficients

--- a/Doc/source/pyplots/datamanager_rebin_1.py
+++ b/Doc/source/pyplots/datamanager_rebin_1.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 5)
+alpha = numpy.arange(0, 181., 2)
+# Add a dimension so the flux is a 2D array
+flux = j(1., numpy.expand_dims(times, 1),
+             numpy.expand_dims(alpha, 0))
+# The ordering of pcolormesh inputs is (y, x), so transpose
+matplotlib.pyplot.pcolormesh(
+    spacepy.toolbox.bin_center_to_edges(times),
+    spacepy.toolbox.bin_center_to_edges(alpha),
+    flux.transpose(), norm=matplotlib.colors.LogNorm())
+matplotlib.pyplot.ylabel('Pitch angle (deg)')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.title('Flux at 1 MeV')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_1.py
+++ b/Doc/source/pyplots/datamanager_rebin_1.py
@@ -7,11 +7,8 @@ alpha = numpy.arange(0, 181., 2)
 # Add a dimension so the flux is a 2D array
 flux = j(1., numpy.expand_dims(times, 1),
              numpy.expand_dims(alpha, 0))
-# The ordering of pcolormesh inputs is (y, x), so transpose
-matplotlib.pyplot.pcolormesh(
-    spacepy.toolbox.bin_center_to_edges(times),
-    spacepy.toolbox.bin_center_to_edges(alpha),
-    flux.transpose(), norm=matplotlib.colors.LogNorm())
+spacepy.plot.simpleSpectrogram(times, alpha, flux, cb=False,
+                               ylog=False)
 matplotlib.pyplot.ylabel('Pitch angle (deg)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 1 MeV')

--- a/Doc/source/pyplots/datamanager_rebin_2.py
+++ b/Doc/source/pyplots/datamanager_rebin_2.py
@@ -6,11 +6,7 @@ times = numpy.arange(0., 7200, 5)
 energies = numpy.logspace(0, 3, 50)
 flux = j(numpy.expand_dims(energies, 0),
          numpy.expand_dims(times, 1), 90.)
-matplotlib.pyplot.pcolormesh(
-    spacepy.toolbox.bin_center_to_edges(times),
-    spacepy.toolbox.bin_center_to_edges(energies),
-    flux.transpose(), norm=matplotlib.colors.LogNorm())
-matplotlib.pyplot.yscale('log')
+spacepy.plot.simpleSpectrogram(times, energies, flux, cb=False)
 matplotlib.pyplot.ylabel('Energy (MeV)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 90 degrees')

--- a/Doc/source/pyplots/datamanager_rebin_2.py
+++ b/Doc/source/pyplots/datamanager_rebin_2.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 5)
+energies = numpy.logspace(0, 3, 50)
+flux = j(numpy.expand_dims(energies, 0),
+         numpy.expand_dims(times, 1), 90.)
+matplotlib.pyplot.pcolormesh(
+    spacepy.toolbox.bin_center_to_edges(times),
+    spacepy.toolbox.bin_center_to_edges(energies),
+    flux.transpose(), norm=matplotlib.colors.LogNorm())
+matplotlib.pyplot.yscale('log')
+matplotlib.pyplot.ylabel('Energy (MeV)')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.title('Flux at 90 degrees')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_3.py
+++ b/Doc/source/pyplots/datamanager_rebin_3.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 5)
+lines = matplotlib.pyplot.plot(
+    times, pa(numpy.arange(8).reshape(1, -1), times.reshape(-1, 1)),
+    marker='o', ms=1, linestyle='')
+matplotlib.pyplot.legend(lines, ['Detector {}'.format(i) for i in range(8)],
+                         loc='best')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.ylabel('Pitch angle (deg)')
+matplotlib.pyplot.title('Measured pitch angle by detector')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_4.py
+++ b/Doc/source/pyplots/datamanager_rebin_4.py
@@ -8,10 +8,8 @@ energies = numpy.logspace(0, 3, 10)
 flux = j(numpy.reshape(energies, (1, 1, -1)),
                      numpy.reshape(times, (-1, 1, 1)),
                      numpy.expand_dims(alpha, -1))
-matplotlib.pyplot.pcolormesh(
-    spacepy.toolbox.bin_center_to_edges(times),
-    spacepy.toolbox.bin_center_to_edges(numpy.arange(8)),
-    flux[..., 0].transpose(), norm=matplotlib.colors.LogNorm())
+spacepy.plot.simpleSpectrogram(times, numpy.arange(8),
+     flux[..., 0], cb=False, ylog=False)
 matplotlib.pyplot.ylabel('Detector')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 1 MeV')

--- a/Doc/source/pyplots/datamanager_rebin_4.py
+++ b/Doc/source/pyplots/datamanager_rebin_4.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 300)
+alpha = pa(numpy.arange(8).reshape(1, -1), times.reshape(-1, 1))
+energies = numpy.logspace(0, 3, 10)
+flux = j(numpy.reshape(energies, (1, 1, -1)),
+                     numpy.reshape(times, (-1, 1, 1)),
+                     numpy.expand_dims(alpha, -1))
+matplotlib.pyplot.pcolormesh(
+    spacepy.toolbox.bin_center_to_edges(times),
+    spacepy.toolbox.bin_center_to_edges(numpy.arange(8)),
+    flux[..., 0].transpose(), norm=matplotlib.colors.LogNorm())
+matplotlib.pyplot.ylabel('Detector')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.title('Flux at 1 MeV')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_5.py
+++ b/Doc/source/pyplots/datamanager_rebin_5.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 300)
+alpha = pa(numpy.arange(8).reshape(1, -1), times.reshape(-1, 1))
+energies = numpy.logspace(0, 3, 10)
+flux = j(numpy.reshape(energies, (1, 1, -1)),
+                     numpy.reshape(times, (-1, 1, 1)),
+                     numpy.expand_dims(alpha, -1))
+matplotlib.pyplot.pcolormesh(
+    spacepy.toolbox.bin_center_to_edges(times),
+    spacepy.toolbox.bin_center_to_edges(energies),
+    flux[:, 0, :].transpose(), norm=matplotlib.colors.LogNorm())
+matplotlib.pyplot.yscale('log')
+matplotlib.pyplot.ylabel('Energy (MeV)')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.title('Flux in detector 0')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_5.py
+++ b/Doc/source/pyplots/datamanager_rebin_5.py
@@ -8,11 +8,7 @@ energies = numpy.logspace(0, 3, 10)
 flux = j(numpy.reshape(energies, (1, 1, -1)),
                      numpy.reshape(times, (-1, 1, 1)),
                      numpy.expand_dims(alpha, -1))
-matplotlib.pyplot.pcolormesh(
-    spacepy.toolbox.bin_center_to_edges(times),
-    spacepy.toolbox.bin_center_to_edges(energies),
-    flux[:, 0, :].transpose(), norm=matplotlib.colors.LogNorm())
-matplotlib.pyplot.yscale('log')
+spacepy.plot.simpleSpectrogram(times, energies, flux[:, 0, :], cb=False)
 matplotlib.pyplot.ylabel('Energy (MeV)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux in detector 0')

--- a/Doc/source/pyplots/datamanager_rebin_6.py
+++ b/Doc/source/pyplots/datamanager_rebin_6.py
@@ -11,10 +11,8 @@ flux = j(numpy.reshape(energies, (1, 1, -1)),
 pa_bins = numpy.arange(0, 181, 36)
 flux_by_pa = spacepy.datamanager.rebin(
     flux, alpha, pa_bins, axis=1)
-matplotlib.pyplot.pcolormesh(
-    spacepy.toolbox.bin_center_to_edges(times), pa_bins,
-    flux_by_pa[..., 0].transpose(),
-    norm=matplotlib.colors.LogNorm())
+spacepy.plot.simpleSpectrogram(times, pa_bins, flux_by_pa[..., 0],
+                               cb=False, ylog=False)
 matplotlib.pyplot.ylabel('Pitch angle (deg)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 1MeV')

--- a/Doc/source/pyplots/datamanager_rebin_6.py
+++ b/Doc/source/pyplots/datamanager_rebin_6.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 300)
+alpha = pa(numpy.arange(8).reshape(1, -1), times.reshape(-1, 1))
+energies = numpy.logspace(0, 3, 10)
+flux = j(numpy.reshape(energies, (1, 1, -1)),
+                     numpy.reshape(times, (-1, 1, 1)),
+                     numpy.expand_dims(alpha, -1))
+pa_bins = numpy.arange(0, 181, 36)
+flux_by_pa = spacepy.datamanager.rebin(
+    flux, alpha, pa_bins, axis=1)
+matplotlib.pyplot.pcolormesh(
+    spacepy.toolbox.bin_center_to_edges(times), pa_bins,
+    flux_by_pa[..., 0].transpose(),
+    norm=matplotlib.colors.LogNorm())
+matplotlib.pyplot.ylabel('Pitch angle (deg)')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.title('Flux at 1MeV')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_7.py
+++ b/Doc/source/pyplots/datamanager_rebin_7.py
@@ -11,11 +11,8 @@ flux = j(numpy.reshape(energies, (1, 1, -1)),
 pa_bins = numpy.arange(0, 181, 36)
 flux_by_pa = spacepy.datamanager.rebin(
     flux, alpha, pa_bins, axis=1)
-matplotlib.pyplot.pcolormesh(
-    spacepy.toolbox.bin_center_to_edges(times), energies,
-    flux_by_pa[:, 2, :].transpose(),
-    norm=matplotlib.colors.LogNorm())
-matplotlib.pyplot.yscale('log')
+spacepy.plot.simpleSpectrogram(times, energies, flux_by_pa[:, 2, :],
+                               cb=False)
 matplotlib.pyplot.ylabel('Energy (MeV)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 90 degrees')

--- a/Doc/source/pyplots/datamanager_rebin_7.py
+++ b/Doc/source/pyplots/datamanager_rebin_7.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from datamanager_rebin_common import *
+
+times = numpy.arange(0., 7200, 300)
+alpha = pa(numpy.arange(8).reshape(1, -1), times.reshape(-1, 1))
+energies = numpy.logspace(0, 3, 10)
+flux = j(numpy.reshape(energies, (1, 1, -1)),
+                     numpy.reshape(times, (-1, 1, 1)),
+                     numpy.expand_dims(alpha, -1))
+pa_bins = numpy.arange(0, 181, 36)
+flux_by_pa = spacepy.datamanager.rebin(
+    flux, alpha, pa_bins, axis=1)
+matplotlib.pyplot.pcolormesh(
+    spacepy.toolbox.bin_center_to_edges(times), energies,
+    flux_by_pa[:, 2, :].transpose(),
+    norm=matplotlib.colors.LogNorm())
+matplotlib.pyplot.yscale('log')
+matplotlib.pyplot.ylabel('Energy (MeV)')
+matplotlib.pyplot.xlabel('Time (sec)')
+matplotlib.pyplot.title('Flux at 90 degrees')
+matplotlib.pyplot.show()

--- a/Doc/source/pyplots/datamanager_rebin_common.py
+++ b/Doc/source/pyplots/datamanager_rebin_common.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
-import matplotlib.colors
 import matplotlib.pyplot
 import numpy
 import spacepy.datamanager
-import spacepy.toolbox
+import spacepy.plot
 
 def j(e, t, a):
     return e ** -2 * (1 / (90 * numpy.sqrt(2 * numpy.pi))) \

--- a/Doc/source/pyplots/datamanager_rebin_common.py
+++ b/Doc/source/pyplots/datamanager_rebin_common.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import matplotlib.colors
+import matplotlib.pyplot
+import numpy
+import spacepy.datamanager
+import spacepy.toolbox
+
+def j(e, t, a):
+    return e ** -2 * (1 / (90 * numpy.sqrt(2 * numpy.pi))) \
+        * numpy.exp(-0.5 * (
+            (a - 90 + 90 * numpy.sin(t / 573.))
+            / 90.) ** 2)
+
+def pa(d, t):
+    return (d * 22.5 + t / 6 * (2 * (d % 2) - 1)) % 180

--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -901,11 +901,10 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
 
     First making the relevant imports::
 
-        >>> import matplotlib.colors
         >>> import matplotlib.pyplot
         >>> import numpy
         >>> import spacepy.datamanager
-        >>> import spacepy.toolbox
+        >>> import spacepy.plot
 
     The functional form of the flux is then::
 
@@ -921,11 +920,8 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
         # Add a dimension so the flux is a 2D array
         >>> flux = j(1., numpy.expand_dims(times, 1),
         ...          numpy.expand_dims(alpha, 0))
-        # The ordering of pcolormesh inputs is (y, x), so transpose
-        >>> matplotlib.pyplot.pcolormesh(
-        ...     spacepy.toolbox.bin_center_to_edge(times),
-        ...     spacepy.toolbox.bin_center_to_edges(alpha),
-        ...     flux.transpose(), norm=matplotlib.colors.LogNorm())
+        >>> spacepy.plot.simpleSpectrogram(times, alpha, flux, cb=False,
+        ...                                ylog=False)
         >>> matplotlib.pyplot.ylabel('Pitch angle (deg)')
         >>> matplotlib.pyplot.xlabel('Time (sec)')
         >>> matplotlib.pyplot.title('Flux at 1 MeV')
@@ -937,11 +933,7 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
         >>> energies = numpy.logspace(0, 3, 50)
         >>> flux = j(numpy.expand_dims(energies, 0),
         ...          numpy.expand_dims(times, 1), 90.)
-        >>> matplotlib.pyplot.pcolormesh(
-        ...     spacepy.toolbox.bin_center_to_edges(times),
-        ...     spacepy.toolbox.bin_center_to_edges(energies),
-        ...     flux.transpose(), norm=matplotlib.colors.LogNorm())
-        >>> matplotlib.pyplot.yscale('log')
+        >>> spacepy.plot.simpleSpectrogram(times, energies, flux, cb=False)
         >>> matplotlib.pyplot.ylabel('Energy (MeV)')
         >>> matplotlib.pyplot.xlabel('Time (sec)')
         >>> matplotlib.pyplot.title('Flux at 90 degrees')
@@ -983,10 +975,8 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
 
     The flux at an energy as a function of detector is not very useful::
 
-        >>> matplotlib.pyplot.pcolormesh(
-        ...     spacepy.toolbox.bin_center_to_edges(times),
-        ...     spacepy.toolbox.bin_center_to_edges(numpy.arange(8)),
-        ...     flux[..., 0].transpose(), norm=matplotlib.colors.LogNorm())
+        >>> spacepy.plot.simpleSpectrogram(times, numpy.arange(8),
+        ...                                flux[..., 0], cb=False, ylog=False)
         >>> matplotlib.pyplot.ylabel('Detector')
         >>> matplotlib.pyplot.xlabel('Time (sec)')
         >>> matplotlib.pyplot.title('Flux at 1 MeV')
@@ -996,11 +986,8 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
     As a function of energy for one detector, the energy dependence is
     apparent but time and pitch angle effects are confounded::
 
-        >>> matplotlib.pyplot.pcolormesh(
-        ...     spacepy.toolbox.bin_center_to_edges(times),
-        ...     spacepy.toolbox.bin_center_to_edges(energies),
-        ...     flux[:, 0, :].transpose(), norm=matplotlib.colors.LogNorm())
-        >>> matplotlib.pyplot.yscale('log')
+        >>> spacepy.plot.simpleSpectrogram(times, energies, flux[:, 0, :],
+        ...                                cb=False)
         >>> matplotlib.pyplot.ylabel('Energy (MeV)')
         >>> matplotlib.pyplot.xlabel('Time (sec)')
         >>> matplotlib.pyplot.title('Flux in detector 0')
@@ -1025,10 +1012,8 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
     but the original shape of the distribution is apparent, and further
     analysis can be performed on the regular pitch angle grid::
 
-        >>> matplotlib.pyplot.pcolormesh(
-        ...     spacepy.toolbox.bin_center_to_edges(times), pa_bins,
-        ...     flux_by_pa[..., 0].transpose(),
-        ...     norm=matplotlib.colors.LogNorm())
+        >>> spacepy.plot.simpleSpectrogram(times, pa_bins, flux_by_pa[..., 0],
+        ...                                cb=False, ylog=False)
         >>> matplotlib.pyplot.ylabel('Pitch angle (deg)')
         >>> matplotlib.pyplot.xlabel('Time (sec)')
         >>> matplotlib.pyplot.title('Flux at 1MeV')
@@ -1037,11 +1022,8 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
 
     Or by energy::
 
-        >>> matplotlib.pyplot.pcolormesh(
-        ...     spacepy.toolbox.bin_center_to_edges(times), energies,
-        ...     flux_by_pa[:, 2, :].transpose(),
-        ...     norm=matplotlib.colors.LogNorm())
-        >>> matplotlib.pyplot.yscale('log')
+        >>> spacepy.plot.simpleSpectrogram(times, energies, flux_by_pa[:, 2, :],
+        ...                                cb=False)
         >>> matplotlib.pyplot.ylabel('Energy (MeV)')
         >>> matplotlib.pyplot.xlabel('Time (sec)')
         >>> matplotlib.pyplot.title('Flux at 90 degrees')

--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -880,7 +880,10 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
         By default, the ``bindata`` are treated as point values. If
         ``bindatadelta`` is specified, it is treated as the half-width of
         the ``bindata``, allowing a single input value to be split between
-        output bins. Must be scalar, or same shape as `bindata`.
+        output bins. Must be scalar, or same shape as `bindata`. Note that
+        input values are not weighted by the bin width, but by number of
+        input values or by ``weights``. (Combining ``weights`` with
+        ``bindatadelta`` is not comprehensively tested.)
 
     Returns
     =======
@@ -900,9 +903,11 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
         if not numpy.isscalar(bindatadelta):
             assert bindata.shape == bindatadelta.shape
             bindatadelta = numpy.reshape(bindatadelta, binnedshape)
+            bindatadelta = numpy.rollaxis(
+                bindatadelta, axis=axis, start=len(data.shape))
+    # Add axes to match shapes. Move the axis to rebin to the end of the line.
     bindata = numpy.reshape(bindata, binnedshape)
     indata = data # Holding a reference without transformations
-    # Move the axis to rebin to the end of the line.
     data = numpy.rollaxis(data, axis=axis, start=len(data.shape))
     bindata = numpy.rollaxis(bindata, axis=axis, start=len(data.shape))
     nbins = len(bins) - 1

--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -893,14 +893,18 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
     """
     bintype = bintype.lower()
     assert bintype in ('mean', 'count', 'unc')
+    data = numpy.require(data, dtype=numpy.floating)
+    bindata = numpy.require(bindata, dtype=numpy.floating)
     if axis < 0:
         axis = len(data.shape) + axis
     binnedshape = _find_shape(data.shape, bindata.shape)
     if weights is not None:
+        weights = numpy.require(weights, dtype=numpy.floating)
         assert weights.shape == bindata.shape
         weights = numpy.reshape(weights, binnedshape)
     if bindatadelta is not None:
         if not numpy.isscalar(bindatadelta):
+            bindatadelta = numpy.require(bindatadelta, dtype=numpy.floating)
             assert bindata.shape == bindatadelta.shape
             bindatadelta = numpy.reshape(bindatadelta, binnedshape)
             bindatadelta = numpy.rollaxis(

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -606,7 +606,8 @@ def simpleSpectrogram(*args, **kwargs):
         if X.shape[0] == Z.shape[0]: # same length, expand X
             X = tb.bin_center_to_edges(X) # hopefully evenly spaced
         if len(Y.shape) == 1: # 1d, just use as axis
-            Y = tb.bin_center_to_edges(Y) # hopefully evenly spaced
+            if Y.shape[0] == Z.shape[1]: # same length, expand Y
+                Y = tb.bin_center_to_edges(Y) # hopefully evenly spaced
         elif len(Y.shape) == 2:
             Y_orig = Y
             # 2d this is time dependent and thus need to overplot several

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -657,7 +657,8 @@ def simpleSpectrogram(*args, **kwargs):
     
     if cb: # add a colorbar
         cb_ = fig.colorbar(pc)
-        cb_.set_label(cbtitle)
+        if cbtitle is not None:
+            cb_.set_label(cbtitle)
     return ax
 
     

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -400,7 +400,7 @@ class DataManagerFunctionTests(unittest.TestCase):
                  .reshape(inval.shape) == inval).all())
 
 
-class DatamanagerBinningTests(unittest.TestCase):
+class DataManagerBinningTests(unittest.TestCase):
     """Test of binning and helper functions"""
 
     def testFindShape(self):

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -691,6 +691,30 @@ class DatamanagerBinningTests(unittest.TestCase):
         numpy.testing.assert_array_equal(
             expected, rebinned)
 
+    def testRebinBindataDelta(self):
+        """Rebin data where the binning data have deltas"""
+        bins = numpy.arange(6)
+        indata = numpy.array([1, 2, 3, 4, 5])
+        bindata = numpy.array([1, 1.5, 1, 3, 4])
+        # This means input ranges
+        # A 0.5 to 1.5: 1
+        # B 1.0 to 2.0: 2
+        # C 0.5 to 1.5: 3
+        # D 2.5 to 3.5: 4
+        # E 3.5 to 4.5: 5
+        #Outputs are 0-1, 1-2, 2-3, 3-4, 4-5
+        expected = numpy.array([
+            2, 2, 4, 4.5, 5])
+        rebinned = spacepy.datamanager.rebin(indata, bindata, bins,
+                                             bindatadelta=0.5)
+        numpy.testing.assert_array_equal(
+            expected, rebinned)
+        # Try this specifying an array of bins
+        rebinned = spacepy.datamanager.rebin(
+            indata, bindata, bins, bindatadelta=numpy.repeat([0.5], 5))
+        numpy.testing.assert_array_equal(
+            expected, rebinned)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -751,6 +751,17 @@ class DatamanagerBinningTests(unittest.TestCase):
         numpy.testing.assert_array_equal(
             expected, rebinned)
 
+    def testRebinListInput(self):
+        """Test rebinning of an array, list instead of array input"""
+        bins = [0, 4, 8]
+        indata = [[40, 38, 51, 91], [56, 93, 60, 42]]
+        bindata = [[0.5, 2.5, 4, 6], [1, 3.5, 6, 6.5]]
+        expected = numpy.empty(dtype=numpy.float64, shape=(100, 6, 5))
+        expected = [[39, 71], [74.5, 51]]
+        rebinned = spacepy.datamanager.rebin(indata, bindata, bins)
+        numpy.testing.assert_allclose(
+            expected, rebinned, atol=1e-20)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -715,6 +715,42 @@ class DatamanagerBinningTests(unittest.TestCase):
         numpy.testing.assert_array_equal(
             expected, rebinned)
 
+    def testRebinBindataDelta2D(self):
+        """Rebin data where the binning data have deltas, multi-D"""
+        bins = numpy.arange(0, 9, 4)
+        indata = numpy.array([[40., 56], [38, 93], [51, 60], [91, 42]])
+        bindata = numpy.array([[0.5, 1], [2.5, 3.5], [5, 6], [6, 6.5]])
+        bindeltas = numpy.array([[0.5, 1], [1.5, 1.5], [1, 1], [1, 0.5]])
+        expected = numpy.array([[2, 5. / 3], [2, 7. / 3]])
+        counts = spacepy.datamanager.rebin(
+            indata, bindata, bins, bindatadelta=bindeltas, axis=0,
+            bintype='count')
+        numpy.testing.assert_allclose(expected, counts)
+        expected = numpy.array([[39, 70.8], [71, 57]])
+        rebinned = spacepy.datamanager.rebin(
+            indata, bindata, bins, bindatadelta=bindeltas, axis=0)
+        numpy.testing.assert_allclose(
+            expected, rebinned)
+        # Treat these values as uncertainties
+        expected = numpy.array([[27.586228448267445, 50.12783657809302],
+                                [52.15841255253078, 34.084229401257566]])
+        rebinned = spacepy.datamanager.rebin(
+            indata, bindata, bins, bindatadelta=bindeltas, axis=0,
+            bintype='unc')
+        numpy.testing.assert_allclose(
+            expected, rebinned)
+
+    def testRebinBindataAxis0Irregular(self):
+        """Rebin data on axis 0 with irregular sampling"""
+        bins = numpy.arange(0, 9, 4)
+        indata = numpy.array([[40., 56], [38, 93], [51, 60], [91, 42]])
+        bindata = numpy.array([[0.5, 1], [2.5, 3.5], [4, 6], [6, 6.5]])
+        expected = numpy.array([[39, 74.5], [71, 51]])
+        rebinned = spacepy.datamanager.rebin(
+            indata, bindata, bins, axis=0)
+        numpy.testing.assert_array_equal(
+            expected, rebinned)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds a function that allows the rebinning of one dimension of an array by data in another array. The canonical example of this is going from an array organized by sensor number and tagged by pitch angle, to one binned by pitch angle.

This is the type of thing I've found myself doing a _lot_ and nailing it down in general is actually nontrivial.

I think the one thing lacking in the documentation is a full end-to-end example, but since this usually involves big arrays it's hard to come up with a concise example.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
