### PR TITLE
Fix handling of OMNI databases without UTC

### DIFF
--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -374,8 +374,17 @@ def omnirange(dbase='QDhourly'):
               'Test': testfln}
     if dbase not in infile:
         raise NotImplementedError('')
+    # Possible time variables in the HDF file and their ticktock dtype
+    timeinfo = [('UTC', 'UTC'), ('Epoch', 'ISO'), ('RDT', 'RDT')]
     with h5.File(infile[dbase], mode='r') as hfile:
-        tt = spt.Ticktock([hfile['UTC'][0], hfile['UTC'][-1]])
+        for varname, dtype in timeinfo:
+            if varname in hfile:
+                tt = spt.Ticktock([hfile[varname][0], hfile[varname][-1]],
+                                  dtype=dtype)
+                break
+        else:
+            raise ValueError('Cannot find time variable in {}'
+                             .format(infile[dbase]))
     start, end = tt.UTC
     
     return start, end


### PR DESCRIPTION
fe42d8a4e138e7a4a2cc12fabdd1d301b98d499e switched away from using RDT to determine the start/end time of an omni database, in favor of UTC. Unfortunately UTC is not stored in the OMNI2 HDF5 files, but generated on read. This PR tries (in order) UTC, Epoch/ISO string (for OMNI2), and RDT (as a fallback.)

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A, see below) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

This isn't possible to unit test since we don't require a downloaded current OMNI2 database for unit tests. However, without the fix integration_omni.py should fail (and succeed with.)