### PR TITLE
toolbox: remove broken doctest

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -68,6 +68,7 @@ toolbox
  - Change update to get leapseconds from NASA MODIS instead of USNO
  - New functions quaternionFromMatrix/quaternionToMatrix to convert between
    quaternions and 3D rotation matrices.
+ - Fix human_sort; this had been broken since 0.1.6.
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -190,7 +190,10 @@ Other dependencies have no established minimum. See
 
 Major bugfixes
 **************
-None of note (but many minor ones).
+:meth:`~spacepy.toolbox.human_sort` was fixed for non-numeric inputs
+(the normal case.) This had been broken since 0.1.6.
+
+Many minor bugfixes as well.
 
 Other changes
 *************

--- a/Doc/source/toolbox.rst
+++ b/Doc/source/toolbox.rst
@@ -60,6 +60,7 @@ Other functions
     getNamedPath
     human_sort
     hypot
+    indsFromXrange
     interpol
     intsolve
     medAbsDev

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -174,9 +174,15 @@ def hypot(*args):
     >>> tot = 500
     >>> for num in tb.logspace(1, tot, 10):
     >>>     print num
-    >>>     num_list.append(timeit.timeit(stmt='tb.hypot(a)', setup='from spacepy import toolbox as tb; import numpy as np; a = [3]*{0}'.format(int(num)), number=10000))
-    >>>     num_np.append(timeit.timeit(stmt='tb.hypot(a)', setup='from spacepy import toolbox as tb; import numpy as np; a = np.asarray([3]*{0})'.format(int(num)), number=10000))
-    >>>     num_scalar.append(timeit.timeit(stmt='tb.hypot(*a)', setup='from spacepy import toolbox as tb; import numpy as np; a = [3]*{0}'.format(int(num)), number=10000))
+    >>>     num_list.append(timeit.timeit(stmt='tb.hypot(a)',
+                            setup='from spacepy import toolbox as tb;
+                            import numpy as np; a = [3]*{0}'.format(int(num)), number=10000))
+    >>>     num_np.append(timeit.timeit(stmt='tb.hypot(a)',
+                          setup='from spacepy import toolbox as tb;
+                          import numpy as np; a = np.asarray([3]*{0})'.format(int(num)), number=10000))
+    >>>     num_scalar.append(timeit.timeit(stmt='tb.hypot(*a)',
+                              setup='from spacepy import toolbox as tb;
+                              import numpy as np; a = [3]*{0}'.format(int(num)), number=10000))
     >>> from pylab import *
     >>> loglog(tb.logspace(1, tot, 10),  num_list, lw=2, label='list')
     >>> loglog(tb.logspace(1, tot, 10),  num_np, lw=2, label='numpy->ctypes')
@@ -189,8 +195,10 @@ def hypot(*args):
     .. image:: ../../source/images/hypot_no_extension_speeds_3cases.png
     """
     if lib.have_libspacepy:
-        if len(args) == 1 and hasattr(args, 'ndim'): # it is an array
-                ans = lib.hypot_tb(args[0], np.product(args[0].shape))
+        if len(args) == 1 and isinstance(args[0], np.ndarray):  # it is an array
+                # make sure everything is C-ready
+                ans = lib.hypot_tb(np.require(args[0], dtype=np.float64, requirements='C'),
+                                   np.product(args[0].shape))
                 return ans
     ans = 0.0
     for arg in args:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -196,10 +196,10 @@ def hypot(*args):
     """
     if lib.have_libspacepy:
         if len(args) == 1 and isinstance(args[0], np.ndarray):  # it is an array
-                # make sure everything is C-ready
-                ans = lib.hypot_tb(np.require(args[0], dtype=np.float64, requirements='C'),
-                                   np.product(args[0].shape))
-                return ans
+            # make sure everything is C-ready
+            ans = lib.hypot_tb(np.require(args[0], dtype=np.float64, requirements='C'),
+                               np.product(args[0].shape))
+            return ans
     ans = 0.0
     for arg in args:
         if hasattr(arg, '__iter__'):

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -346,13 +346,9 @@ def tCommon(ts1, ts2, mask_only=True):
 
     tn1, tn2 = date2num(ts1), date2num(ts2)
 
-    v_test = np.__version__.split('.')
-    if v_test[0] == 1 and v_test[1] <= 3:
-        el1in2 = np.setmember1d(tn1, tn2) #makes mask of present/absent
-        el2in1 = np.setmember1d(tn2, tn1)
-    else:
-        el1in2 = np.in1d(tn1, tn2, assume_unique=True) #makes mask of present/absent
-        el2in1 = np.in1d(tn2, tn1, assume_unique=True)
+    el1in2 = np.in1d(tn1, tn2, assume_unique=True)  #makes mask of present/absent
+    el1in2 = np.in1d(tn1, tn2, assume_unique=True)  #makes mask of present/absent
+    el2in1 = np.in1d(tn2, tn1, assume_unique=True)
 
     if mask_only:
         return el1in2, el2in1

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -197,8 +197,9 @@ def hypot(*args):
     if lib.have_libspacepy:
         if len(args) == 1 and isinstance(args[0], np.ndarray):  # it is an array
             # make sure everything is C-ready
-            ans = lib.hypot_tb(np.require(args[0], dtype=np.float64, requirements='C'),
-                               np.product(args[0].shape))
+            ans = lib.hypot_tb(
+                np.require(args[0], dtype=np.double, requirements='C'),
+                np.product(args[0].shape))
             return ans
     ans = 0.0
     for arg in args:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -455,7 +455,7 @@ def savepickle(fln, dict, compress=None):
         container with stuff
     compress : bool
         write as a gzip-compressed file
-                     (.gz will be added to L{fln}).
+                     (.gz will be added to ``fln``).
                      If not specified, defaults to uncompressed, unless the
                      compressed file exists and the uncompressed does not.
 
@@ -468,12 +468,9 @@ def savepickle(fln, dict, compress=None):
     >>> d = {'grade':[1,2,3], 'name':['Mary', 'John', 'Chris']}
     >>> savepickle('test.pbin', d)
     """
-    if compress == None:
-        # TODO, what is this line meant to do? Whay not just check fln for ending in gz?
-        if not os.path.exists(fln) and os.path.exists(fln + '.gz'):
-            compress = True
-        else:
-            compress = False
+    if compress == None: # Guess at compression
+        # Assume compressed if compressed already exists (and no uncompressed)
+        compress = not os.path.exists(fln) and os.path.exists(fln + '.gz')
     if compress:
         import gzip
         with open(fln + '.gz', 'wb') as fh:
@@ -483,7 +480,6 @@ def savepickle(fln, dict, compress=None):
     else:
         with open(fln, 'wb') as fh:
             pickle.dump(dict, fh, 2) # 2 ... fast binary
-    return
 
 
 # -----------------------------------------------

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -14,8 +14,8 @@ Copyright 2010 Los Alamos National Security, LLC.
 #If you add functions here, be sure to:
 #1) add to the __all__ list
 #2) add to functions in Doc/source/toolbox.rst so it goes in the docs
-from __future__ import division
 from __future__ import absolute_import
+from __future__ import division
 
 import calendar
 import datetime
@@ -30,7 +30,7 @@ try:
 except ImportError: # Python2
     import httplib as http
     http.client = http
-import itertools
+import numbers
 import os
 import os.path
 import re
@@ -46,7 +46,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import numbers
 import warnings
 import zipfile
 
@@ -3046,8 +3045,3 @@ def poisson_fit(data, initial=None, method='Powell'):
                    method=method,  # minimization method, see docs
                    )
     return ans
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1464,6 +1464,13 @@ def indsFromXrange(inxrange):
     inxrange : xrange
         input xrange object to parse
 
+    Returns
+    =======
+    list of int
+       List of start, stop indices in the xrange. The return value is not
+       defined if a stride is specified or if stop is before start (but
+       will work when stop equals start).
+
     Examples
     ========
     >>> import spacepy.toolbox as tb
@@ -1479,7 +1486,6 @@ def indsFromXrange(inxrange):
     if not isinstance(inxrange, xrange): return None
     valstr = inxrange.__str__()
     if ',' not in valstr:
-        # TODO, can't figure out in what case this code is run, every case is False then off to else.
         res = re.search(r'(\d+)', valstr)
         retval = [int(0), int(res.group(1))]
     else:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -468,6 +468,7 @@ def savepickle(fln, dict, compress=None):
     >>> savepickle('test.pbin', d)
     """
     if compress == None:
+        # TODO, what is this line meant to do? Whay not just check fln for ending in gz?
         if not os.path.exists(fln) and os.path.exists(fln + '.gz'):
             compress = True
         else:
@@ -1481,6 +1482,7 @@ def indsFromXrange(inxrange):
     if not isinstance(inxrange, xrange): return None
     valstr = inxrange.__str__()
     if ',' not in valstr:
+        # TODO, can't figure out in what case this code is run, every case is False then off to else.
         res = re.search(r'(\d+)', valstr)
         retval = [int(0), int(res.group(1))]
     else:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -595,7 +595,6 @@ def human_sort( l ):
     """
     convert = lambda text: int(text) if text.isdigit() else text
     alphanum_key = lambda key: [ convert(c) for c in re.split(r'([0-9]+)', key) ]
-    alphanum_key = None
     try:
         l.sort( key=alphanum_key )
     except TypeError:

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -165,6 +165,12 @@ class SimpleFunctionTests(unittest.TestCase):
         foo = xrange(23, 39)
         self.assertEqual([23, 39], tb.indsFromXrange(foo))
 
+    @unittest.expectedFailure
+    def test_indsFromXrange_zerolen(self):
+        """indsFromXrange claims useful when zero len range, seems not true"""
+        foo = xrange(20, 10)  # empty
+        self.assertEqual([23, 39], tb.indsFromXrange(foo))
+
     def test_interweave(self):
         """interweave should have known result"""
         a = numpy.arange(5)

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -178,12 +178,13 @@ class SimpleFunctionTests(unittest.TestCase):
         """indsFromXrange should have known result"""
         foo = xrange(23, 39)
         self.assertEqual([23, 39], tb.indsFromXrange(foo))
+        foo = xrange(5)
+        self.assertEqual([0, 5], tb.indsFromXrange(foo))
 
-    @unittest.expectedFailure
     def test_indsFromXrange_zerolen(self):
-        """indsFromXrange claims useful when zero len range, seems not true"""
-        foo = xrange(20, 10)  # empty
-        self.assertEqual([23, 39], tb.indsFromXrange(foo))
+        """indsFromXrange with zero length range"""
+        foo = xrange(20, 20)  # empty
+        self.assertEqual([20, 20], tb.indsFromXrange(foo))
 
     def test_interweave(self):
         """interweave should have known result"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -601,6 +601,19 @@ class SimpleFunctionTests(unittest.TestCase):
             self.assertEqual(tb.hypot(numpy.array([3.,4.])), 5.0)
             self.assertEqual(tb.hypot(numpy.array([3,4])), 5.0)
 
+    def test_hypot_array(self):
+        """hypot when called on an array falls to C"""
+        invals = [ numpy.asarray([3, 4]), numpy.arange(3,6), numpy.arange(3,10), numpy.asarray([-1,2,3]) ]
+        ans = [ 5, 7.0710678118654755, 16.73320053068151, 3.7416573867739413 ]
+        for i, tst in enumerate(invals):
+            self.assertAlmostEqual(ans[i], tb.hypot(*tst))
+        for i, tst in enumerate(invals):
+            self.assertAlmostEqual(ans[i], tb.hypot(tst))
+        self.assertEqual(5.0, tb.hypot(5.0))
+        if spacepy.lib.have_libspacepy:
+            self.assertEqual(tb.hypot(numpy.array([3.,4.])), 5.0)
+            self.assertEqual(tb.hypot(numpy.array([3,4])), 5.0)
+
     def testThreadJob(self):
         """Multithread the square of an array"""
         numpy.random.seed(0)

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -31,7 +31,6 @@ from scipy import inf
 from scipy.stats import poisson
 
 import spacepy.toolbox as tb
-import spacepy.time as st
 import spacepy.lib
 
 #Py3k compatibility renamings
@@ -113,6 +112,14 @@ class PickleAssembleTests(unittest.TestCase):
 
 
 class SimpleFunctionTests(unittest.TestCase):
+
+    @unittest.expectedFailure
+    def test_humansort(self):
+        """humansort should give known answers"""
+        dat = ['r1.txt', 'r10.txt', 'r2.txt']
+        dat.sort()
+        assert dat == ['r1.txt', 'r10.txt', 'r2.txt']  # standard python sort
+        assert tb.human_sort(dat) == ['r1.txt', 'r2.txt', 'r10.txt']  # human sort
 
     def test_quaternionDeprecation(self):
         """Make sure deprecated quaternion functions work"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -121,13 +121,19 @@ class PickleAssembleTests(unittest.TestCase):
 
 class SimpleFunctionTests(unittest.TestCase):
 
-    @unittest.expectedFailure
     def test_humansort(self):
-        """humansort should give known answers"""
+        """human_sort should give known answers"""
+        dat = ['1.10', '1.2', '1.3', '1.20']
+        self.assertEqual(
+            ['1.2', '1.3', '1.10', '1.20'],
+            tb.human_sort(dat))
         dat = ['r1.txt', 'r10.txt', 'r2.txt']
-        dat.sort()
-        assert dat == ['r1.txt', 'r10.txt', 'r2.txt']  # standard python sort
-        assert tb.human_sort(dat) == ['r1.txt', 'r2.txt', 'r10.txt']  # human sort
+        dat.sort() # Standard Python sort
+        self.assertEqual(['r1.txt', 'r10.txt', 'r2.txt'], dat)
+        self.assertEqual(['r1.txt', 'r2.txt', 'r10.txt'],
+                         tb.human_sort(dat))
+        dat = [5, 1, 3, -1]
+        self.assertEqual([-1, 1, 3, 5], tb.human_sort(dat))
 
     def test_quaternionDeprecation(self):
         """Make sure deprecated quaternion functions work"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -93,12 +93,19 @@ class PickleAssembleTests(unittest.TestCase):
     def testSaveLoadPickleCompress(self):
         """savePickle should write a pickle to disk and loadPickle should load it (compressed)"""
         tb.savepickle(os.path.join(self.tempdir, 'test_pickle_1.pkl'), self.D1, compress=True)
-        files = glob.glob(os.path.join(self.tempdir, '*.pkl.gz'))
-        self.assertTrue(os.path.join(self.tempdir,'test_pickle_1.pkl.gz') in files)
+        files = os.listdir(self.tempdir)
+        self.assertTrue('test_pickle_1.pkl.gz' in files)
+        self.assertFalse('test_pickle_1.pkl' in files)
         DD = tb.loadpickle(os.path.join(self.tempdir,'test_pickle_1.pkl'))
         self.assertEqual(self.D1, DD)
         DD = tb.loadpickle(os.path.join(self.tempdir,'test_pickle_1.pkl.gz'))
         self.assertEqual(self.D1, DD)
+        # Save without specifying compression, make sure saves compressed
+        # (because compressed file already exists)
+        tb.savepickle(os.path.join(self.tempdir, 'test_pickle_1.pkl'), self.D1)
+        files = os.listdir(self.tempdir)
+        self.assertTrue('test_pickle_1.pkl.gz' in files)
+        self.assertFalse('test_pickle_1.pkl' in files)
 
     def test_assemble(self):
         tb.savepickle(os.path.join(self.tempdir, 'test_pickle_1.pkl'), self.D1)


### PR DESCRIPTION
Leftover doctest at the bottom of toolbox, hasn't worked since before 0.1.5. 

Also some code was checking for <numpy 1.3 which is a lot older than we support. 

None of the other modules have it, I propose removing it. 

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

(JTN: Closes #414)