### PR TITLE
Fixing the datamodel.SpaceData.toXXX method calls, closes #404

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Changes in Version 0.2.2 (2020-xx-xx)
 - Quaternion math functions moved to coordinates module
 coordinates
  - Include upstream fix for SPH->RLL coordinate transform
+datamodel
+ - Fix in SpaceData.toXXX() methods that would fail in some cases
 datamanager
  - New function "rebin", rebin an axis of an array by contents of another
 irbempy

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Changes in Version 0.2.2 (2020-xx-xx)
 coordinates
  - Include upstream fix for SPH->RLL coordinate transform
 datamodel
- - Fix in SpaceData.toXXX() methods that would fail in some cases
+ - Fix in SpaceData.toXXX() methods which would fail in some cases, now work as intended
 datamanager
  - New function "rebin", rebin an axis of an array by contents of another
 irbempy

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -508,11 +508,11 @@ class SpaceData(dict, MetaMixin):
             del kwargs['attrs']
 
         super(SpaceData, self).__init__(*args, **kwargs)
-        self.toCDF = partial(toCDF, SDobject=self, *args, **kwargs)
+        self.toCDF = partial(toCDF, SDobject=self)
         self.toCDF.__doc__ = toCDF.__doc__
-        self.toHDF5 = partial(toHDF5, SDobject=self, *args, **kwargs)
+        self.toHDF5 = partial(toHDF5, SDobject=self)
         self.toHDF5.__doc__ = toHDF5.__doc__
-        self.toJSONheadedASCII = partial(toJSONheadedASCII, insd=self, *args, **kwargs)
+        self.toJSONheadedASCII = partial(toJSONheadedASCII, insd=self)
         self.toJSONheadedASCII.__doc__ = toJSONheadedASCII.__doc__
 
     #Need to remove the partials on copy, http://bugs.python.org/issue4380

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -515,15 +515,6 @@ class SpaceData(dict, MetaMixin):
         self.toJSONheadedASCII = partial(toJSONheadedASCII, insd=self)
         self.toJSONheadedASCII.__doc__ = toJSONheadedASCII.__doc__
 
-    #Need to remove the partials on copy, http://bugs.python.org/issue4380
-    #They will be recreated by __init__
-    def __getstate__(self):
-        d = copy.copy(self.__dict__)
-        if 'toCDF' in d: del d['toCDF']
-        if 'toHDF5' in d: del d['toHDF5']
-        if 'toJSONheadedASCII' in d: del d['toJSONheadedASCII']
-        return d
-
 ## To enable string output of repr, instead of just printing, uncomment his block
 #    def __repr__(self):
 #        #redirect stdout to StringIO

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -11,6 +11,7 @@ from __future__ import division
 
 import copy
 import datetime
+import marshal
 import os
 import os.path
 import tempfile
@@ -315,7 +316,17 @@ class SpaceDataTests(unittest.TestCase):
         a = dm.SpaceData({'a': [1, 2, 3]})
         a.attrs['FILLVAL'] = 123
         p_str = pickle.dumps(a)
-        ret =  pickle.loads(p_str)
+        ret = pickle.loads(p_str)
+        assert a == ret
+        assert a.attrs == ret.attrs
+
+    @unittest.expectedFailure
+    def test_marshal(self):
+        """SpaceData objects don't marshal, note that here"""
+        a = dm.SpaceData({'a': [1, 2, 3]})
+        a.attrs['FILLVAL'] = 123
+        p_str = marshal.dumps(a)
+        ret = marshal.loads(p_str)
         assert a == ret
         assert a.attrs == ret.attrs
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -15,7 +15,6 @@ import os
 import os.path
 import tempfile
 import unittest
-
 try:
     import StringIO
 except ImportError:

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -311,7 +311,16 @@ class SpaceDataTests(unittest.TestCase):
         # Known failure, cannot delete property from instance.
 #        self.assertFalse('meta' in dir(a))
 
-        
+    def test_pickle(self):
+        """Make sure that SpaceData objects behave with pickle"""
+        a = dm.SpaceData({'a': [1, 2, 3]})
+        a.attrs['FILLVAL'] = 123
+        p_str = pickle.dumps(a)
+        ret =  pickle.loads(p_str)
+        assert a == ret
+        assert a.attrs == ret.attrs
+
+
 class dmarrayTests(unittest.TestCase):
     def setUp(self):
         super(dmarrayTests, self).setUp()


### PR DESCRIPTION
Fixed the datamodel.SpaceData.toXXX method calls. 

`functools.partial` had been used incorrectly from the beginning and needed to be fixed. Only some cases caused the issue. None should now. 

Also removed code checking for a really old python bug, https://bugs.python.org/issue4380. 

Tests added that cause the cases in #404 

- [X ] Pull request has descriptive title
- [ X] Pull request gives overview of changes
- [ X] New code has inline comments where necessary
- [ n/a] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ X] New features and bug fixes should have unit tests
- [ X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

