### PR TITLE
Skip Q-D daily files for years in ViRBO file (Closes #373)

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -745,7 +745,8 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
     return None
 
 
-def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True):
+def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True,
+                  startyear=None):
     """Crawl files in a directory-by-year structure
 
     Parameters
@@ -766,6 +767,10 @@ def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True):
         Only update files if timestamp on server is newer than
         timestamp on local file (default). Set False to always
         download files.
+    startyear : int (optional)
+        First year to crawl, as four-digit number or four-character string.
+        If not specified, will download all years. If specified, will delete
+        years prior to this which have already been downloaded.
 
     Returns
     =======
@@ -791,7 +796,8 @@ def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True):
     p = LinkExtracter()
     p.feed(data)
     p.close()
-    yearlist = [y[0:4] for y in p.links if re.match(r'\d{4}/', y)]
+    yearlist = [y[0:4] for y in p.links if re.match(r'\d{4}/', y)
+                and (startyear is None or y[0:4] >= str(startyear))]
     downloadme = {}
     for i, y in enumerate(yearlist):
         yearurl = '{}{}/'.format(base_url, y)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -843,7 +843,7 @@ def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True,
     return filenames if newdata else None
 
 
-def _get_qindenton_daily(qd_daily_url=None, cached=True):
+def _get_qindenton_daily(qd_daily_url=None, cached=True, startyear=None):
     """Download the Qin-Denton OMNI-like daily files
     
     Parameters
@@ -856,6 +856,9 @@ def _get_qindenton_daily(qd_daily_url=None, cached=True):
         Only update files if timestamp on server is newer than
         timestamp on local file (default). Set False to always
         download files.
+    startyear : int (optional)
+        If specified, start downloading files from the year given,
+        rather than all years. This will delete older files!
 
     Returns
     =======
@@ -867,7 +870,7 @@ def _get_qindenton_daily(qd_daily_url=None, cached=True):
         qd_daily_url = spacepy.config['qd_daily_url']
     datadir = os.path.join(spacepy.DOT_FLN, 'data', 'qindenton_daily_files')
     _crawl_yearly(qd_daily_url, r'QinDenton_\d{8}_hour.txt',
-                  datadir, name='Q-D daily', cached=cached)
+                  datadir, name='Q-D daily', cached=cached, startyear=startyear)
     #Read and process
     print("Processing Q-D daily files ...")
     return _assemble_qindenton_daily(datadir)
@@ -1371,13 +1374,14 @@ def update(all=True, QDomni=False, omni=False, omni2=False, leapsecs=False,
         omnidata['ticks'] = spt.Ticktock(omnidata['UTC'], 'UTC')
         omnidata['RDT'] = omnidata['ticks'].RDT
         del omnidata['ticks'] #Can be quickly regenerated on import
+        startyear = omnidata['Year'][-1]
         del omnidata['Year']
         del omnidata['Hr']
 
         # Supplement with daily files
         print('Supplementing with latest Q-D daily files,'
               ' this will take a while...')
-        dailyomnidata = _get_qindenton_daily(cached=cached)
+        dailyomnidata = _get_qindenton_daily(cached=cached, startyear=startyear)
         # Find where new files start
         idx = np.searchsorted(omnidata['UTC'], dailyomnidata['UTC'][0])
         for k in sorted(omnidata.keys()):


### PR DESCRIPTION
This PR changes toolbox.update to check for the last year in the ViRBO omnibus file, and only starts downloading daily files from NMC from that year. There's still some overlap, but a whole lot less (and this is easier than trying to get things down to the day.)

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ ] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

 (EDIT: Closes #373 . Does it not pick it up from the title?)