### PR TITLE
test_pycdf_istp: suppress a deprecation warning that we know about

### DIFF
--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -736,7 +736,16 @@ class FileTests(ISTPTestsBase):
 
     def testTimes(self):
         """Compare filename to Epoch times"""
-        self.cdf['Epoch'] = [datetime.datetime(1999, 1, 1, i) for i in range(3)]
+        warnings.filterwarnings(
+            'ignore',
+            message=r'^No type specified for time input; assuming .*$',
+            category=DeprecationWarning,
+            module='^spacepy.pycdf$')
+        try:
+            self.cdf['Epoch'] = [datetime.datetime(1999, 1, 1, i)
+                                 for i in range(3)]
+        finally:
+            del warnings.filters[0]
         self.cdf['Epoch'].append(datetime.datetime(1999, 1, 2, 0))
         errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
         self.assertEqual(1, len(errs))
@@ -744,7 +753,16 @@ class FileTests(ISTPTestsBase):
         del self.cdf['Epoch'][-1]
         errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
         self.assertEqual(0, len(errs))
-        self.cdf['Epoch'] = [datetime.datetime(1999, 1, 2, i) for i in range(3)]
+        warnings.filterwarnings(
+            'ignore',
+            message=r'^No type specified for time input; assuming .*$',
+            category=DeprecationWarning,
+            module='^spacepy.pycdf$')
+        try:
+            self.cdf['Epoch'] = [datetime.datetime(1999, 1, 2, i)
+                                 for i in range(3)]
+        finally:
+            del warnings.filters[0]
         errs = spacepy.pycdf.istp.FileChecks.times(self.cdf)
         self.assertEqual(1, len(errs))
         self.assertEqual('Epoch: date 19990102 doesn\'t match file '


### PR DESCRIPTION
This PR cleans up a pycdf ISTP test that was emitting a deprecation warning. The code's okay with choosing any time type, but a `DeprecationWarning` is thrown right now because the default is changing (#426). This just suppresses the warning until we're through the transition  (#198).

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
