### PR TITLE
CI testing of supported dependency versions (Closes #366) (Closes #421)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ matrix:
     env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.15.1,<1.16.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1" CFLAGS="-Wno-error=format-security"
+    env: NUMPY_VERSION=">=1.15.1,<1.16.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1" CFLAGS="-Wno-error=format-security"
   - python: 3.7
     dist: bionic
     env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.8
     dist: bionic
-    env: NUMPY_VERSION=">=1.17.0,<1.18.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1" CFLAGS="-Wno-error=format-security"
+    env: NUMPY_VERSION=">=1.17.0,<1.18.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1" CFLAGS="-Wno-error=format-security"
   - python: 3.8
     dist: bionic
     env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ matrix:
 # which works with that Python. (For latest, generally specify no version
 # and let pip select latest, unless there's a max version known to work
 # with a given Python.)
+# Old astropy + new gcc requires overriding some CFLAGS, see
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=871156
   - python: 2.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.10.0,<1.11.0" PIPLIST="scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.0,<1.1 h5py>=2.6,<2.7 ffnet>=0.7.0,<0.8 astropy>=1.0,<1.1"
+    env: NUMPY_VERSION=">=1.10.0,<1.11.0" PIPLIST="scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.0,<1.1 h5py>=2.6,<2.7 ffnet>=0.7.0,<0.8 astropy>=1.0,<1.1" CFLAGS="-Wno-error=format-security"
   - python: 2.7
     dist: bionic
     env: NUMPY_VERSION=">=1.16.0,<1.17.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
@@ -23,19 +25,19 @@ matrix:
     env: NUMPY_VERSION=">=1.18.0,<1.19.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.6
     dist: bionic
-    env: NUMPY_VERSION=">=1.12.0,<1.13.0" PIPLIST="scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+    env: NUMPY_VERSION=">=1.12.0,<1.13.0" PIPLIST="scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1" CFLAGS="-Wno-error=format-security"
   - python: 3.6
     dist: bionic
     env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.15.1,<1.16.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+    env: NUMPY_VERSION=">=1.15.1,<1.16.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1" CFLAGS="-Wno-error=format-security"
   - python: 3.7
     dist: bionic
     env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.8
     dist: bionic
-    env: NUMPY_VERSION=">=1.17.0,<1.18.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+    env: NUMPY_VERSION=">=1.17.0,<1.18.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1" CFLAGS="-Wno-error=format-security"
   - python: 3.8
     dist: bionic
     env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,49 +4,51 @@ sudo: yes
 
 matrix:
  include:
+# For the most part, these versions are: what's the earliest we support,
+# coupled with what's the earliest and latest version of each dep
+# which works with that Python. (For latest, generally specify no version
+# and let pip select latest, unless there's a max version known to work
+# with a given Python.)
   - python: 2.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.6.0,<1.7.0"
+    env: NUMPY_VERSION=">=1.10.0,<1.11.0" PIPLIST="scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.0,<1.1 h5py>=2.6,<2.7 ffnet>=0.7.0,<0.8 astropy>=1.0,<1.1"
   - python: 2.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.16.0,<1.17.0"
+    env: NUMPY_VERSION=">=1.16.0,<1.17.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.5
     dist: xenial
-    env: NUMPY_VERSION=">=1.10.0,<1.11.0"
+    env: NUMPY_VERSION=">=1.10.0,<1.11.0" PIPLIST="scipy>=0.17.0,<0.18.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
   - python: 3.5
     dist: xenial
-    env: NUMPY_VERSION=">=1.18.0,<1.19.0"
+    env: NUMPY_VERSION=">=1.18.0,<1.19.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.6
     dist: bionic
-    env: NUMPY_VERSION=">=1.12.0,<1.13.0"
+    env: NUMPY_VERSION=">=1.12.0,<1.13.0" PIPLIST="scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
   - python: 3.6
     dist: bionic
-    env: NUMPY_VERSION=">=1.18.0"
+    env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.15.1,<1.16.0"
+    env: NUMPY_VERSION=">=1.15.1,<1.16.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
   - python: 3.7
     dist: bionic
-    env: NUMPY_VERSION=">=1.18.0"
+    env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
   - python: 3.8
     dist: bionic
-    env: NUMPY_VERSION=">=1.17.0,<1.18.0"
+    env: NUMPY_VERSION=">=1.17.0,<1.18.0" PIPLIST="scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
   - python: 3.8
     dist: bionic
-    env: NUMPY_VERSION=">=1.18.0"
+    env: NUMPY_VERSION=">=1.18.0" PIPLIST="scipy matplotlib networkx h5py ffnet astropy"
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb
+ # blas/lapack dev needed for scipy versions without binary wheels
+ - sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb libblas-dev liblapack-dev
 
 install:
  - pip install --force-reinstall "numpy${NUMPY_VERSION}"
- - pip install scipy
- - pip install matplotlib
- - pip install h5py
- - pip install networkx
- - pip install ffnet
- - pip install "astropy>=1.0"
+ # Make sure new packages don't override numpy version
+ - pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
  - pip freeze #summarize what we have for debug purposes
  - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz; tar xzf cdf37_1-dist-cdf.tar.gz; cd cdf37_1-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Test lots of python/dependency versions.
+# Basically superfluous to the CI, but nice to be able to test easily without
+# having to put in the PR....
+
+# ffnet install will fail if LD_LIBRARY_PATH is set!
+
+# This might be necessary for some versions of scipy that don't have binaries
+sudo aptitude install libblas-dev liblapack-dev
+# download/install miniconda
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+bash ./Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
+# download/install CDF
+wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz; tar xzf cdf37_1-dist-cdf.tar.gz; pushd cdf37_1-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
+source ${HOME}/cdf/bin/definitions.B
+
+# For the most part, these versions are: what's the earliest we support,
+# coupled with what's the earliest and latest version of each dep
+# which works with that Python.
+TESTS=("2.7|numpy>=1.10.0,<1.11.0|scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.0,<1.1 h5py>=2.6,<2.7 ffnet>=0.7.0,<0.8 astropy>=1.0,<1.1"
+       "2.7|numpy>=1.16.0,<1.17.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.5|numpy>=1.10.0,<1.11.0|scipy>=0.17.0,<0.18.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+       "3.5|numpy>=1.18.0,<1.19.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.6|numpy>=1.12.0,<1.13.0|scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+       "3.6|numpy>=1.18.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.7|numpy>=1.15.1,<1.16.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+       "3.7|numpy>=1.18.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.8|numpy>=1.17.0,<1.18.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+       "3.8|numpy>=1.18.0|scipy matplotlib networkx h5py ffnet astropy"
+      )
+for thisTest in "${TESTS[@]}"
+do
+    IFS='|' read -ra tmpTest <<< "$thisTest"
+    PYVER=${tmpTest[0]}
+    NUMPY="${tmpTest[1]}"
+    PIPLIST="${tmpTest[2]}"
+    ENVNAME=py${PYVER//.}
+    ~/miniconda/bin/conda create -y -n ${ENVNAME} python=${PYVER}
+    source ~/miniconda/bin/activate ${ENVNAME}
+    # Get numpy in first (lots uses distutils)
+    pip install ${NUMPY}
+    # But don't let it grab a different version of numpy later
+    pip install ${NUMPY} ${PIPLIST}
+    python setup.py install
+    pushd tests
+    echo Python ${PYVER}
+    echo ${NUMPY} ${PIPLIST}
+    python test_all.py
+    popd
+    conda deactivate
+    ~/miniconda/bin/conda env remove --name ${ENVNAME}
+done
+rm -rf ~/miniconda
+rm ./Miniconda3-latest-Linux-x86_64.sh

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -24,9 +24,9 @@ TESTS=("2.7|numpy>=1.10.0,<1.11.0|scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0
        "3.5|numpy>=1.18.0,<1.19.0|scipy matplotlib networkx h5py ffnet astropy"
        "3.6|numpy>=1.12.0,<1.13.0|scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
        "3.6|numpy>=1.18.0|scipy matplotlib networkx h5py ffnet astropy"
-       "3.7|numpy>=1.15.1,<1.16.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+       "3.7|numpy>=1.15.1,<1.16.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1"
        "3.7|numpy>=1.18.0|scipy matplotlib networkx h5py ffnet astropy"
-       "3.8|numpy>=1.17.0,<1.18.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+       "3.8|numpy>=1.17.0,<1.18.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1"
        "3.8|numpy>=1.18.0|scipy matplotlib networkx h5py ffnet astropy"
       )
 for thisTest in "${TESTS[@]}"

--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -58,6 +58,7 @@ range set the keyword argument interp to False.
 
 """
 import bisect, re, os
+import sys
 import numpy as np
 from spacepy.datamodel import SpaceData, dmarray, dmcopy, unflatten, readJSONheadedASCII, dmfilled, fromHDF5
 from spacepy.toolbox import tOverlapHalf, indsFromXrange
@@ -396,7 +397,11 @@ except ImportError:
 #dotfln = os.environ['HOME']+'/.spacepy'
 omnifln = os.path.join(DOT_FLN,'data','omnidata{0}'.format(_ext))
 omni2fln = os.path.join(DOT_FLN,'data','omni2data{0}'.format(_ext))
-testfln = os.path.join('data','OMNItest{0}'.format(_ext))
+# Test data is stored relative to the test script
+testfln = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])),
+                       'data', 'OMNItest{0}'.format(_ext))
+if not os.path.isfile(testfln): # Hope it's relative to current!
+    testfln = os.path.join(os.path.abspath('data'), 'OMNItest{0}'.format(_ext))
 
 if _ext=='.h5':
     presentQD = h5py.is_hdf5(omnifln)

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1524,18 +1524,18 @@ class Bats2d(IdlFile):
             use_ax_lims = bool(ax.artists) and \
                 not(ax.get_xlim() == ax.get_ylim() == (0,1))
         
-        # Set range over which to place lines.  Use keyword values OR
-        # axes ranges OR full domain (in that order).
+        # Set range over which to place lines.  Use keyword values if provided
+        # OR subset of axes ranges that fit in domain (if axes are reasonable)
         if xlim == None:
+            xlim = [self[dims[0]].min(), self[dims[0]].max()]
             if use_ax_lims:
-                xlim = ax.get_xlim()
-            else:
-                xlim = [self[dims[0]].min(), self[dims[0]].max()]
+                axlim = ax.get_xlim()
+                xlim = [max(xlim[0], axlim[0]), min(xlim[1], axlim[1])]
         if ylim == None:
+            ylim = [self[dims[1]].min(), self[dims[1]].max()]
             if use_ax_lims:
-                ylim = ax.get_ylim()
-            else:
-                ylim = [self[dims[1]].min(), self[dims[1]].max()]
+                axlim = ax.get_ylim()
+                ylim = [max(ylim[0], axlim[0]), min(ylim[1], axlim[1])]
 
         # If initial source points not given, create a random set:
         if not start_points:

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1350,7 +1350,12 @@ class Bats2d(IdlFile):
         The method kwarg sets the numerical method to use for the
         tracing.  Default is Runge-Kutta 4 (rk4).
         '''
-
+        startvals = [x, y]
+        dims = self['grid'].attrs['dims']
+        for v, d in zip(startvals, dims):
+            if v < self[d].min() or v > self[d].max():
+                raise ValueError('Start value {} out of range for variable {}.'
+                                 .format(v, d))
         stream = Stream(self, x, y, xvar, yvar, style=style, 
                         maxPoints=maxPoints, method=method, extract=extract)
 

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -222,6 +222,21 @@ class TestBats2d(unittest.TestCase):
 
         # Test adding streams via "add_stream_scatter":
         self.mhd.add_stream_scatter('ux','uz',target=ax,narrow=1)
+
+    def testGetStreamBad(self):
+        """Get a streamline with a start point outside the input grid"""
+        with self.assertRaises(ValueError) as cm:
+            # X range is -220 to 31 (Z==0 is in range)
+            self.mhd.get_stream(50, 0, 'ux', 'uz', method='rk4')
+        self.assertEqual(
+            'Start value 50 out of range for variable x.',
+            str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            # Z range is -124 to 124 (X==0 is in range)
+            self.mhd.get_stream(0, 150, 'ux', 'uz', method='rk4')
+        self.assertEqual(
+            'Start value 150 out of range for variable z.',
+            str(cm.exception))
         
 class TestMagGrid(unittest.TestCase):
     '''


### PR DESCRIPTION
This PR selects specific versions of all our dependencies so that we're explicitly testing the oldest supported version of everything. This includes rearranging how the pip installs are done so we get the requested version of numpy (Closes #366). By necessity this also gets the pybats tests working on matplotlib 1.5.1 (Closes #421). And to help make it all work there's a quick shell script that builds conda environments and runs the tests in them, basically mimicking CI so we don't have to open a PR to test against a bunch of versions. Oh and it fixes omni and omni-related tests when running the tests with a working directory other than the test directory.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
