### PR TITLE
Disable matplotlib 3.3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
 install:
  - pip install --force-reinstall "numpy${NUMPY_VERSION}"
  - pip install scipy
- - pip install matplotlib
+ - pip install "matplotlib<3.3"
  - pip install h5py
  - pip install networkx
  - pip install ffnet


### PR DESCRIPTION
This PR is a quick workaround for #381 until it's properly fixed. It just installs older matplotlib in our CI so that the 3.3 change doesn't bite us. Hopefully it'll go away soon, but in the meantime #381 is blocking us from getting anything done.