### PR TITLE
toolbox.bootHisto: use RNG seed; make test deterministic.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -69,6 +69,7 @@ toolbox
  - New functions quaternionFromMatrix/quaternionToMatrix to convert between
    quaternions and 3D rotation matrices.
  - Fix human_sort; this had been broken since 0.1.6.
+ - Fix function bootHisto to pass through RNG seed if provided
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1844,7 +1844,7 @@ def bootHisto(data, inter=90., n=1000, seed=None,
     histogram_kwargs['bins'] = bin_edges
     ci_low, ci_high = spacepy.poppy.boots_ci(
         data, n, inter,
-        lambda x: np.histogram(x, **histogram_kwargs)[0],
+        lambda x: np.histogram(x, **histogram_kwargs)[0], seed=seed,
         nretvals=len(bin_edges) - 1)
     if not plot and all([x is None for x in (target, figsize, loc)]):
         return bin_edges, ci_low, ci_high, sample

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -440,12 +440,13 @@ class SimpleFunctionTests(unittest.TestCase):
         numpy.testing.assert_equal(
             [  7,  45, 149, 283, 272, 162,  71,   9,   0,   2], sample)
         #This is a very coarse chunk-check to allow for variations in
-        #RNGs. Values from 100000 iterations
+        #RNGs; by using the same seed it should be deterministic on a
+        #given RNG. Values from 100000 iterations
         numpy.testing.assert_allclose(
-            [3.,  34., 131., 260., 249., 143.,  58.,   4.,   0.,   0.],
+            [3.,  35., 131., 260., 249., 143.,  58.,   4.,   0.,   0.],
             ci_low, atol=2, rtol=1e-2)
         numpy.testing.assert_allclose(
-            [12.,  56., 168., 306., 295., 181.,  84.,  14.,   0.,   5.],
+            [12.,  56., 168., 307., 295., 181.,  85.,  14.,   0.,   5.],
             ci_high, atol=2, rtol=1e-2)
 
     def test_logspace(self):


### PR DESCRIPTION
`bootHisto` accepts a `seed` argument to specify a seed for the RNG. Unfortunately this was not properly passed through to the underlying bootstrap function, which made `bootHisto` nondeterministic even on a single machine with a constant seed. The tests used this functionality to avoid random failures; since this didn't work, there was a cron job CI failure on master.

This PR passes through the `seed` argument properly. This results in a slight shift in the expected value in the tests, since the seed  is now being applied in the test.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A)Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
