### PR TITLE
datamanager.rebin example: specify axis limits (Closes #402)

### DIFF
--- a/Doc/source/pyplots/datamanager_rebin_1.py
+++ b/Doc/source/pyplots/datamanager_rebin_1.py
@@ -9,6 +9,8 @@ flux = j(1., numpy.expand_dims(times, 1),
              numpy.expand_dims(alpha, 0))
 spacepy.plot.simpleSpectrogram(times, alpha, flux, cb=False,
                                ylog=False)
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(0, 180)
 matplotlib.pyplot.ylabel('Pitch angle (deg)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 1 MeV')

--- a/Doc/source/pyplots/datamanager_rebin_2.py
+++ b/Doc/source/pyplots/datamanager_rebin_2.py
@@ -7,6 +7,8 @@ energies = numpy.logspace(0, 3, 50)
 flux = j(numpy.expand_dims(energies, 0),
          numpy.expand_dims(times, 1), 90.)
 spacepy.plot.simpleSpectrogram(times, energies, flux, cb=False)
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(1, 1e3)
 matplotlib.pyplot.ylabel('Energy (MeV)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 90 degrees')

--- a/Doc/source/pyplots/datamanager_rebin_3.py
+++ b/Doc/source/pyplots/datamanager_rebin_3.py
@@ -8,6 +8,8 @@ lines = matplotlib.pyplot.plot(
     marker='o', ms=1, linestyle='')
 matplotlib.pyplot.legend(lines, ['Detector {}'.format(i) for i in range(8)],
                          loc='best')
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(0, 180)
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.ylabel('Pitch angle (deg)')
 matplotlib.pyplot.title('Measured pitch angle by detector')

--- a/Doc/source/pyplots/datamanager_rebin_4.py
+++ b/Doc/source/pyplots/datamanager_rebin_4.py
@@ -10,6 +10,8 @@ flux = j(numpy.reshape(energies, (1, 1, -1)),
                      numpy.expand_dims(alpha, -1))
 spacepy.plot.simpleSpectrogram(times, numpy.arange(8),
      flux[..., 0], cb=False, ylog=False)
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(-0.5, 7.5)
 matplotlib.pyplot.ylabel('Detector')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 1 MeV')

--- a/Doc/source/pyplots/datamanager_rebin_5.py
+++ b/Doc/source/pyplots/datamanager_rebin_5.py
@@ -9,6 +9,8 @@ flux = j(numpy.reshape(energies, (1, 1, -1)),
                      numpy.reshape(times, (-1, 1, 1)),
                      numpy.expand_dims(alpha, -1))
 spacepy.plot.simpleSpectrogram(times, energies, flux[:, 0, :], cb=False)
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(1, 1e3)
 matplotlib.pyplot.ylabel('Energy (MeV)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux in detector 0')

--- a/Doc/source/pyplots/datamanager_rebin_6.py
+++ b/Doc/source/pyplots/datamanager_rebin_6.py
@@ -13,6 +13,8 @@ flux_by_pa = spacepy.datamanager.rebin(
     flux, alpha, pa_bins, axis=1)
 spacepy.plot.simpleSpectrogram(times, pa_bins, flux_by_pa[..., 0],
                                cb=False, ylog=False)
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(0, 180)
 matplotlib.pyplot.ylabel('Pitch angle (deg)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 1MeV')

--- a/Doc/source/pyplots/datamanager_rebin_7.py
+++ b/Doc/source/pyplots/datamanager_rebin_7.py
@@ -13,6 +13,8 @@ flux_by_pa = spacepy.datamanager.rebin(
     flux, alpha, pa_bins, axis=1)
 spacepy.plot.simpleSpectrogram(times, energies, flux_by_pa[:, 2, :],
                                cb=False)
+matplotlib.pyplot.xlim(0, 7200)
+matplotlib.pyplot.ylim(1, 1e3)
 matplotlib.pyplot.ylabel('Energy (MeV)')
 matplotlib.pyplot.xlabel('Time (sec)')
 matplotlib.pyplot.title('Flux at 90 degrees')


### PR DESCRIPTION
This PR adds explicit axis limits to the example code for datamanager.rebin, so closes #402. Whether or not this was an issue depended on what version of matplotlib you were using, but in some cases the axis limits were set way out and there was lots of whitespace. I didn't add the limit setting to the example code in the docstring, just the behind-the-scenes code that actually renders the plot.