### PR TITLE
toolbox.get_url: fix last modified dates on locales other than C

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1178,7 +1178,14 @@ def get_url(url, outfile=None, reporthook=None, cached=False,
         headers = r.info()
     modified = headers.get('Last-Modified', None)
     if modified is not None:
-        modified = datetime.datetime.strptime(modified, "%a, %d %b %Y %X GMT")
+        # strptime is affected by locale (including the month name) but the
+        # header is a constant format, so massage
+        modified = modified.split()[1:5] # Get rid of day of week and 'GMT'
+        modified[1] = str(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                           'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']\
+                          .index(modified[1]) + 1) # Make month numerical
+        modified = datetime.datetime.strptime(
+            ' '.join(modified), "%d %m %Y %H:%M:%S")
         modified = calendar.timegm(modified.timetuple())
     if cached:
         if outfile is None:


### PR DESCRIPTION
toolbox.get_url tried to be fancy and use strptime %a and %X to parse the last modified headers. Unfortunately those formats are locale-dependent, whereas the http headers are universal. This PR changes the parsing to specify the format and avoid locale-specific names for months and day-of-week.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A, see below) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

This isn't something that can be really handled with a unit test, but running `integration_toolbox.py` (the integration test) with a locale set to something that uses e.g. 12-hour time or non-English names should fail before this PR and pass after.

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

