### PR TITLE
Various enhancements to pycdf.istp compliance checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ pycdf
    another variable
  - istp.VariableChecks adds check for VALID/SCALE MIN/MAX Entry types
  - istp.VariableChecks adds check for DELTA attributes
+ - istp.VariableChecks adds check for FILLVAL
  - istp.VariableChecks and FileChecks add check for empty attribute Entries
  - istp.VarBundle class to copy variables, slices, and depends between CDFs
  - istp.nanfill function to replace fill values with NaN

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -130,7 +130,7 @@ class VariableChecks(object):
             except:
                 if catch:
                     errors.append('Test {} did not complete.'.format(
-                        f.__name__))
+                        func.__name__))
                 else:
                     raise
         return errors
@@ -687,7 +687,7 @@ class FileChecks(object):
             except:
                 if catch:
                     errors.append('Test {} did not complete.'.format(
-                        f.__name__))
+                        func.__name__))
                 else:
                     raise
 

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -467,7 +467,17 @@ class VariableChecks(object):
                     continue
                 if firstdim: #Add pseudo-record dim
                     attrval = numpy.reshape(attrval, (1, -1))
-            if numpy.any((attrval < minval)) or numpy.any((attrval > maxval)):
+            # min, max, variable data all same dtype
+            if not numpy.can_cast(numpy.asanyarray(attrval),
+                                  numpy.asanyarray(minval).dtype):
+                errs.append(
+                    '{} type {} not comparable to variable type {}.'.format(
+                        which,
+                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
+                        spacepy.pycdf.lib.cdftypenames[v.type()]
+                    ))
+                continue # Cannot do comparisons
+            if numpy.any((minval > attrval)) or numpy.any((maxval < attrval)):
                 errs.append('{} ({}) outside valid data range ({},{}).'.format(
                     which, attrval[0, :] if multidim else attrval,
                     minval, maxval))

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -160,7 +160,7 @@ class VariableChecks(object):
             Description of each validation failure.
 
         """
-        return ['{} variable {} missing'.format(a, v.attrs[a])
+        return ['{} variable {} missing.'.format(a, v.attrs[a])
                 for a in v.attrs
                 if (a.startswith(('DEPEND_', 'LABL_PTR_',))
                     or a in ('DELTA_PLUS_VAR', 'DELTA_MINUS_VAR'))

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -39,6 +39,7 @@ Contact: Jonathan.Niehof@unh.edu
 import collections
 import datetime
 import functools
+import inspect
 import itertools
 import math
 import os.path
@@ -87,7 +88,7 @@ class VariableChecks(object):
     .. automethod:: validscale
 
     """
-    #When adding new tests, add to list above, and the list in all()
+    #When adding new tests, add to list above
     #Validation failures should be formatted as a sentence (initial cap,
     #closing period) and NOT include the variable name.
 
@@ -119,11 +120,9 @@ class VariableChecks(object):
         >>> spacepy.pycdf.istp.VariableChecks.all(v)
         ['No FIELDNAM attribute.']
         """
-        #Update this list when adding new test functions
-        callme = (cls.deltas, cls.depends, cls.depsize, cls.empty_entry,
-                  cls.fieldnam, cls.fillval,
-                  cls.recordcount, cls.validrange, cls.validscale,
-                  cls.validdisplaytype)
+        callme = [func for name, func in inspect.getmembers(cls)
+                  if not name.startswith('_') and not name.endswith('_')
+                  and callable(func) and name != 'all']
         errors = []
         for f in callme:
             try:
@@ -639,7 +638,7 @@ class FileChecks(object):
     .. automethod:: times
 
     """
-    #When adding new tests, add to list above, and the list in all()
+    #When adding new tests, add to list above.
     #Validation failures should be formatted as a sentence (initial cap,
     #closing period).
 
@@ -678,7 +677,9 @@ class FileChecks(object):
         'Var: No FIELDNAM attribute.']
         """
         #Update this list when adding new test functions
-        callme = (cls.empty_entry, cls.filename, cls.time_monoton, cls.times,)
+        callme = [func for name, func in inspect.getmembers(cls)
+                  if not name.startswith('_') and not name.endswith('_')
+                  and callable(func) and name != 'all']
         errors = []
         for func in callme:
             try:

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -468,7 +468,7 @@ class VariableChecks(object):
                 if firstdim: #Add pseudo-record dim
                     attrval = numpy.reshape(attrval, (1, -1))
             if numpy.any((attrval < minval)) or numpy.any((attrval > maxval)):
-                errs.append('{} ({}) outside data range ({},{}).'.format(
+                errs.append('{} ({}) outside valid data range ({},{}).'.format(
                     which, attrval[0, :] if multidim else attrval,
                     minval, maxval))
             if not rng or not len(v): #nothing to compare

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -130,7 +130,7 @@ class VariableChecks(object):
             except:
                 if catch:
                     errors.append('Test {} did not complete.'.format(
-                        func.__name__))
+                        f.__name__))
                 else:
                     raise
         return errors

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -186,6 +186,23 @@ class VariablesTests(ISTPTestsBase):
              'VALIDMIN type CDF_INT2 does not match variable type CDF_INT4.'],
             errs)
 
+    def testValidRangeIncompatibleType(self):
+        """Validmin/validmax can't be compared to variable type"""
+        v = self.cdf.new('var1', data=[1, 2, 3],
+                         type=spacepy.pycdf.const.CDF_INT4)
+        v.attrs.new('VALIDMIN', data='2')
+        v.attrs.new('VALIDMAX', data='5')
+        errs = spacepy.pycdf.istp.VariableChecks.validrange(v)
+        errs.sort()
+        self.assertEqual(4, len(errs))
+        self.assertEqual(
+            ['VALIDMAX type CDF_CHAR does not match variable type CDF_INT4.',
+             'VALIDMAX type CDF_CHAR not comparable to variable type CDF_INT4.',
+             'VALIDMIN type CDF_CHAR does not match variable type CDF_INT4.',
+             'VALIDMIN type CDF_CHAR not comparable to variable type CDF_INT4.'
+            ],
+            errs)
+
     def testValidRangeNRV(self):
         """Validmin/validmax"""
         v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -439,7 +439,7 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(2, len(errs))
         errs.sort()
         self.assertEqual(
-            ['SCALEMIN (-200) outside data range (-128,127).',
+            ['SCALEMIN (-200) outside valid data range (-128,127).',
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
              ],
              errs)
@@ -448,7 +448,7 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(3, len(errs))
         errs.sort()
         self.assertEqual(
-            ['SCALEMIN (200) outside data range (-128,127).',
+            ['SCALEMIN (200) outside valid data range (-128,127).',
              'SCALEMIN > SCALEMAX.',
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
              ],
@@ -458,9 +458,9 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(5, len(errs))
         errs.sort()
         self.assertEqual(
-            ['SCALEMAX (-200) outside data range (-128,127).',
+            ['SCALEMAX (-200) outside valid data range (-128,127).',
              'SCALEMAX type CDF_INT2 does not match variable type CDF_BYTE.',
-             'SCALEMIN (200) outside data range (-128,127).',
+             'SCALEMIN (200) outside valid data range (-128,127).',
              'SCALEMIN > SCALEMAX.',
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
              ],
@@ -470,9 +470,9 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(4, len(errs))
         errs.sort()
         self.assertEqual(
-            ['SCALEMAX (200) outside data range (-128,127).',
+            ['SCALEMAX (200) outside valid data range (-128,127).',
              'SCALEMAX type CDF_INT2 does not match variable type CDF_BYTE.',
-             'SCALEMIN (200) outside data range (-128,127).',
+             'SCALEMIN (200) outside valid data range (-128,127).',
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
              ],
              errs)
@@ -487,7 +487,7 @@ class VariablesTests(ISTPTestsBase):
         self.assertEqual(2, len(errs))
         errs.sort()
         self.assertEqual([
-            'SCALEMAX ([300 320]) outside data range (-128,127).',
+            'SCALEMAX ([300 320]) outside valid data range (-128,127).',
             'SCALEMAX type CDF_INT2 does not match variable type CDF_BYTE.'
             ],
             errs)

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -49,6 +49,7 @@ class ISTPTestsBase(unittest.TestCase):
 
 class VariablesTests(ISTPTestsBase):
     """Tests of variable-checking functions"""
+    longMessage = True
 
     def testAllVarFailure(self):
         """Call variable checks with a known bad one"""
@@ -328,6 +329,22 @@ class VariablesTests(ISTPTestsBase):
         v.attrs.new('FILLVAL', -32768, type=spacepy.pycdf.const.CDF_INT2)
         errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
         self.assertEqual(0, len(errs))
+
+    def testFillvalFloat(self):
+        """Test for fillval being okay when off by float precision"""
+        v = self.cdf.new('var1', data=[1, 2, 3],
+                         type=spacepy.pycdf.const.CDF_FLOAT)
+        v.attrs.new('FILLVAL', -1e31, type=spacepy.pycdf.const.CDF_FLOAT)
+        errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
+        self.assertEqual(0, len(errs), '\n'.join(errs))
+
+    def testFillvalString(self):
+        """Test for fillval being okay in a string"""
+        v = self.cdf.new('var1', data=['foo', 'bar'],
+                                       type=spacepy.pycdf.const.CDF_CHAR)
+        v.attrs.new('FILLVAL', ' ', type=spacepy.pycdf.const.CDF_CHAR)
+        errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
+        self.assertEqual(0, len(errs), '\n'.join(errs))
 
     def testMatchingRecordCount(self):
         """Same number of records for DEPEND_0"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -13,6 +13,7 @@ import warnings
 
 import numpy
 import numpy.testing
+import spacepy
 import spacepy.pycdf
 import spacepy.pycdf.const
 import spacepy.pycdf.istp
@@ -48,6 +49,22 @@ class ISTPTestsBase(unittest.TestCase):
 
 class VariablesTests(ISTPTestsBase):
     """Tests of variable-checking functions"""
+
+    def testAllVarFailure(self):
+        """Call variable checks with a known bad one"""
+        class BadTestClass(spacepy.pycdf.istp.VariableChecks):
+            @classmethod
+            def varraiseserror(cls, v):
+                raise RuntimeError('Bad')
+        data = spacepy.dmarray([1, 2, 3], dtype=numpy.int8, attrs={
+            'FIELDNAM': 'var1',
+            'FILLVAL': -128,
+            })
+        var = self.cdf.new('var1', data=data)
+        errs = BadTestClass.all(var, catch=True)
+        self.assertEqual(
+            ['Test varraiseserror did not complete.'],
+            errs)
 
     def testEmptyEntries(self):
         """Are there any CHAR entries of empty string"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -24,10 +24,12 @@ class ISTPTestsBase(unittest.TestCase):
     def setUp(self):
         """Setup: make an empty, open, writeable CDF"""
         self.tempdir = tempfile.mkdtemp()
+        # We know what the backward-compatible default is, suppress it.
         warnings.filterwarnings(
-            'ignore', message='^.*set_backward not called.*$',
+            'ignore',
+            message=r'^spacepy\.pycdf\.lib\.set_backward not called.*$',
             category=DeprecationWarning,
-            module='^spacepy.pycdf')
+            module='^spacepy.pycdf$')
         try:
             self.cdf = spacepy.pycdf.CDF(os.path.join(
                 self.tempdir, 'source_descriptor_datatype_19990101_v00.cdf'),
@@ -724,11 +726,17 @@ class VarBundleChecksBase(unittest.TestCase):
 
     def tearDown(self):
         """Close CDFs; delete output"""
+        # Suppress did-not-compress warnings on close
+        warnings.filterwarnings(
+            'ignore', r'^DID_NOT_COMPRESS.*',
+            spacepy.pycdf.CDFWarning, r'^spacepy\.pycdf$')
         try:
             self.incdf.close()
             self.outcdf.close()
         except:
             pass
+        finally:
+            del warnings.filters[0]
         shutil.rmtree(self.tempdir)
 
 

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -64,14 +64,14 @@ class VariablesTests(ISTPTestsBase):
         self.cdf['var1'].attrs['DEPEND_0'] = 'var2'
         errs = spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])
         self.assertEqual(1, len(errs))
-        self.assertEqual('DEPEND_0 variable var2 missing', errs[0])
+        self.assertEqual('DEPEND_0 variable var2 missing.', errs[0])
         self.cdf['var2'] = [1, 2, 3]
         self.assertEqual(
             0, len(spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])))
         self.cdf['var1'].attrs['DELTA_PLUS_VAR'] = 'foobar'
         errs = spacepy.pycdf.istp.VariableChecks.depends(self.cdf['var1'])
         self.assertEqual(1, len(errs))
-        self.assertEqual('DELTA_PLUS_VAR variable foobar missing', errs[0])
+        self.assertEqual('DELTA_PLUS_VAR variable foobar missing.', errs[0])
 
     def testDeltas(self):
         """DELTA variables"""
@@ -566,7 +566,7 @@ class FileTests(ISTPTestsBase):
         errs = spacepy.pycdf.istp.FileChecks.all(self.cdf)
         self.assertEqual(2, len(errs))
         self.assertEqual([
-            'var1: DEPEND_0 variable var2 missing',
+            'var1: DEPEND_0 variable var2 missing.',
             'var1: No FILLVAL attribute.',
             ],
             sorted(errs))

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -571,6 +571,21 @@ class FileTests(ISTPTestsBase):
             ],
             sorted(errs))
 
+    def testAllFailure(self):
+        """Call file checks with a known bad one"""
+        self.cdf.attrs['Logical_source'] = \
+            'source_descriptor_datatype'
+        self.cdf.attrs['Logical_file_id'] = \
+            'source_descriptor_datatype_19990101_v00'
+        class BadTestClass(spacepy.pycdf.istp.FileChecks):
+            @classmethod
+            def raiseserror(cls, f):
+                raise RuntimeError('Bad')
+        errs = BadTestClass.all(self.cdf, catch=True)
+        self.assertEqual(
+            ['Test raiseserror did not complete.'],
+            errs)
+
     def testEmptyEntries(self):
         """Are there any CHAR gEntries of empty string"""
         self.cdf['var1'] = [1, 2, 3]


### PR DESCRIPTION
This...grew.

Initially the concern was that the check for data in the file being within VALIDMIN/VALIDMAX threw an exception when the FILLVAL was of the wrong type. (I was testing a file that had a string for FILLVAL in a numeric variable....don't ask.) So as a result:

- VariableChecks.validrange now will complete with a bad FILLVAL rather than throwing exception.
- New VariableChecks.fillval to see if there _is_ a valid FILLVAL. This sort of duplicates funtionality in the existing NASA ISTP checks, but I think it's important because otherwise the validrange checks (which it can't do) won't necessarily return reasonable values.
- Suppressed some CDF warnings in the tests while I was here.
- Noticed FileChecks.depends didn't end a sentence with a period, so took care of that
- Got sick of manually adding every check to the `all` method, so automated that.
- That made it possible to subclass and add new methods, which made it possible to test the kwarg of `all` to catch exceptions in subtests. The test, of course, failed, so now it's fixed. The idea here is that if you're running _all_ tests on a file you probaby want a list of failures of things that could be checked and a statement that one of the tests completely blew up, rather than just a bare traceback of the one that blew up--often some of the tests that completed but failed are the reason for the test blowing up, and fixing those would fix the problem.

One simple fix that turned into a bunch of quality-of-life improvements in this corner of code.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
