### PR TITLE
Deprecate toolbox.feq (Closes #412)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -70,6 +70,7 @@ toolbox
    quaternions and 3D rotation matrices.
  - Fix human_sort; this had been broken since 0.1.6.
  - Fix function bootHisto to pass through RNG seed if provided
+ - Deprecate function feq in favor of numpy.isclose.
 
 Changes in Version 0.2.1 (2019-10-02)
 =====================================

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -53,12 +53,15 @@ still to make backward-compatible CDFs, but this will change in
 specifying a time type; the default is still to use EPOCH or
 EPOCH16, but this will change to TIME_TT2000 in 0.3.0.
 
+:func:`~spacepy.pybats.rim.fix_format` is now deprecated, as
+:class:`~spacepy.pybats.rim.Iono` can now read these files directly.
+
 Quaternion math functions have been moved to
 :mod:`~spacepy.coordinates`; using the functions in
 :mod:`~spacepy.toolbox` is deprecated.
 
-:func:`~spacepy.pybats.rim.fix_format` is now deprecated, as
-:class:`~spacepy.pybats.rim.Iono` can now read these files directly.
+:func:`~spacepy.toolbox.feq` is deprecated; numpy 1.7 added the equivalent
+:func:`~numpy.isclose`.
 
 Dependency requirements
 ***********************

--- a/spacepy/data_assimilation.py
+++ b/spacepy/data_assimilation.py
@@ -6,7 +6,6 @@ from numpy import shape, dot, eye, set_printoptions, diag, sum
 import numpy as np
 from numpy.linalg import svd
 import pdb
-from spacepy.toolbox import feq
 
 __contact__ = 'Josef Koller, jkoller@lanl.gov'
 
@@ -410,7 +409,7 @@ class ensemble(object):
         # create L vector where random noise will be added
         erridx = np.array([],dtype=int)
         for Lval in PSDdata['Lstar']:
-            Lidx = np.where( feq(Lval,Lgrid) )[0]
+            Lidx = np.where( np.isclose(Lval,Lgrid) )[0]
             erridx = np.append(erridx,np.array([int(Lidx)]))
 
         # calculate the rel. average uncertainty based on (obs -
@@ -475,7 +474,7 @@ class ensemble(object):
         #erridx = np.array([False]*len(Lgrid))
         erridx = np.array([],dtype=int)
         for Lval in Lobs:
-            Lidx = np.where( feq(Lval,Lgrid) )[0]
+            Lidx = np.where( np.isclose(Lval,Lgrid) )[0]
             erridx = np.append(erridx,np.array([int(Lidx)]))
 
         # compute residual
@@ -545,7 +544,7 @@ def average_window(PSDdata, Lgrid):
     # run through all unique grid-points and compute average observation
     for i, iL in enumerate(tmpLobs):
         # identify idex of each unique grid-point
-        idx = np.where(feq(iL,Lobs))
+        idx = np.where(np.isclose(iL,Lobs))
         # compute average observation for each unique grid-point
         tmpy[i] = np.average(y[idx])
 
@@ -748,7 +747,7 @@ def assimilate_JK(dd):
         # add model error
         relstd = np.zeros(nens)
         for yval, iobs in zip(y, range(len(y))):
-            idx = np.where( feq(L[iobs],Lgrid) )
+            idx = np.where( np.isclose(L[iobs],Lgrid) )
             relstd[:] = 0.5*( yval - HA[iobs,:] )
             A[idx,:] = np.random.normal( HA[iobs,:], np.abs(relstd))
             idx2 = np.where(A[idx,:] < minPSD); A[idx,idx2] = minPSD # add min flux here
@@ -815,7 +814,7 @@ def addmodelerror_old2(dd, A, y, L):
         NLs = int(round( (L2-L1)/dL ) + 1 )
         for Lpos in linspace(L1, L2, NLs):
             #print dL, L1, L2, NLs
-            index = where( feq(Lpos,Lgrid) ) # use float point comparison
+            index = where( np.isclose(Lpos,Lgrid) ) # use float point comparison
             stdev = 0.5*abs( yval - mean(A[index,:]) )
             #print Lpos
             center = reshape( A[index,:], (nens) )
@@ -848,7 +847,7 @@ def addmodelerror_old(dd, A, y, L):
         NLs = int(round( (L2-L1)/dL ) + 1 )
         for Lpos in np.linspace(L1, L2, NLs):
             #print dL, L1, L2, NLs
-            index = np.where( feq(Lpos,Lgrid) ) # use float point comparison
+            index = np.where( np.isclose(Lpos,Lgrid) ) # use float comparison
             stdev = 0.5*np.abs( yval - np.mean(A[index,:]) )
             #print Lpos
             center = np.reshape( A[index,:], (nens) )

--- a/spacepy/irbempy/irbempy.py
+++ b/spacepy/irbempy/irbempy.py
@@ -212,8 +212,8 @@ def get_Bfield(ticks, loci, extMag='T01STORM', options=[1,0,0,0,0], omnivals=Non
             xin1[i],xin2[i],xin3[i], magin[:,i])
 
         # take out all the odd 'bad values' and turn them into NaN
-        if tb.feq(Blocal,badval): Blocal = np.NaN
-        BxyzGEO[np.where( tb.feq(BxyzGEO, badval)) ] = np.NaN
+        if np.isclose(Blocal,badval): Blocal = np.NaN
+        BxyzGEO[np.where( np.isclose(BxyzGEO, badval)) ] = np.NaN
 
         results['Blocal'][i] = Blocal
         results['Bvec'][i,:] = BxyzGEO
@@ -291,9 +291,9 @@ def find_Bmirror(ticks, loci, alpha, extMag='T01STORM', options=[1,0,0,0,0], omn
             iyearsat[i],idoysat[i],secs[i], xin1[i],xin2[i],xin3[i], alpha, magin[:,i])
 
         # take out all the odd 'bad values' and turn them into NaN
-        if tb.feq(blocal,badval): blocal = np.NaN
-        if tb.feq(bmirr,badval) : bmirr  = np.NaN
-        GEOcoord[np.where( tb.feq(GEOcoord,badval)) ] = np.NaN
+        if np.isclose(blocal,badval): blocal = np.NaN
+        if np.isclose(bmirr,badval) : bmirr  = np.NaN
+        GEOcoord[np.where( np.isclose(GEOcoord,badval)) ] = np.NaN
 
         results['Blocal'][i] = blocal
         results['Bmirr'][i] = bmirr	
@@ -362,8 +362,8 @@ def find_magequator(ticks, loci, extMag='T01STORM', options=[1,0,0,0,0], omnival
             iyearsat[i],idoysat[i],secs[i], xin1[i],xin2[i],xin3[i],magin[:,i])
 
         # take out all the odd 'bad values' and turn them into NaN
-        if tb.feq(bmin,badval): bmin = np.NaN
-        GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+        if np.isclose(bmin,badval): bmin = np.NaN
+        GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
 
         results['Bmin'][i] = bmin
         results['loci'][i] = GEOcoord
@@ -471,8 +471,8 @@ def find_LCDS(ticks, alpha, extMag='T01STORM', options=[1,0,0,0,0], omnivals=Non
                 iyearsat[0],idoysat[0],secs[0], xin1[0],xin2[0],xin3[0],magin[:,0])
 
             # take out all the odd 'bad values' and turn them into NaN
-            if tb.feq(bmin,badval): bmin = np.NaN
-            GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+            if np.isclose(bmin,badval): bmin = np.NaN
+            GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
             #Now get Lstar at this location...
             if GEOcoord[0]!=np.NaN:
                 pos1 = spc.Coords(GEOcoord, 'GEO', 'car')
@@ -507,8 +507,8 @@ def find_LCDS(ticks, alpha, extMag='T01STORM', options=[1,0,0,0,0], omnivals=Non
                 iyearsat[0],idoysat[0],secs[0], xin1[0],xin2[0],xin3[0],magin[:,0])
 
             # take out all the odd 'bad values' and turn them into NaN
-            if tb.feq(bmin,badval): bmin = np.NaN
-            GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+            if np.isclose(bmin,badval): bmin = np.NaN
+            GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
             #Now get Lstar at this location...
             if GEOcoord[0]!=np.NaN:
                 pos2 = spc.Coords(GEOcoord, 'GEO', 'car')
@@ -541,8 +541,8 @@ def find_LCDS(ticks, alpha, extMag='T01STORM', options=[1,0,0,0,0], omnivals=Non
                 bmin, GEOcoord = oplib.find_magequator1(kext,options,sysaxes,\
                     iyearsat[0],idoysat[0],secs[0], xin1[0],xin2[0],xin3[0],magin[:,0])
                 # take out all the odd 'bad values' and turn them into NaN
-                if tb.feq(bmin,badval): bmin = np.NaN
-                GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+                if np.isclose(bmin,badval): bmin = np.NaN
+                GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
                 #print('bmin, GEOcoord = {0},{1}'.format(bmin, GEOcoord))
                 if not (np.isnan(bmin)):
                     #Now get Lstar at this location...
@@ -669,8 +669,8 @@ def find_LCDS_K(ticks, K, extMag='T01STORM', options=[1,1,3,0,0], omnivals=None,
                 iyearsat[0],idoysat[0],secs[0], xin1[0],xin2[0],xin3[0],magin[:,0])
 
             # take out all the odd 'bad values' and turn them into NaN
-            if tb.feq(bmin,badval): bmin = np.NaN
-            GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+            if np.isclose(bmin,badval): bmin = np.NaN
+            GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
             #Now get Lstar at this location...
             if np.isfinite(GEOcoord[0]):
                 pos1 = spc.Coords(GEOcoord, 'GEO', 'car')
@@ -723,8 +723,8 @@ def find_LCDS_K(ticks, K, extMag='T01STORM', options=[1,1,3,0,0], omnivals=None,
                 iyearsat[0],idoysat[0],secs[0], xin1[0],xin2[0],xin3[0],magin[:,0])
 
             # take out all the odd 'bad values' and turn them into NaN
-            if tb.feq(bmin,badval): bmin = np.NaN
-            GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+            if np.isclose(bmin,badval): bmin = np.NaN
+            GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
             #Now get Lstar at this location...
             if np.isfinite(GEOcoord[0]):
                 pos2 = spc.Coords(GEOcoord, 'GEO', 'car')
@@ -766,8 +766,8 @@ def find_LCDS_K(ticks, K, extMag='T01STORM', options=[1,1,3,0,0], omnivals=None,
                 bmin, GEOcoord = oplib.find_magequator1(kext,options,sysaxes,\
                     iyearsat[0],idoysat[0],secs[0], xin1[0],xin2[0],xin3[0],magin[:,0])
                 # take out all the odd 'bad values' and turn them into NaN
-                if tb.feq(bmin,badval): bmin = np.NaN
-                GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+                if np.isclose(bmin,badval): bmin = np.NaN
+                GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
                 #print('bmin, GEOcoord = {0},{1}'.format(bmin, GEOcoord))
                 if not (np.isnan(bmin)):
                     #Now get Lstar at this location...
@@ -855,8 +855,8 @@ def AlphaOfK(ticks, loci, K, extMag='T01STORM', options=[0,0,3,0,0], omnivals=No
                          iyearsat[i],idoysat[i],secs[i], xin1[i],xin2[i],xin3[i],magin[:,i])
 
         # take out all the odd 'bad values' and turn them into NaN
-        if tb.feq(bmin,badval): bmin = np.NaN
-        GEOcoord[np.where( tb.feq(GEOcoord, badval)) ] = np.NaN
+        if np.isclose(bmin,badval): bmin = np.NaN
+        GEOcoord[np.where( np.isclose(GEOcoord, badval)) ] = np.NaN
 
         pa0 = 90 #start with equatorially mirroring
         #Now get K for initial alpha at this location...
@@ -979,9 +979,9 @@ def find_footpoint(ticks, loci, extMag='T01STORM', options=[1,0,3,0,0], hemi='sa
             iyearsat[i], idoysat[i], secs[i], xin1[i], xin2[i], xin3[i], alt, hemi_flag, magin[:,i])
 
         # take out all the odd 'bad values' and turn them into NaN
-        if tb.feq(bfootmag,badval): bmin = np.NaN
-        xfoot[np.where( tb.feq(xfoot, badval)) ] = np.NaN
-        bfoot[np.where( tb.feq(bfoot, badval)) ] = np.NaN
+        if np.isclose(bfootmag,badval): bmin = np.NaN
+        xfoot[np.where( np.isclose(xfoot, badval)) ] = np.NaN
+        bfoot[np.where( np.isclose(bfoot, badval)) ] = np.NaN
 
         results['Bfoot'][i] = bfootmag
         results['loci'][i] = xfoot
@@ -1316,7 +1316,7 @@ def get_AEP8(energy, loci, model='min', fluxtype='diff', particles='e'):
         print('Warning: coords need to be either a spacepy.coordinates.Coords instance or a list of [BBo, L]')
         
     
-    flux[np.where( tb.feq(flux, d['badval'])) ] = np.NaN
+    flux[np.where( np.isclose(flux, d['badval'])) ] = np.NaN
     
     return flux[0,0]
     
@@ -1455,17 +1455,17 @@ def _get_Lstar(ticks, loci, alpha, extMag='T01STORM', options=[1,0,0,0,0], omniv
     lm, lstar, bmirr, bmin, xj, mlt = func(*args)
 
     # take out all the odd 'bad values' and turn them into NaN
-    lm[np.where( tb.feq(lm,d['badval'])) ] = np.NaN
-    lstar[np.where( tb.feq(lstar,d['badval'])) ] = np.NaN
-    bmin[np.where( tb.feq(bmin,d['badval'])) ] = np.NaN
-    xj[np.where( tb.feq(xj,d['badval'])) ] = np.NaN
-    mlt[np.where( tb.feq(mlt,d['badval'])) ] = np.NaN
+    lm[np.where( np.isclose(lm,d['badval'])) ] = np.NaN
+    lstar[np.where( np.isclose(lstar,d['badval'])) ] = np.NaN
+    bmin[np.where( np.isclose(bmin,d['badval'])) ] = np.NaN
+    xj[np.where( np.isclose(xj,d['badval'])) ] = np.NaN
+    mlt[np.where( np.isclose(mlt,d['badval'])) ] = np.NaN
 
     results = {}
     if no_shell_splitting:
         results['Lm'] = lm[0:nTAI][:,None]
         results['Lstar'] = lstar[0:nTAI][:,None]
-        bmirr[np.where( tb.feq(bmirr,d['badval'])) ] = np.NaN
+        bmirr[np.where( np.isclose(bmirr,d['badval'])) ] = np.NaN
         results['Blocal'] = bmirr[0:nTAI]
         results['Bmirr'] = results['Blocal'][:,None]
         results['Bmin'] = bmin[0:nTAI]
@@ -1474,7 +1474,7 @@ def _get_Lstar(ticks, loci, alpha, extMag='T01STORM', options=[1,0,0,0,0], omniv
     else:		
         results['Lm'] = lm[0:nTAI, 0:nalpha]
         results['Lstar'] = lstar[0:nTAI, 0:nalpha]
-        bmirr[np.where( tb.feq(bmirr, d['badval'])) ] = np.NaN
+        bmirr[np.where( np.isclose(bmirr, d['badval'])) ] = np.NaN
         results['Bmirr'] = bmirr[0:nTAI, 0:nalpha]
         results['Bmin'] = bmin[0:nTAI]
         results['Xj'] = xj[0:nTAI, 0:nalpha]

--- a/spacepy/radbelt.py
+++ b/spacepy/radbelt.py
@@ -17,7 +17,6 @@ from spacepy import help
 import numpy as np
 import spacepy.time as st
 import pdb
-import spacepy.toolbox as tb
 
 __contact__ = 'Josef Koller, jkoller@lanl.gov'
 
@@ -331,7 +330,7 @@ class RBmodel(object):
                         # average observation
                         for j, iL in enumerate(lstar):
                             # identify idex of grid-point
-                            idx = np.where(tb.feq(iL,tmplstar))
+                            idx = np.where(np.isclose(iL,tmplstar))
                             # assign observation for grid-point
                             psd[j] = psd[j] + tmppsd[idx]
                             # add for number of observations
@@ -784,7 +783,7 @@ class RBmodel(object):
                     # print assimilated result
                     Hx = np.zeros_like(y)
                     for iL,Lstar in enumerate(Lobs):
-                        idx = np.where(tb.feq(self.Lgrid,Lstar))
+                        idx = np.where(np.isclose(self.Lgrid,Lstar))
                         Hx[iL] = self.PSDa[idx,i]
                     print(Hx)
                     print(HA)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -601,6 +601,10 @@ def human_sort( l ):
         l.sort()
     return l
 
+@spacepy.deprecated(
+    '0.2.2', 'use numpy.isclose',
+    'use :func:`numpy.isclose`; the ``rtol`` keyword is equivalent to'
+    ' ``precision``.')
 def feq(x, y, precision=0.0000005):
     """
     compare two floating point values if they are equal
@@ -609,6 +613,7 @@ def feq(x, y, precision=0.0000005):
     See Also
     --------
     numpy.allclose
+    numpy.isclose
 
     Parameters
     ----------

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -373,19 +373,31 @@ class SimpleFunctionTests(unittest.TestCase):
         """feq should return true when they are equal"""
         val1 = 1.1234
         val2 = 1.1235
-        self.assertTrue(tb.feq(val1, val2, 0.0001))
-        numpy.testing.assert_array_equal(
-            [False, True, False, False],
-            tb.feq([1., 2., 3., 4.],
-                   [1.25, 2.05, 2.2, 500.1],
-                   0.1)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=DeprecationWarning)
+            self.assertTrue(tb.feq(val1, val2, 0.0001))
+            numpy.testing.assert_array_equal(
+                [False, True, False, False],
+                tb.feq([1., 2., 3., 4.],
+                       [1.25, 2.05, 2.2, 500.1],
+                       0.1)
             )
+        self.assertEqual(2, len(w))
+        for this_w in w:
+            self.assertEqual(DeprecationWarning, this_w.category)
+            self.assertEqual(DeprecationWarning, this_w.category)
+            self.assertEqual('use numpy.isclose', str(this_w.message))
 
     def testfeq_notequal(self):
         """feq should return false when they are not equal"""
         val1 = 1.1234
         val2 = 1.1235
-        self.assertFalse(tb.feq(val1, val2, 0.000005))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=DeprecationWarning)
+            self.assertFalse(tb.feq(val1, val2, 0.000005))
+        self.assertEqual(1, len(w))
+        self.assertEqual(DeprecationWarning, w[0].category)
+        self.assertEqual('use numpy.isclose', str(w[0].message))
 
     def test_medAbsDev(self):
         """medAbsDev should return a known range for given random input"""


### PR DESCRIPTION
This PR marks `toolbox.feq` as deprecated, notes such in the release notes, and replaces all SpacePy usage of `feq` with `numpy.isclose`, closes #412.

`feq` and `isclose` have different values for `rtol` (`precision` in `feq`), but I have not put in an explicit `rtol` in every new `isclose` call to keep them identical. It appears that all the `feq` calls were a general "should be exactly equal but, hey, it's floating point" not "the 5e-7 tolerance is exactly what I was looking for."

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
