### PR TITLE
Doc Makefile: remove autosummary source files with "make clean"

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf $(BUILDDIR)/*
+	-rm -rf $(BUILDDIR)/* source/autosummary/*.rst source/autosummary/autosummary/*.rst
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html


### PR DESCRIPTION
Autosummary sources are autogenerated, and the check for updated docstring inputs isn't always perfect. "make clean" should remove all intermediate/automatic steps to ensure a clean build from scratch, so this PR adds removing the autosummary sources.

Yes, there are two nested directories of "autosummary"; it's because a toctree is being defined twice, but fixing it breaks the doc build, so that's going to have to wait for a more involved docs overhaul.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
