### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ matrix:
   - python: 3.7
     dist: bionic
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
+  - python: 3.7
+    dist: bionic
+    env: NUMPY_VERSION="==1.14.5"
   - python: 3.8
     dist: bionic
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
-  - python: 3.8
-    dist: bionic
-    env: NUMPY_VERSION="==1.14.5"
 
 before_install:
  - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,35 @@
 language: python
 
+sudo: yes
+
 matrix:
  include:
   - python: 2.7
+    dist: bionic
     env: NUMPY_VERSION="==1.15.4"
   - python: 2.7
+    dist: bionic
     env: NUMPY_VERSION="==1.13.3"
   - python: 2.7
+    dist: bionic
     env: NUMPY_VERSION="==1.11.3"
   - python: 3.5
+    dist: xenial
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
   - python: 3.5
+    dist: xenial
     env: NUMPY_VERSION="==1.13.3"
   - python: 3.6
-    env: NUMPY_VERSION=">=1.6,!=1.15.0"
-  - python: 3.6
-    env: NUMPY_VERSION="==1.13.3"
-  - python: 3.7
-    dist: xenial
-    sudo: yes
+    dist: bionic
     env: NUMPY_VERSION=">=1.6,!=1.15.0"
   - python: 3.7
-    dist: xenial
+    dist: bionic
+    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+  - python: 3.8
+    dist: bionic
+    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+  - python: 3.8
+    dist: bionic
     env: NUMPY_VERSION="==1.14.5"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,31 +6,34 @@ matrix:
  include:
   - python: 2.7
     dist: bionic
-    env: NUMPY_VERSION="==1.15.4"
+    env: NUMPY_VERSION=">=1.6.0,<1.7.0"
   - python: 2.7
     dist: bionic
-    env: NUMPY_VERSION="==1.13.3"
-  - python: 2.7
-    dist: bionic
-    env: NUMPY_VERSION="==1.11.3"
+    env: NUMPY_VERSION=">=1.16.0,<1.17.0"
   - python: 3.5
     dist: xenial
-    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+    env: NUMPY_VERSION=">=1.10.0,<1.11.0"
   - python: 3.5
     dist: xenial
-    env: NUMPY_VERSION="==1.13.3"
+    env: NUMPY_VERSION=">=1.18.0,<1.19.0"
   - python: 3.6
     dist: bionic
-    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+    env: NUMPY_VERSION=">=1.12.0,<1.13.0"
+  - python: 3.6
+    dist: bionic
+    env: NUMPY_VERSION=">=1.18.0"
   - python: 3.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+    env: NUMPY_VERSION=">=1.15.1,<1.16.0"
   - python: 3.7
     dist: bionic
-    env: NUMPY_VERSION="==1.14.5"
+    env: NUMPY_VERSION=">=1.18.0"
   - python: 3.8
     dist: bionic
-    env: NUMPY_VERSION=">=1.6,!=1.15.0"
+    env: NUMPY_VERSION=">=1.17.0,<1.18.0"
+  - python: 3.8
+    dist: bionic
+    env: NUMPY_VERSION=">=1.18.0"
 
 before_install:
  - sudo apt-get update -qq


### PR DESCRIPTION
Our builds were all running on xenial; now that focal is out it seemed time to move to bionic. We also weren't testing Python 3.8. My thought is we probably want to test "latest" numpy on most minor versions of Python, with tests for the special cases that caused trouble on the latest python. I couldn't find back the issues that caused us to test particular versions of numpy; it's possible we can drop some in the future.

Here's the Python/numpy version matrix. "Latest" numpy is anything >=1.6 excluding 1.15.0, since 1.15.0 had a bug we couldn't work around (in I think f2py).

- Python 2.7 (moved to bionic, no other changes)
  - numpy 1.15.4 (probably the latest Python 2 numpy)
  - numpy 1.13.3 (a problem child?)
  - numpy 1.11.3 (a problem child?) 
- Python 3.5 (stays on xenial, no bionic support in travis)
  - numpy latest
  - numpy 1.13.3 (problem child?)
- Python 3.6 (moved to bionic)
  - numpy latest
  - DELETED numpy 1.13.3
- Python 3.7 (moved to bionic)
  - numpy latest
  - DELETED numpy 1.14.5
 - Python 3.8 (all new, bionic)
   - numpy latest
   - numpy 1.14.5 (problem child?)

If I can do math right, this means we stay at 9 builds, add Python 3.8, and maintain our numpy version coverage.