### PR TITLE
Update dependency version documentation

### DIFF
--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -60,37 +60,37 @@ SpacePy. Where available, the dependency name links to its version
 history. The oldest version supported according to this policy is in
 **bold**.
 
-.. list-table:: SpacePy dependency versions (2020/1/9)
+.. list-table:: SpacePy dependency versions (2020/9/17)
    :widths: 10 10 10 10 10 10 10
    :header-rows: 1
 
    * - Dependency
      - Current Release
-     - Ubuntu 16.04LTS
      - Ubuntu 18.04LTS
+     - Ubuntu 20.04LTS
      - NEP 29 (42/24 mo.)
      - NEP 29 (2/3 minor versions)
      - SpacePy current minimum
    * - `CPython <https://www.python.org/downloads/>`_
-     - 3.8.1 (2019/12/18)
-     - **3.5.1** (2015/12/7)
-     - 3.6.5 (2018/2/5)
-     - 3.6.0 (2016/12/23)
+     - 3.8.5 (2020/7/20)
+     - **3.6.5** (2018/2/5)
+     - 3.8.2 (2020/2/24) 
+     - 3.8.0 (2019/10/14)
      - 3.7.0 (2018/6/27)
      - 3.2.0 (2011/2/20) or 2.7.0 (2010/7/3)
-   * - `CDF <https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest-release/unix/CHANGES.txt>`_
-     - 3.7.1 (2018/8/21)
+   * - `CDF <https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/CHANGES.txt>`_
+     - 3.8.0.1 (2020/7/7)
      - N/A
      - N/A
-     - 3.7.0 (2018/5/11)
-     - **3.5.0** (2013/9/15)
+     - 3.8.0 (2019/10/27)
+     - **3.6.0** (2015/2/5)
      - 2.7.0 (1999/9/27)
    * - `dateutil <https://github.com/dateutil/dateutil/releases>`_
      - 2.8.1 (2019/11/3)
-     - **2.4.2** (2015/3/31)
      - 2.6.1 (2017/7/10)
-     - 2.7.0 (2018/3/11)
-     - 2.6.0 (2016/11/8)
+     - 2.7.3 (2018/5/9)
+     - 2.8.0 (2019/2/5)
+     - **2.6.0** (2016/11/8)
      - tested from 1.4 (2008/2/27)
    * - `ffnet <https://github.com/mrkwjc/ffnet/releases>`_
      - 0.8.4 (2018/10/28)
@@ -101,36 +101,36 @@ history. The oldest version supported according to this policy is in
      - tested from 0.7 (2011/8/8)
    * - `h5py <https://github.com/h5py/h5py/releases>`_
      - 2.10.0 (2019/9/6)
-     - **2.6.0** (2017/3/18)
-     - 2.7.1 (2017/9/1)
-     - 2.8.0 (2018/5/13)
+     - **2.7.1** (2017/9/1)
+     - 2.10.0 (2019/9/6)
+     - 2.9.0 (2018/12/19)
      - 2.8.0 (2018/5/13)
      - tested from 2.6 (2017/3/18)
    * - `matplotlib <https://github.com/matplotlib/matplotlib/releases>`_
+     - 3.3.2 (2020/9/15)
+     - **2.1.1** (2017/12/9)
      - 3.1.2 (2019/12/4)
-     - **1.5.1** (2016/1/10)
-     - 2.1.1 (2017/12/9)
-     - 2.1.0 (2017/10/7)
      - 3.0.0 (2018/9/17)
+     - 3.1.0 (2019/5/17)
      - 1.5.0 (2015/10/29)
    * - `networkx <https://github.com/networkx/networkx/releases>`_
-     - 2.4.0 (2019/10/16)
-     - 1.11 (2016/1/30)
+     - 2.5 (2020/8/22)
      - **1.11** (2016/1/30)
-     - 2.1 (2018/1/22)
-     - 2.1 (2018/1/22)
+     - 2.4 (2019/10/16)
+     - 2.2 (2018/9/19)
+     - 2.3 (2019/4/11)
      - tested from 1.0 (2010/1/7)
    * - `numpy <https://github.com/numpy/numpy/releases>`_
-     - 1.18.1 (2020/1/6)
-     - **1.11.0** (2016/3/27)
-     - 1.13.1 (2017/7/6)
-     - 1.14.0 (2018/1/6)
+     - 1.19.2 (2020/9/10)
+     - **1.13.1** (2017/7/6)
+     - 1.17.4 (2019/11/10)
      - 1.16.0 (2019/1/13)
+     - 1.17.0 (2019/7/26)
      - 1.10.0 (2015/10/5)
    * - `scipy <https://github.com/scipy/scipy/releases>`_
-     - 1.4.1 (2019/12/18)
-     - **0.17.0** (2016/1/23)
-     - 0.19.1 (2017/6/23)
+     - 1.5.2 (2020/7/23)
+     - **0.19.1** (2017/6/23)
+     - 1.3.3 (2019/11/23)
      - 1.2.0 (2018/12/17)
-     - 1.1.0 (2018/5/5)
+     - 1.3.0 (2019/5/17)
      - 0.11.0 (2012/9/24)

--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -91,21 +91,21 @@ history. The oldest version supported according to this policy is in
      - 2.6.1 (2017/7/10)
      - 2.7.0 (2018/3/11)
      - 2.6.0 (2016/11/8)
-     - minimum not established
+     - tested from 1.4 (2008/2/27)
    * - `ffnet <https://github.com/mrkwjc/ffnet/releases>`_
      - 0.8.4 (2018/10/28)
      - N/A
      - N/A
      - 0.8.4 (2018/10/28)
      - **0.6.0** (2007/3/22)
-     - minimum not established (tested from 0.7.0)
+     - tested from 0.7 (2011/8/8)
    * - `h5py <https://github.com/h5py/h5py/releases>`_
      - 2.10.0 (2019/9/6)
      - **2.6.0** (2017/3/18)
      - 2.7.1 (2017/9/1)
      - 2.8.0 (2018/5/13)
      - 2.8.0 (2018/5/13)
-     - minimum not established
+     - tested from 2.6 (2017/3/18)
    * - `matplotlib <https://github.com/matplotlib/matplotlib/releases>`_
      - 3.1.2 (2019/12/4)
      - **1.5.1** (2016/1/10)
@@ -119,18 +119,18 @@ history. The oldest version supported according to this policy is in
      - **1.11** (2016/1/30)
      - 2.1 (2018/1/22)
      - 2.1 (2018/1/22)
-     - minimum not established
+     - tested from 1.0 (2010/1/7)
    * - `numpy <https://github.com/numpy/numpy/releases>`_
      - 1.18.1 (2020/1/6)
      - **1.11.0** (2016/3/27)
      - 1.13.1 (2017/7/6)
      - 1.14.0 (2018/1/6)
      - 1.16.0 (2019/1/13)
-     - 1.4.0 (2009/12/27)
+     - 1.10.0 (2015/10/5)
    * - `scipy <https://github.com/scipy/scipy/releases>`_
      - 1.4.1 (2019/12/18)
      - **0.17.0** (2016/1/23)
      - 0.19.1 (2017/6/23)
      - 1.2.0 (2018/12/17)
      - 1.1.0 (2018/5/5)
-     - 0.10.0 (2011/11/13)
+     - 0.11.0 (2012/9/24)

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -27,11 +27,11 @@ of 2020. See :doc:`py2k_eol`.
 
 Required to install SpacePy.
 
-NumPy 1.4+
-----------
+NumPy 1.10+
+-----------
 `NumPy <http://numpy.scipy.org/>`_ provides the
 high-performance array data structure used throughout SpacePy. Version
-1.4 or later is required; 1.6 or later recommended.
+1.10 or later is required.
 
 Required to install SpacePy. f2py is part of NumPy, but is sometimes
 packaged separately; it is required (at installation time) if
@@ -42,7 +42,7 @@ Due to a numpy bug, numpy 1.15.0 is not supported. Use 1.15.1 or later.
 dateutil
 --------
 If you choose not to install :ref:`matplotlib <dependencies_mpl>`,
-`dateutil <http://labix.org/python-dateutil>`_ is required.
+`dateutil <http://labix.org/python-dateutil>`_ 1.4 or later is required.
 (Installing matplotlib will fulfill this dependency.)
 
 C compiler
@@ -61,7 +61,7 @@ methods such as pip.
 
 .. _dependencies_scipy:
 
-SciPy 0.10+
+SciPy 0.11+
 -----------
 `SciPy <http://www.scipy.org/>`_ provides several useful scientific
 and numerical functions build on top of NumPy.  It is highly
@@ -91,30 +91,30 @@ modules may have limited functionality or fail entirely:
 
 .. _dependencies_ffnet:
 
-ffnet
------
+ffnet 0.7+
+----------
 `ffnet <http://ffnet.sourceforge.net/>`_ is a neural network package,
 required for :mod:`~spacepy.LANLstar`.
 
 .. _dependencies_networkx:
 
-networkx
---------
+networkx 1.0+
+-------------
 `networkx <http://networkx.lanl.gov/>`_ is a requirement for ffnet,
 and thus :mod:`~spacepy.LANLstar`.
 
 .. _dependencies_h5py:
 
-h5py
-----
+h5py 2.6+
+---------
 `h5py <http://code.google.com/p/h5py/>`_ provides a Python interface to
 HDF5 files. It is required for the HDF import/export capability of
 :mod:`~spacepy.datamodel` and for use of the :mod:`~spacepy.omni` module.
 
 .. _dependencies_cdf:
 
-CDF
----
+CDF 2.7+
+--------
 NASA's `CDF <http://cdf.gsfc.nasa.gov/>`_ library provides access to
 Common Data Format files. It is required for :mod:`~spacepy.pycdf`,
 and thus for the CDF import/export capability of
@@ -166,8 +166,7 @@ unaffected by that dependency.
      -
      -
      -
-     - :func:`~spacepy.coordinates.quaternionFromMatrix` unless using
-       numpy 1.8 or later
+     -
    * - :mod:`~spacepy.datamodel`
      - * :meth:`~spacepy.datamodel.SpaceData.toCDF`
        * :func:`~spacepy.datamodel.fromCDF`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.6,!=1.15.0
-scipy>=0.10
+numpy>=1.10,!=1.15.0
+scipy>=0.11
 matplotlib>=1.5
-h5py
-ffnet
+h5py>=2.6
+ffnet>=0.7

--- a/setup.py
+++ b/setup.py
@@ -985,17 +985,17 @@ if not egginfo_only:
 if use_setuptools:
 #Sadly the format here is DIFFERENT than the distutils format
     setup_kwargs['install_requires'] = [
-        'numpy>=1.6',
-        'scipy>=0.10',
+        'numpy>=1.10,!=1.15.0',
+        'scipy>=0.11',
         'matplotlib>=1.5',
-        'h5py',
+        'h5py>=2.6',
         #Do not install ffnet on Windows since there's no binary
         #(people must hand-install)
-        'ffnet;platform_system!="Windows"',
+        'ffnet>=0.7;platform_system!="Windows"',
         #ffnet needs networkx but not marked as requires, so to get it via pip
         #we need to ask for it ourselves
-        'networkx',
-        'python_dateutil',
+        'networkx>=1.0',
+        'python_dateutil>=1.4',
     ]
 if 'bdist_wheel' in sys.argv:
     setup_kwargs['cmdclass']['bdist_wheel'] = bdist_wheel

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1496,13 +1496,8 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
             except ValueError:
                 warnings.warn('Key {0} for conversion not found in file'.format(conkey), UserWarning)
                 continue
-            #https://github.com/numpy/numpy/issues/2160
-            if len(mdata[name].shape) == 1:
-                for i,element in numpy.ndenumerate(mdata[name]):
-                    mdata[name][i[0]] = conversions[name](element)
-            else:
-                for i,element in numpy.ndenumerate(mdata[name]):
-                    mdata[name][i] = conversions[name](element)
+            for i,element in numpy.ndenumerate(mdata[name]):
+                mdata[name][i] = conversions[name](element)
 
     for remkey in keys:
         try:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1358,8 +1358,7 @@ class TimeClassTests(unittest.TestCase):
         """testing get UTC from GPS"""
         t1 = t.Ticktock([6.93882013e+08, 6.93964813e+08], 'GPS')
         expected = t.Ticktock(['2002-01-01T01:00:00', '2002-01-02'])
-        #        numpy.testing.assert_array_equal(t1, expected)
-        self.assertTrue((t1 == expected).all())
+        numpy.testing.assert_array_equal(t1, expected)
 
     def test_GPSinput(self):
         """Regressions on GPS input, correct TAI/UTC conversions"""


### PR DESCRIPTION
This PR updates the documentation of what dependencies are required and thus closes #365 . In the process I also removed a few workarounds for earlier versions of dependencies which are no longer supported (I didn't do an exhaustive search, just grabbed the quick ones I remembered) and updated the table of how we choose what dependencies to support.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
