### PR TITLE
Fix irbem build on Raspberry Pi

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ irbempy
  - Rev620 adds IGRF13 coefficients
  - Add conversion so all systems supported by coordinates can be passed
    to IRBEMlib routines
+ - Fix compilation on Raspberry Pi
 plot
  - utils.EventClicker support for non-line plots (e.g. pcolor)
  - New method for adding arrows to lines in utils

--- a/setup.py
+++ b/setup.py
@@ -548,6 +548,7 @@ class build(_build):
         with open(fln, 'w') as f:
             f.write(filestr)
 
+        print('Building irbem library...')
         # compile (platform dependent)
         os.chdir('source')
         comppath = {
@@ -567,7 +568,8 @@ class build(_build):
         if fcompiler == 'gnu':
             if bit == 64:
                 compflags = '-m64 ' + compflags
-        if fcompiler == 'gnu95':
+        if fcompiler == 'gnu95' and not os.uname()[4].startswith('arm'):
+            # Raspberry Pi doesn't have this switch and assumes 32-bit
             compflags = '-m{0} '.format(bit) + compflags
         if fcompiler.startswith('intel'):
             if bit == 32:


### PR DESCRIPTION
irbem didn't build on Raspberry Pi because the `-m32` bit-size option isn't supported on Pi. This PR fixes that by just nixing that compiler option on ARM. It's possible other ARM systems might support this, but even then they might not require this. If necessary, in the future we can do a direct gfortran call for a toy program with the flag and if it fails, remove it. For now, though, this is a straightforward solution that works. Closes #23.

In the process I added another line of output so it was clear when the IRBEM build started vs. the intents stuff.

The irbem tests run with this fix (currently running other tests; if they fail, that will likely be a separate issue.)

Thanks to @scivision for help in debugging this as part of a PyHC hackathon.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
