### PR TITLE
Update dependency versions in README and remove legacy numpy workaround in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ SpacePy supports both Python 2.7 and 3.x.
 ### Dependencies
 
 SpacePy has a number of well-maintained dependencies, most of which are automatically installed by ```pip```. These include:
- - numpy (>=1.6, !=1.15.0)
- - scipy (>=0.10)
+ - numpy (>=1.10, !=1.15.0)
+ - scipy (>=0.11)
  - matplotlib (>=1.5)
  - h5py
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -336,18 +336,10 @@ class QuaternionFunctionTests(unittest.TestCase):
         ortho_test = np.dot(matrix, matrix.transpose())
         np.testing.assert_array_almost_equal(
             ortho_test, np.identity(3))
-        try:
-            det = np.linalg.det(matrix)
-        except AttributeError: # det new in numpy 1.8.0
-            det = matrix[0, 0] * matrix[1, 1] * matrix[2, 2] \
-                  + matrix[0, 1] * matrix[1, 2] * matrix[2, 0] \
-                  + matrix[0, 2] * matrix[1, 0] * matrix[2, 1] \
-                  - matrix[0, 2] * matrix[1, 1] * matrix[2, 0] \
-                  - matrix[0, 1] * matrix[1, 0] * matrix[2, 2] \
-                  - matrix[0, 0] * matrix[1, 2] * matrix[2, 1]
+        det = np.linalg.det(matrix)
         self.assertTrue(det > 0) # Proper?
-        invect = np.array([[5, 3, 2], [1, 0, 0], [.2, 5, 20],
-                              [0, 2, 2]])
+        invect = np.array([[5, 3, 2], [1, 0, 0],
+                           [0.2, 5, 20], [0, 2, 2]])
         # Test matrix vs. quaternion rotation, single vector
         expected = spc.quaternionRotateVector(Qin, invect[1, :])
         actual = np.dot(matrix, invect[1, :])


### PR DESCRIPTION
Resolves #431 

Changes:
- A workaround in `test_coordinates` for `numpy` versions < 1.8 is no longer required as SpacePy's minimum supported version is now 1.10. The workaround has been removed.
- The dependencies list in `README.md` has been updated in line with the `requirements.txt` and the docs.

Checklist:
- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] [N/A] New code has inline comments where necessary
- [x] [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] [N/A] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] [N/A] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
