### PR TITLE
Support Ticktock to/from astropy.time.Time (Closes #321)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
  - pip install h5py
  - pip install networkx
  - pip install ffnet
+ - pip install "astropy>=1.0"
  - pip freeze #summarize what we have for debug purposes
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz; tar xzf cdf37_1-dist-cdf.tar.gz; cd cdf37_1-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,6 +58,7 @@ time
    in many cases they were undefined in previous versions.
  - now and today return UTC times, not local.
  - matplotlib no longer required, including RDT and randomDate.
+ - Add support for conversion to/from astropy.time.Time
 toolbox
  - New function get_url to retrieve data from a URL
  - Change update to retrieve OMNI2 data from SPDF not ViRBO

--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -78,7 +78,14 @@ history. The oldest version supported according to this policy is in
      - 3.8.0 (2019/10/14)
      - 3.7.0 (2018/6/27)
      - 3.2.0 (2011/2/20) or 2.7.0 (2010/7/3)
-   * - `CDF <https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/CHANGES.txt>`_
+   * - `AstroPy <https://docs.astropy.org/en/stable/changelog.html#changelog>`_
+     - 4.0.1 (2020/3/27)
+     - **1.1.1** (2016/1/8)
+     - 2.0.4 (2018/2/6)
+     - 3.0 (2018/2/12)
+     - 3.2 (2019/6/14)
+     - 1.0 (2015/2/18)
+   * - `CDF <https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest-release/unix/CHANGES.txt>`_
      - 3.8.0.1 (2020/7/7)
      - N/A
      - N/A

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -139,6 +139,13 @@ f2py) must be installed before SpacePy.
 
 :mod:`~spacepy.coordinates` requires :mod:`~spacepy.irbempy`.
 
+.. _dependencies_astropy:
+
+Astropy 1.0+
+------------
+:mod:`~spacepy.time` requires AstroPy if conversion to/from
+AstroPy :class:`~astropy.time.Time` is desired.
+
 Soft Dependency Summary
 =======================
 
@@ -159,9 +166,11 @@ unaffected by that dependency.
      - :ref:`matplotlib <dependencies_mpl>`
      - :ref:`networkx <dependencies_networkx>`
      - :ref:`SciPy <dependencies_scipy>`
+     - :ref:`AstroPy <dependencies_astropy>`
    * - :mod:`~spacepy.coordinates`
      -
      - :class:`~spacepy.coordinates.Coords` (except Windows binaries)
+     -
      -
      -
      -
@@ -179,6 +188,7 @@ unaffected by that dependency.
      -
      -
      -
+     -
    * - :mod:`~spacepy.empiricals`
      -
      -
@@ -188,9 +198,11 @@ unaffected by that dependency.
      -
      - * :func:`~spacepy.empiricals.vampolaPA`
        * :func:`~spacepy.empiricals.omniFromDirectionalFlux`
+     -
    * - :mod:`~spacepy.irbempy`
      -
      - :mod:`Entire module <spacepy.irbempy>` (except Windows binaries)
+     -
      -
      -
      -
@@ -204,11 +216,13 @@ unaffected by that dependency.
      -
      - :mod:`Entire module <spacepy.LANLstar>`
      -
+     -
    * - :mod:`~spacepy.omni`
      -
      -
      -
      - :mod:`Entire module <spacepy.omni>`
+     -
      -
      -
      -
@@ -220,6 +234,7 @@ unaffected by that dependency.
      - :mod:`Entire module <spacepy.plot>`
      -
      -
+     -
    * - :mod:`~spacepy.poppy`
      -
      -
@@ -229,6 +244,7 @@ unaffected by that dependency.
        * :meth:`~spacepy.poppy.PPro.plot`
        * :meth:`~spacepy.poppy.PPro.plot_mult`
        * :func:`~spacepy.poppy.plot_two_ppro`
+     -
      -
      -
    * - :mod:`~spacepy.pybats`
@@ -273,8 +289,10 @@ unaffected by that dependency.
        * :func:`~spacepy.pybats.trace2d.test_dipole`
      -
      -
+     -
    * - :mod:`~spacepy.pycdf`
      - :mod:`Entire module <spacepy.pycdf>`
+     -
      -
      -
      -
@@ -290,6 +308,7 @@ unaffected by that dependency.
        * :meth:`~spacepy.radbelt.RBmodel.plot_obs`
      -
      -
+     -
    * - :mod:`~spacepy.seapy`
      -
      -
@@ -298,6 +317,16 @@ unaffected by that dependency.
      - :mod:`Entire module <spacepy.seapy>`
      -
      - * :func:`~spacepy.seapy.sea_signif`
+     -
+   * - :mod:`~spacepy.time`
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     - AstroPy support in :class:`~spacepy.time.Ticktock`
    * - :mod:`~spacepy.toolbox`
      -
      -
@@ -312,4 +341,5 @@ unaffected by that dependency.
      - * :func:`~spacepy.toolbox.dist_to_list`
        * :func:`~spacepy.toolbox.intsolve`
        * :func:`~spacepy.toolbox.poisson_fit`
+     -
 

--- a/Doc/source/images/ticktock_relationships.svg
+++ b/Doc/source/images/ticktock_relationships.svg
@@ -22,11 +22,59 @@
     <marker
        inkscape:isstock="true"
        style="overflow:visible"
-       id="marker4707"
+       id="marker5412"
        refX="0"
        refY="0"
        orient="auto"
        inkscape:stockid="Arrow1Lend">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         id="path5414" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5202"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path5204"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4796"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
+         id="path4798" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4707"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          inkscape:connector-curvature="0"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
@@ -424,16 +472,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="168.37915"
-     inkscape:cy="125.28047"
+     inkscape:cx="498.00333"
+     inkscape:cy="316.54912"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      units="in"
-     inkscape:window-width="2560"
-     inkscape:window-height="1411"
+     inkscape:window-width="1920"
+     inkscape:window-height="1051"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="1080"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -447,7 +495,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -501,7 +549,7 @@
            style="stroke:#000000;stroke-opacity:1" /></flowRegion><flowPara
          id="flowPara4193" /></flowRoot>    <g
        id="g4872"
-       transform="translate(5.3303417,0)">
+       transform="translate(-3.3673347,0)">
       <path
          transform="translate(-298.91824,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -529,7 +577,7 @@
     </g>
     <g
        id="g4908"
-       transform="translate(-521.40855,0)">
+       transform="translate(-538.8039,0)">
       <path
          transform="translate(314.12579,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -596,7 +644,7 @@
     </g>
     <g
        id="g4878"
-       transform="translate(176.66806,0)">
+       transform="translate(141.87732,0)">
       <path
          transform="translate(-211.34051,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -624,7 +672,7 @@
     </g>
     <g
        id="g4686"
-       transform="translate(175.39548,0)">
+       transform="translate(131.90706,0)">
       <path
          transform="translate(-123.76279,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -652,7 +700,7 @@
     </g>
     <g
        id="g4884"
-       transform="translate(174.12286,0)">
+       transform="translate(121.93678,0)">
       <path
          transform="translate(-36.185058,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -680,7 +728,7 @@
     </g>
     <g
        id="g4866"
-       transform="translate(265.51837,0)">
+       transform="translate(239.42532,0)">
       <path
          transform="translate(-386.49596,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -708,7 +756,7 @@
     </g>
     <g
        id="g4896"
-       transform="translate(85.272522,0)">
+       transform="translate(24.388831,0)">
       <path
          transform="translate(138.9704,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -846,7 +894,7 @@
     </g>
     <g
        id="g5151"
-       transform="translate(339.28571,-215.71429)">
+       transform="translate(339.28571,-197.71429)">
       <path
          transform="translate(-90.481004,300.93591)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -874,7 +922,7 @@
     </g>
     <g
        id="g4679"
-       transform="translate(335.71428,-384.28571)">
+       transform="translate(339.71428,-346.28571)">
       <path
          transform="translate(-90.481004,394.8801)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -1162,7 +1210,7 @@
        inkscape:connection-start="#path4209-3-5-0" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker7542)"
-       d="m 228.64658,338.40099 10.92961,106.72577"
+       d="m 213.46157,338.40099 23.90428,106.72577"
        id="path7534"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1170,7 +1218,7 @@
        inkscape:connection-end="#path4209-3-5-7-0-3-4-6" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8322)"
-       d="M 214.90015,338.40099 106.06259,504.90779"
+       d="m 199.06381,338.40099 -94.56023,166.5068"
        id="path8314"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1178,7 +1226,7 @@
        inkscape:connection-end="#path4209-3-5-0" />
     <g
        id="g4902"
-       transform="translate(84,0)">
+       transform="translate(14.418614,0)">
       <path
          transform="translate(226.5481,-144.32362)"
          d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
@@ -1250,7 +1298,7 @@
        inkscape:connection-end="#path4209-6" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8872)"
-       d="M 136.32986,338.40099 98.327741,504.90779"
+       d="M 128.41169,338.40099 97.548238,504.90779"
        id="path8864"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1274,7 +1322,7 @@
        inkscape:connection-end="#path4209-3-1" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker9874)"
-       d="M 724.52433,338.40099 538.43322,506.80554"
+       d="M 661.12118,338.40099 532.25498,506.80554"
        id="path9866"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1282,7 +1330,7 @@
        inkscape:connection-end="#path4209-3-1" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker4693)"
-       d="m 553.69656,514.03768 90.24961,-27.95083"
+       d="m 553.69656,523.30478 94.24961,-4.48502"
        id="path4685"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1290,7 +1338,7 @@
        inkscape:connection-end="#g4679" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4508)"
-       d="m 409.95643,338.40099 97.82414,168.40455"
+       d="M 382.62017,338.40099 505.11683,506.80554"
        id="path4500"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1298,7 +1346,7 @@
        inkscape:connection-end="#path4209-3-1" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5355)"
-       d="m 553.69656,530.31139 93.82104,14.12899"
+       d="m 553.69656,533.7495 93.82104,23.25277"
        id="path5347"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1306,7 +1354,7 @@
        inkscape:connection-end="#g5151" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4491)"
-       d="M 174.03047,338.40099 484.79108,506.80554"
+       d="M 163.09597,338.40099 483.72559,506.80554"
        id="path4483"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1322,7 +1370,7 @@
        inkscape:connection-end="#g4492" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4701)"
-       d="M 567.24036,338.40099 523.10689,506.80554"
+       d="m 527.14718,338.40099 -7.94711,168.40455"
        id="path4693"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1330,7 +1378,7 @@
        inkscape:connection-end="#path4209-3-1" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4704)"
-       d="M 331.31445,338.40099 500.11741,506.80554"
+       d="M 303.97819,338.40099 497.45367,506.80554"
        id="path4696"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1338,7 +1386,7 @@
        inkscape:connection-end="#path4209-3-1" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5082)"
-       d="m 517.68038,543.16882 -4.13823,113.7085"
+       d="m 517.68037,543.16882 -4.13822,113.7085"
        id="path5074"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1346,7 +1394,7 @@
        inkscape:connection-end="#g4498" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4708)"
-       d="M 645.88232,338.40099 530.77005,506.80554"
+       d="M 596.67706,338.40099 525.97531,506.80554"
        id="path4700"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
@@ -1362,11 +1410,85 @@
        inkscape:connection-end="#path4209-3-5-2-9" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4707)"
-       d="m 488.59841,338.40099 26.84532,168.40455"
+       d="m 457.61732,338.40099 54.8075,168.40455"
        id="path4699"
        inkscape:connector-type="polyline"
        inkscape:connector-curvature="0"
        inkscape:connection-start="#g4686"
        inkscape:connection-end="#path4209-3-1" />
+    <g
+       id="g4902-3"
+       transform="translate(92.026097,0)">
+      <path
+         transform="translate(226.5481,-144.32362)"
+         d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
+         id="path4209-3-5-7-0-3-6-6"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         xlink:href="#rect4207"
+         inkscape:original="M 395.68164 443.33008 L 395.68164 485.75586 L 472.45312 485.75586 L 472.45312 443.33008 L 395.68164 443.33008 z "
+         inkscape:radius="-3.0304577"
+         sodipodi:type="inkscape:offset"
+         inkscape:href="#rect4207" />
+      <text
+         sodipodi:linespacing="125%"
+         id="text4617-7"
+         y="323.04926"
+         x="643.44446"
+         style="font-style:normal;font-weight:normal;font-size:15px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           id="tspan4619-5"
+           y="323.04926"
+           x="643.44446"
+           sodipodi:role="line">APT</tspan></text>
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker4796)"
+       d="M 89.52884,335.816 482.98757,509.39052"
+       id="path4788"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#g4890"
+       inkscape:connection-end="#g4903" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker5202)"
+       d="M 731.83778,338.40099 539.14587,506.80554"
+       id="path5194"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#g4902-3"
+       inkscape:connection-end="#g4903" />
+    <g
+       id="g4902-3-3"
+       transform="translate(21.311763,143.82977)">
+      <path
+         transform="translate(226.5481,-144.32362)"
+         d="m 398.71289,446.36133 0,36.36328 70.70899,0 0,-36.36328 -70.70899,0 z"
+         id="path4209-3-5-7-0-3-6-6-6"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         xlink:href="#rect4207"
+         inkscape:original="M 395.68164 443.33008 L 395.68164 485.75586 L 472.45312 485.75586 L 472.45312 443.33008 L 395.68164 443.33008 z "
+         inkscape:radius="-3.0304577"
+         sodipodi:type="inkscape:offset"
+         inkscape:href="#rect4207" />
+      <text
+         sodipodi:linespacing="125%"
+         id="text4617-7-0"
+         y="323.04926"
+         x="643.44446"
+         style="font-style:normal;font-weight:normal;font-size:15px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           id="tspan4619-5-6"
+           y="323.04926"
+           x="643.44446"
+           sodipodi:role="line">APT</tspan></text>
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker5412)"
+       d="m 553.69656,511.81707 92.87619,-34.59784"
+       id="path5404"
+       inkscape:connector-type="polyline"
+       inkscape:connector-curvature="0"
+       inkscape:connection-start="#g4903"
+       inkscape:connection-end="#g4902-3-3" />
   </g>
 </svg>

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -26,6 +26,9 @@ adds IGRF13 coefficients. :mod:`~spacepy.coordinates` and
 coordinate systems as inputs to routines; if a routine does not
 support an input system, it will be automatically converted.
 
+:class:`~spacepy.time.Ticktock` supports conversions to and from
+:class:`astropy.time.Time`.
+
 The following classes, functions, and methods are new:
 
 .. autosummary::
@@ -57,14 +60,19 @@ Quaternion math functions have been moved to
 
 Dependency requirements
 ***********************
+Not all dependencies are required for all functionality; see
+:doc:`dependencies` for full details, including what functionality is
+lost if a dependency is not installed.
+
 numpy 1.10 is now required. (Many functions erroneously required it from 0.2.1, but this was not adequately documented.)
 
-scipy 0.11 is now required. (Again, this was erroneously required in 0.2.0 without appropriate documentation.)
+scipy 0.11 is now the minimum supported version of SciPy. (Again, this was erroneously required in 0.2.0 without appropriate documentation.)
 
 Several dependencies without an established minimum version were tested.
 
-As of 0.2.2, the minimum versions of dependencies are:
+As of 0.2.2, minimum supported versions of dependencies are:
   * CPython 2 2.7 or CPython 3 3.2
+  * AstroPy 1.0
   * CDF 2.7
   * dateutil 1.4 (earlier may work)
   * ffnet 0.7 (earlier may work)
@@ -73,8 +81,6 @@ As of 0.2.2, the minimum versions of dependencies are:
   * networkx 1.0 (earlier may work)
   * numpy 1.10
   * scipy 0.11
-
-See :doc:`dependencies` for full details.
 
 Major bugfixes
 **************

--- a/setup.py
+++ b/setup.py
@@ -996,6 +996,9 @@ if use_setuptools:
         #we need to ask for it ourselves
         'networkx>=1.0',
         'python_dateutil>=1.4',
+        # AstroPy is only required to convert to/from AstroPy, so either
+        # user has it or don't care.
+        #'astropy>=1.0',
     ]
 if 'bdist_wheel' in sys.argv:
     setup_kwargs['cmdclass']['bdist_wheel'] = bdist_wheel

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -200,8 +200,7 @@ class Ticktock(MutableSequence):
     CDF
         CDF Epoch type: float milliseconds since 0000-1-1 ignoring leapseconds
     APT
-        AstroPy :class:`~astropy.time.Time`. Ticktock objects using AstroPy
-        time as input may not pickle properly. Requires AstroPy 1.0.
+        AstroPy :class:`~astropy.time.Time`. Requires AstroPy 1.0.
         (New in version 0.2.2.)
 
     Possible output data types: All those listed above, plus:

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -201,7 +201,7 @@ class Ticktock(MutableSequence):
         CDF Epoch type: float milliseconds since 0000-1-1 ignoring leapseconds
     APT
         AstroPy :class:`~astropy.time.Time`. Ticktock objects using AstroPy
-        time as input may not pickle properly. Requires AstroPy 0.3.
+        time as input may not pickle properly. Requires AstroPy 1.0.
         (New in version 0.2.2.)
 
     Possible output data types: All those listed above, plus:
@@ -1460,7 +1460,7 @@ class Ticktock(MutableSequence):
         =====
         .. versionadded:: 0.2.2
 
-        Requires AstroPy 0.3.
+        Requires AstroPy 1.0.
 
         Examples
         ========

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1459,13 +1459,17 @@ class Ticktock(MutableSequence):
         =====
         .. versionadded:: 0.2.2
 
-        Requires AstroPy 1.0.
+        Requires AstroPy 1.0. The returned value will be on the ``tai``
+        scale in ``gps`` format (unless the :class:`Ticktock` was created
+        from a :class:`~astropy.time.Time` object, in which case it will
+        be the original input.) See the :mod:`astropy.time` docs for
+        conversion to other scales and formats.
 
         Examples
         ========
         >>> a = Ticktock('2002-02-02T12:00:00', 'ISO')
         >>> a.APT
-        <Time object: scale='utc' format='gps' value=696686413.0>
+        <Time object: scale='tai' format='gps' value=696686413.0>
 
         See Also
         =========

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1094,6 +1094,22 @@ class TimeClassTests(unittest.TestCase):
             [datetime.datetime(2010, 1, 1)],
             t1.UTC)
 
+    def test_astropy_pickle(self):
+        """Pickle with AstroPy time inputs"""
+        apt = astropy.time.Time([
+            '2010-01-01',
+            '2010-01-01T00:01:00'])
+        t1 = t.Ticktock(apt, dtype='APT')
+        pkl = pickle.dumps(t1)
+        t2 = pickle.loads(pkl)
+        self.assertEqual('APT', t2.data.attrs['dtype'])
+        numpy.testing.assert_array_equal(
+            [datetime.datetime(2010, 1, 1),
+             datetime.datetime(2010, 1, 1, 0, 1)],
+            t2.UTC)
+        numpy.testing.assert_array_equal(
+            [1640995234.0, 1640995294.0], t2.TAI)
+
     def test_astropy_output(self):
         """AstroPy time outputs"""
         t1 = t.Ticktock(['2010-01-01',


### PR DESCRIPTION
This PR adds support for the AstroPy time object. It can be passed to the Ticktock constructor, and a new .getAPT() method and .APT attribute will return AstroPy time.

EDIT: I keep on forgetting the title doesn't work for this. Closes #321 

A few things to note:

1. AstroPy is added as a dependency in the documentation and the CI, but it is _not_ added to setup.py or requires.txt. Installing AstroPy adds no functionality to SpacePy; it's only of interest if you want to work with AstroPy. In which case, chances are you have AstroPy and don't need SpacePy to ask pip to install it.
2. Some combinations of Python 3 version + AstroPy version will throw a ResourceWarning from the tests. This is an AstroPy problem; merely importing AstroPy 1.1.1 on Python 3.5.2 with warnings set to 'always' will make this happen. Okay on AstroPy 3.0 on Python 3.6.9. This will reproduce:
    ```python
    import warnings
    warnings.simplefilter('always', category=ResourceWarning)
    import astropy
    ```
3. In the docstring for Ticktock it now mentions that `.APT` require AstroPy 1.0. This is the only case I know of where we mention dependencies in the docstring. On the one hand it seems reasonable to mention it to avoid surprise; on the other hand, we don't list everything that's required for every single function in SpacePy. Options here are to leave as-is, just say "AstroPy" without version, or assume that if you're looking for AstroPy objects the requirement for AstroPy is assumed.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
