### PR TITLE
Update CI to CDF 3.8.0.1 (Closes #400)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
  # Make sure new packages don't override numpy version
  - pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
  - pip freeze #summarize what we have for debug purposes
- - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz; tar xzf cdf37_1-dist-cdf.tar.gz; cd cdf37_1-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
+ - wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; cd cdf38_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME install; cd ..
 
 script:
  - python setup.py install

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -12,7 +12,7 @@ sudo aptitude install libblas-dev liblapack-dev
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash ./Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
 # download/install CDF
-wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf37_1/linux/cdf37_1-dist-cdf.tar.gz; tar xzf cdf37_1-dist-cdf.tar.gz; pushd cdf37_1-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
+wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; pushd cdf38_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
 source ${HOME}/cdf/bin/definitions.B
 
 # For the most part, these versions are: what's the earliest we support,


### PR DESCRIPTION
This PR changes the Travis CI config to build the latest 3.8.0.1 version of the CDF library (the tarball is labeled 3.8.0 but the library reports as 3.8.0.1). pycdf has been tested against this version (Closes #400)

Note that at this point (and even with #422) we're only testing against the latest CDF library, not earlier ones, but that's a question for another day (#423).

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
