### PR TITLE
pycdf: warn default time type is about to change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,8 @@ pycdf
  - istp.nanfill function to replace fill values with NaN
  - Warn if make CDF without explicitly setting backward compatible mode
    (either true or false); default will change to NOT backward compatible.
+ - Warn if assign datetime to a variable without specifying a type;
+   default will change to CDF_TIME_TT2000.
  - Fix epoch_to_num with newer versions of matplotlib.
 pybats
  - Updated gitm.GitmBin reader to fix failures in Python 3.x.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -49,7 +49,9 @@ Deprecations and removals
 explicitly setting backward compatible or not backward compatible
 (:meth:`~spacepy.pycdf.Library.set_backward`). The default is
 still to make backward-compatible CDFs, but this will change in
-0.3.0.
+0.3.0. Similarly it now warns if creating a time variable without
+specifying a time type; the default is still to use EPOCH or
+EPOCH16, but this will change to TIME_TT2000 in 0.3.0.
 
 Quaternion math functions have been moved to
 :mod:`~spacepy.coordinates`; using the functions in


### PR DESCRIPTION
This PR adds warnings and documentation that the default time type will change from CDF_EPOCH/CDF_EPOCH16 to CDF_TIME_TT2000 in the next release, per #198.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #)