### PR TITLE
Improvements to deprecator decorator

### DIFF
--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -155,8 +155,12 @@ def deprecated(version, message, docstring=None):
     Other Parameters
     ================
     docstring : str
-        If specified, this will be used in the docstring instead of
-        ``message``. It can be a multi-line string (separated with
+
+        .. versionadded:: 0.2.2
+
+        If specified, ``docstring`` will be added to the modified function's
+        docstring instead of ``message`` (which will only be used in the
+        deprecation warning.) It can be a multi-line string (separated with
         ``\\n``). It will be indented to match the existing docstring.
 
     Notes

--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -581,7 +581,7 @@ def quaternionConjugate(Qin, scalarPos='last'):
 
     Parameters
     ==========
-    vec : array_like
+    Qin : array_like
         input quaternion to conjugate
 
     Returns

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -2314,32 +2314,38 @@ def interpol(newx, x, y, wrap=None, **kwargs):
 # -----------------------------------------------
 
 @spacepy.deprecated(
-    '0.2.2', 'Use :func:`spacepy.coordinates.quaternionNormalize`')
-def quaternionNormalize(*args, **kwargs):
+    '0.2.2', 'moved to spacepy.coordinates',
+    'use :func:`spacepy.coordinates.quaternionNormalize`')
+def quaternionNormalize(Qin, scalarPos='last'):
     """Given an input quaternion, return the unit quaternion."""
     import spacepy.coordinates
-    return spacepy.coordinates.quaternionNormalize(*args, **kwargs)
+    return spacepy.coordinates.quaternionNormalize(Qin, scalarPos=scalarPos)
 
 @spacepy.deprecated(
-    '0.2.2', 'Use :func:`spacepy.coordinates.quaternionRotateVector`')
-def quaternionRotateVector(*args, **kwargs):
+    '0.2.2', 'moved to spacepy.coordinates',
+    'use :func:`spacepy.coordinates.quaternionRotateVector`')
+def quaternionRotateVector(Qin, Vin, scalarPos='last', normalize=True):
     """Given quaternion and vector, return vector rotated by quaternion."""
     import spacepy.coordinates
-    return spacepy.coordinates.quaternionRotateVector(*args, **kwargs)
+    return spacepy.coordinates.quaternionRotateVector(
+        Qin, Vin, scalarPos=scalarPos, normalize=normalize)
 
 @spacepy.deprecated(
-    '0.2.2', 'Use :func:`spacepy.coordinates.quaternionMultiply`')
-def quaternionMultiply(*args, **kwargs):
+    '0.2.2', 'moved to spacepy.coordinates',
+    'use :func:`spacepy.coordinates.quaternionMultiply`')
+def quaternionMultiply(Qin1, Qin2, scalarPos='last'):
     """Given quaternions, return the product."""
     import spacepy.coordinates
-    return spacepy.coordinates.quaternionMultiply(*args, **kwargs)
+    return spacepy.coordinates.quaternionMultiply(
+        Qin1, Qin2, scalarPos=scalarPos)
 
 @spacepy.deprecated(
-    '0.2.2', 'Use :func:`spacepy.coordinates.quaternionConjugate`')
-def quaternionConjugate(*args, **kwargs):
+    '0.2.2', 'moved to spacepy.coordinates',
+    'use :func:`spacepy.coordinates.quaternionConjugate`')
+def quaternionConjugate(Qin, scalarPos='last'):
     """Given an input quaternion, return the conjugated."""
     import spacepy.coordinates
-    return spacepy.coordinates.quaternionConjugate(*args, **kwargs)
+    return spacepy.coordinates.quaternionConjugate(Qin, scalarPos=scalarPos)
 
 # -----------------------------------------------
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -82,6 +82,33 @@ class SpacepyFuncTests(unittest.TestCase):
             "            ",
             testfunc.__doc__)
 
+    def testDeprecationDifferentMessage(self):
+        """Test the deprecation decorator, docstring different from message"""
+        @spacepy.deprecated(0.1, 'pithy message', docstring='foo\nbar')
+        def testfunc(x):
+            """test function
+
+            this will test things
+            """
+            return x + 1
+        self.assertEqual(
+            "test function\n"
+            "\n"
+            "            .. deprecated:: 0.1\n"
+            "               foo\n"
+            "               bar\n"
+            "\n"
+            "            this will test things\n"
+            "            ",
+            testfunc.__doc__)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', 'pithy message',
+                                    DeprecationWarning, '^spacepy')
+            self.assertEqual(2, testfunc(1))
+        self.assertEqual(1, len(w))
+        self.assertEqual(DeprecationWarning, w[0].category)
+        self.assertEqual('pithy message', str(w[0].message))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -29,13 +29,12 @@ class SpacepyFuncTests(unittest.TestCase):
         self.assertEqual(
             "\n"
             "            test function\n"
-            "            \n"
+            "\n"
             "            .. deprecated:: 0.1\n"
             "               pithy message\n"
-            "            \n"
             "\n"
             "            this will test things\n"
-            "            \n",
+            "            ",
             testfunc.__doc__)
         with warnings.catch_warnings(record=True) as w:
             #make sure to catch expected warnings
@@ -52,10 +51,9 @@ class SpacepyFuncTests(unittest.TestCase):
         def testfunc(x):
             return x + 1
         self.assertEqual(
-            "    \n"
+            "\n"
             "    .. deprecated:: 0.1\n"
-            "       pithy message\n"
-            "    \n",
+            "       pithy message",
             testfunc.__doc__)
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', 'pithy message',
@@ -64,6 +62,25 @@ class SpacepyFuncTests(unittest.TestCase):
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
         self.assertEqual('pithy message', str(w[0].message))
+
+    def testDeprecationDifferentIndent(self):
+        """Test the deprecation decorator, first line indented differently"""
+        @spacepy.deprecated(0.1, 'pithy message')
+        def testfunc(x):
+            """test function
+
+            this will test things
+            """
+            return x + 1
+        self.assertEqual(
+            "test function\n"
+            "\n"
+            "            .. deprecated:: 0.1\n"
+            "               pithy message\n"
+            "\n"
+            "            this will test things\n"
+            "            ",
+            testfunc.__doc__)
 
 
 if __name__ == '__main__':

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -122,7 +122,7 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
         self.assertEqual(
-            'Use :func:`spacepy.coordinates.quaternionNormalize`',
+            'moved to spacepy.coordinates',
             str(w[0].message))
         numpy.testing.assert_array_almost_equal(
             [0.693,  0.,  0.693,  0.196], tst, decimal=2)
@@ -134,7 +134,7 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
         self.assertEqual(
-            'Use :func:`spacepy.coordinates.quaternionRotateVector`',
+            'moved to spacepy.coordinates',
             str(w[0].message))
         numpy.testing.assert_array_almost_equal(
             [0, 0, 1], tst, decimal=5)
@@ -146,7 +146,7 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
         self.assertEqual(
-            'Use :func:`spacepy.coordinates.quaternionMultiply`',
+            'moved to spacepy.coordinates',
             str(w[0].message))
         numpy.testing.assert_array_equal([0, 0, 0, 1], tst)
 
@@ -156,7 +156,7 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
         self.assertEqual(
-            'Use :func:`spacepy.coordinates.quaternionConjugate`',
+            'moved to spacepy.coordinates',
             str(w[0].message))
         numpy.testing.assert_array_equal([-.707, 0, -.707, 0.2], tst)
 


### PR DESCRIPTION
There's a function decorator to easily deprecate a function in the top-level module. This PR makes several improvements:

- Gets the formatting of the wrapped function's docstring correct; indentation used to be based on the first line and that wasn't always right. It was also adding an extra linebreak at the end, which wasn't needed.
- Allows separation between the message in the DeprecationWarning and what gets added to the docstring
- Some work on getting the function signature to carry through. The only real functional change here is a note in the docstring that it doesn't carry through properly in Python 2, but it's a big diff because of an unwrapping of a function-in-a-function that made the operation a lot less clear.
- Fix up the deprecated quaternion functions in toolbox using these new features
- Mostly unrelated but I was looking at it, fix the docstring for quaternionConjugate where the parameter was "Qin" in the signature but "vec" in the docstring.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A)Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
