### PR TITLE
travis CI: run unit tests with verbose flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
 
 script:
  - python setup.py install
- - cd tests; . /home/travis/bin/definitions.B; xvfb-run python test_all.py
+ - cd tests; . /home/travis/bin/definitions.B; xvfb-run python test_all.py -v
 
 notifications:
  webhooks: https://www.travisbuddy.com/


### PR DESCRIPTION
This PR adds the "-v" flag to the invocation of the unit tests in Travis CI. Every test will then print a line when it starts and when it finishes. This will make it clear which tests are raising warnings, and which tests are hanging. I've been seeing an occasional hang with the Python 3.8 tests and this will help isolate it. I'm also going to be hitting it on my local machine, but it might be related to the Travis setup, so I want that information. And this is useful in general--we only look at the output if it fails, and in that case the detail is helpful.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
