### PR TITLE
Expose documentation of top-level module

### DIFF
--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -108,6 +108,7 @@ Description of all functions within SpacePy, by module.
 .. toctree::
     :maxdepth: 1
 
+    spacepy
     ae9ap9
     coordinates
     datamanager

--- a/Doc/source/spacepy.rst
+++ b/Doc/source/spacepy.rst
@@ -1,0 +1,9 @@
+
+
+#############################
+spacepy - main SpacePy module
+#############################
+
+.. automodule:: spacepy
+    :members:
+

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -18,7 +18,10 @@ and can be launched by typing:
 Most functionality is in spacepy's submodules. Each module has specific
 help available:
 
+.. rubric:: Submodules
+
 .. autosummary::
+    :template: clean_module.rst
 
     ~spacepy.coordinates
     ~spacepy.data_assimilation
@@ -35,6 +38,16 @@ help available:
     ~spacepy.time
     ~spacepy.toolbox
     ~spacepy.ae9ap9
+
+.. rubric:: Functions
+
+.. autosummary::
+
+    deprecated
+    help
+
+.. autofunction:: deprecated
+.. autofunction:: help
 
 Copyright 2010-2016 Los Alamos National Security, LLC.
 """


### PR DESCRIPTION
The docstring of the top-level spacepy module isn't exposed in our documentation. We have very little there, but I was looking at e.g. the deprecation decorator and it's not linked from the docs. This PR puts it on a footing with the rest of the modules.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)