### PR TITLE
time.Ticktock: allow non-str string-like input (Closes #354)

### DIFF
--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1144,23 +1144,19 @@ class Ticktock(MutableSequence):
                    else (d.encode('ascii') for d in self.data) if str is bytes \
                         else (d.decode('ascii') for d in self.data)
             # try a few special cases that are faster than dateutil.parser
-            try:
-                UTC = [datetime.datetime.strptime(isot, '%Y-%m-%dT%H:%M:%S') for isot in data]
-            except ValueError:
+            for strfmt in ('%Y-%m-%dT%H:%M:%S',
+                           '%Y-%m-%dT%H:%M:%SZ',
+                           '%Y-%m-%d',
+                           '%Y%m%d',
+                           '%Y%m%d %H:%M:%S'):
                 try:
-                    UTC = [datetime.datetime.strptime(isot, '%Y-%m-%dT%H:%M:%SZ') for isot in data]
+                    UTC = [datetime.datetime.strptime(isot, strfmt)
+                           for isot in data]
+                    break
                 except ValueError:
-                    try:
-                        UTC = [datetime.datetime.strptime(isot, '%Y-%m-%d') for isot in data]
-                    except ValueError:
-                        try:
-                            UTC = [datetime.datetime.strptime(isot, '%Y%m%d') for isot in data]
-                        except ValueError:
-                            try:
-                                UTC = [datetime.datetime.strptime(isot, '%Y%m%d %H:%M:%S') for isot in data]
-                            except ValueError:
-                                UTC = [dup.parse(isot) for isot in data]
-
+                    continue
+            else:
+                UTC = [dup.parse(isot) for isot in data]
         elif self.data.attrs['dtype'].upper() == 'TAI':
             self.TAI = self.data
             TAI0 = datetime.datetime(1958, 1, 1, 0, 0, 0, 0)

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1141,8 +1141,8 @@ class Ticktock(MutableSequence):
         elif self.data.attrs['dtype'].upper() == 'ISO':
             self.ISO = self.data
             data = self.data if isinstance(self.data[0], str) \
-                   else (d.encode('ascii') for d in self.data) if str is bytes \
-                        else (d.decode('ascii') for d in self.data)
+                   else [d.encode('ascii') for d in self.data] if str is bytes \
+                        else [d.decode('ascii') for d in self.data]
             # try a few special cases that are faster than dateutil.parser
             for strfmt in ('%Y-%m-%dT%H:%M:%S',
                            '%Y-%m-%dT%H:%M:%SZ',

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1141,8 +1141,7 @@ class Ticktock(MutableSequence):
         elif self.data.attrs['dtype'].upper() == 'ISO':
             self.ISO = self.data
             data = self.data if isinstance(self.data[0], str) \
-                   else [d.encode('ascii') for d in self.data] if str is bytes \
-                        else [d.decode('ascii') for d in self.data]
+                   else self.data.astype('S' if str is bytes else 'U')
             # try a few special cases that are faster than dateutil.parser
             for strfmt in ('%Y-%m-%dT%H:%M:%S',
                            '%Y-%m-%dT%H:%M:%SZ',

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -25,7 +25,6 @@ import warnings
 
 import numpy
 
-import spacepy
 import spacepy.time as t
 
 __all__ = ['TimeFunctionTests', 'TimeClassTests']

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -25,6 +25,7 @@ import warnings
 
 import numpy
 
+import spacepy
 import spacepy.time as t
 
 __all__ = ['TimeFunctionTests', 'TimeClassTests']
@@ -655,18 +656,23 @@ class TimeClassTests(unittest.TestCase):
 
     def test_iso_nonstr(self):
         """ISO string works with types other than str"""
-        isostr = b'2020-01-01T00:00:00'
-        if str is bytes: #Py2k
-            isostr = isostr.decode('ascii')
-        tt = t.Ticktock([isostr])
-        self.assertEqual(
-            datetime.datetime(2020, 1, 1),
-            tt.UTC[0])
-        # Do same thing with explicit type
-        tt = t.Ticktock([isostr], dtype='ISO')
-        self.assertEqual(
-            datetime.datetime(2020, 1, 1),
-            tt.UTC[0])
+        for isostr in (b'2020-01-01T00:00:00',
+                       b'2020-01-01T00:00:00Z',
+                       b'2020-01-01',
+                       b'20200101',
+                       b'20200101 00:00:00',
+                       b'2020 Jan 1'):
+            if str is bytes: #Py2k
+                isostr = isostr.decode('ascii')
+            tt = t.Ticktock([isostr])
+            self.assertEqual(
+                datetime.datetime(2020, 1, 1),
+                tt.UTC[0], isostr)
+            # Do same thing with explicit type
+            tt = t.Ticktock([isostr], dtype='ISO')
+            self.assertEqual(
+                datetime.datetime(2020, 1, 1),
+                tt.UTC[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -653,6 +653,21 @@ class TimeClassTests(unittest.TestCase):
         ans = [datetime.datetime(2002, 1, 1, 1, 0, 0), datetime.datetime(2002, 1, 2, 2, 3, 4)]
         numpy.testing.assert_equal(ans, tt.UTC)
 
+    def test_iso_nonstr(self):
+        """ISO string works with types other than str"""
+        isostr = b'2020-01-01T00:00:00'
+        if str is bytes: #Py2k
+            isostr = isostr.decode('ascii')
+        tt = t.Ticktock([isostr])
+        self.assertEqual(
+            datetime.datetime(2020, 1, 1),
+            tt.UTC[0])
+        # Do same thing with explicit type
+        tt = t.Ticktock([isostr], dtype='ISO')
+        self.assertEqual(
+            datetime.datetime(2020, 1, 1),
+            tt.UTC[0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Ticktock currently fails when the constructor is called with ISO timestrings in a string-like class that isn't actually str. One manifestation of this is in reading times from HDF5 files that were saved in Python 2 in Python 3. This PR fixes that. The Python 2 code is pretty separable from the Python 3 so hopefully it'll be easy to rip out when the time comes.

Note this still leaves the input data alone, not converting it to str. That's consistent with our usual approach in Ticktock but I can see the argument for converting it at construction time.

This seemed minor enough that I left it out of the CHANGELOG, but happy to hear other opinions.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A?) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
