### PR TITLE
Fixes for python 3.8 and other warnings

### DIFF
--- a/spacepy/data_assimilation.py
+++ b/spacepy/data_assimilation.py
@@ -610,7 +610,7 @@ def getobs4window(dd, Tnow):
         L_lower = np.mean([ Lgrid[i], Lgrid[i-1] ])
         L_upper = np.mean([ Lgrid[i+1], Lgrid[i] ])
         indices = np.where( (L_lower < L) & (L <= L_upper) )
-        if np.size(indices) is 0: continue
+        if np.size(indices) == 0: continue
 
         Lmean = np.append(Lmean, iL)
         ymean = np.append(ymean, np.mean(y[indices]))

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1080,7 +1080,7 @@ def toHDF5(fname, SDobject, **kwargs):
                     try:
                         if value.nbytes: truth = True #empty arrays of any dimension are nbytes=0
                     except AttributeError: #not an array
-                        if value or value is 0: truth = True
+                        if value or value == 0: truth = True
 
                     if truth:
                         if bytes is str:

--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -62,7 +62,7 @@ def getLmax(ticks, model='JKemp', dbase='QDhourly'):
     omni = om.get_omni(ticks, dbase=dbase)
     Dst = omni['Dst']
     Lmax = np.zeros(len(Dst))
-    if model is 'JKemp':
+    if model == 'JKemp':
         for i, iDst in enumerate(Dst):
             Lmax[i] = 6.07e-5*iDst*iDst + 0.0436*iDst + 9.37
     else:

--- a/spacepy/irbempy/irbempy.py
+++ b/spacepy/irbempy/irbempy.py
@@ -1677,7 +1677,9 @@ def get_Lstar(ticks, loci, alpha=90, extMag='T01STORM', options=[1,0,0,0,0], omn
     ncalc = len(ticks)
     nalpha = len(alpha)
 
-    if ncpus>1:
+    if ncalc < ncpus * 2: #Don't multiprocess if not worth it
+        ncpus = 1
+    if ncpus > 1:
         import __main__ as main
         if hasattr(main, '__file__'):
             try:
@@ -1688,7 +1690,7 @@ def get_Lstar(ticks, loci, alpha=90, extMag='T01STORM', options=[1,0,0,0,0], omn
         else:
             ncpus = 1 #won't multiprocess in interactive mode
 
-    if ncpus > 1 and ncalc >= ncpus*2:
+    if ncpus > 1:
         nblocks = ncpus
         blocklen = np.floor_divide(ncalc, ncpus)
         tt, cc = [], []
@@ -1708,6 +1710,8 @@ def get_Lstar(ticks, loci, alpha=90, extMag='T01STORM', options=[1,0,0,0,0], omn
                 ov.append(get_ov(omnivals, startind, endind))
         inputs = [[tch, cch, alpha, extMag, options, ov] for tch, cch in zip(tt,cc)]
         result = pool.map(_multi_get_Lstar, inputs)
+        pool.close()
+        pool.join()
         DALL = reassemble(result)
     else: # single NCPU, no chunking
         DALL = _get_Lstar(ticks, loci, alpha, extMag, options, omnivals)

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -304,6 +304,8 @@ class spectrogram(dm.SpaceData):
         np.add(overall_sum, H.transpose(), overall_sum)
 
         overall_count = np.ma.masked_array(overall_count, overall_count == 0)
+        # Explicitly ensure this array owns its mask
+        overall_count.unshare_mask()
         data = np.ma.divide(overall_sum, overall_count)
 
         ## for plotting

--- a/spacepy/poppy.py
+++ b/spacepy/poppy.py
@@ -756,8 +756,8 @@ def boots_ci(data, n, inter, func, seed=None, target=None, sample_size=None, use
                   ctypes.c_ulong(n), ctypes.c_ulong(n_els),
                   ctypes.c_ulong(sample_size),
                   ctypes.c_ulong(seed), clock_seed)
-        gen = (func(surr_ser[i * sample_size:(i  + 1) * sample_size])
-               for i in range(n))
+        gen = [func(surr_ser[i * sample_size:(i  + 1) * sample_size])
+               for i in range(n)]
         #Can't sort if more than one return value
         surr_quan = sorted(gen) if nretvals == 1 else np.stack(gen)
     #get confidence interval

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4307,7 +4307,7 @@ class _Hyperslice(object):
                        and const.CDF_INT8 in types:
                     del types[types.index(const.CDF_INT8)]
             else: #float
-                if dims is ():
+                if dims == ():
                     if d != 0 and (abs(d) > 1.7e38 or abs(d) < 3e-39):
                         types = [const.CDF_DOUBLE, const.CDF_REAL8]
                     else:

--- a/spacepy/radbelt.py
+++ b/spacepy/radbelt.py
@@ -1122,7 +1122,7 @@ class RBmodel(object):
         """
 
 
-        if DLL_model is 'BA2000': # Brautigam and Albert (2000)
+        if DLL_model == 'BA2000': # Brautigam and Albert (2000)
             if type(self.const_kp) == type(0.0):
                 Kp=self.const_kp
             else:
@@ -1130,18 +1130,18 @@ class RBmodel(object):
             alpha = 10.0**(0.506*Kp-9.325)
             beta = 10.0
 
-        elif DLL_model is 'FC2006': # Fei and Chan (2006)
+        elif DLL_model == 'FC2006': # Fei and Chan (2006)
             alpha = 1.5e-6
             beta  = 8.5
 
-        elif DLL_model is 'U2008': # Ukhorskiy (2008)
+        elif DLL_model == 'U2008': # Ukhorskiy (2008)
             alpha = 7.7e-6
             beta  = 6.0
 
-        elif DLL_model is 'S1997': # Selesnick (1997)
+        elif DLL_model == 'S1997': # Selesnick (1997)
             alpha = 1.9e-10
             beta  = 11.7
-        elif DLL_model is 'const': # Constant DLL.
+        elif DLL_model == 'const': # Constant DLL.
             alpha= 1.0
             beta = 1.0
             DLL  = np.zeros(len(Lgrid), dtype=ctypes.c_double)+10.
@@ -1308,7 +1308,7 @@ def get_local_accel(Lgrid, params, SRC_model='JK1'):
     calculate the diffusion coefficient D_LL
     """
 
-    if SRC_model is 'JK1':
+    if SRC_model == 'JK1':
         magn = params['SRCmagn'].seconds
         Lcenter = 5.6
         Lwidth = 0.3

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -741,7 +741,7 @@ class Ticktock(MutableSequence):
         keylist = list(cls.__dict__.keys())
         # keylist.remove('dtype')
         keylist.remove('data')
-        if attrib is not 'data': keylist.remove(attrib)
+        if attrib != 'data': keylist.remove(attrib)
 
         self.UTC = self.getUTC()
         for key in keylist:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1918,9 +1918,9 @@ def linspace(min, max, num, **kwargs):
     geomspace
     logspace
     """
-    if hasattr(min, 'shape') and min.shape is ():
+    if hasattr(min, 'shape') and min.shape == ():
         min = min.item()
-    if hasattr(max, 'shape') and max.shape is ():
+    if hasattr(max, 'shape') and max.shape == ():
         max = max.item()
     if isinstance(min, datetime.datetime):
         from matplotlib.dates import date2num, num2date

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -424,7 +424,7 @@ class DataManagerBinningTests(unittest.TestCase):
             # new dims are removed.
             oldarray = numpy.random.randint(100, size=small)
             newarray = numpy.reshape(oldarray, reshaped)
-            idx = [0 if i == 1 else slice(None) for i in newshape]
+            idx = tuple([0 if i == 1 else slice(None) for i in newshape])
             numpy.testing.assert_array_equal(
                 oldarray,
                 newarray[idx])

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -24,9 +24,16 @@ class ISTPTestsBase(unittest.TestCase):
     def setUp(self):
         """Setup: make an empty, open, writeable CDF"""
         self.tempdir = tempfile.mkdtemp()
-        self.cdf = spacepy.pycdf.CDF(os.path.join(
-            self.tempdir, 'source_descriptor_datatype_19990101_v00.cdf'),
-                                     create=True)
+        warnings.filterwarnings(
+            'ignore', message='^.*set_backward not called.*$',
+            category=DeprecationWarning,
+            module='^spacepy.pycdf')
+        try:
+            self.cdf = spacepy.pycdf.CDF(os.path.join(
+                self.tempdir, 'source_descriptor_datatype_19990101_v00.cdf'),
+                                         create=True)
+        finally:
+            del warnings.filters[0]
 
     def tearDown(self):
         """Delete the empty cdf"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1182,6 +1182,17 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
                             'rbspa_rel04_ect-hope-PA-L3_20121201_v0.0.0.cdf')
     longMessage = True
 
+    def tearDown(self):
+        """Block warnings from CDF closing"""
+        warnings.filterwarnings(
+            'ignore', message='^DID_NOT_COMPRESS.*$',
+            category=spacepy.pycdf.CDFWarning,
+            module='^spacepy.pycdf')
+        try:
+            super(VarBundleChecksHOPE, self).tearDown()
+        finally:
+            del warnings.filters[0]
+
     def testSortOrder(self):
         """Check sort order of variables"""
         bundle = spacepy.pycdf.istp.VarBundle(


### PR DESCRIPTION
This PR started to address some warnings in Python 3.8 and apparently random bugs that might be related (#351, #364). I did clean up the handling of the Pool in get_Lstar, which addresses the ResourceWarning in #364 and hopefully the actual hang, and chances are it addresses the hang in #351, since other people are reporting issues with hangs in Python 3.8 when not properly closing multiprocessing Pools (https://bugs.python.org/issue38744) This is 58f2d1d4.

While I was at it, I cleaned some warnings from 3.8 regarding using `is` for comparison to literal (32efecd7), see the [3.8 release notes](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior), and a whole mess of numpy warnings. I then suppressed some CDF warnings in the CDF tests. The upshot is that the tests should be warning-free on latest numpy and Python.

The only numpy warning that wasn't trivial was d0c5fdb7. This actually didn't raise a warning on the newest numpy, but was relative to a change in numpy 1.11 where masked arrays no longer do a copy-on-write if they share a mask and there's an assignment. I've found masked arrays almost _always_ seem to share their masks (with what, I don't know), so I added an explicit unshare to quiet the warning. This is probably not a problem--there's probably not another reference to that array running around which might accidentally get written to--but it seems better to be safe.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
