### PR TITLE
Increased test coverage of datamodel.py

### DIFF
--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -444,11 +444,7 @@ def dmfilled(shape, fillval=0, dtype=None, order='C', attrs=None):
         
     """
     a = dmarray(numpy.empty(shape, dtype, order), attrs=attrs)
-    try:
-        a.fill(fillval)
-    except TypeError:
-        obj = numpy.core.numeric._maketup(dtype, fillval)
-        a.fill(obj)
+    a.fill(fillval)
     return a
 
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -16,6 +16,7 @@ import os
 import os.path
 import tempfile
 import unittest
+
 try:
     import StringIO
 except ImportError:
@@ -93,6 +94,12 @@ class SpaceDataTests(unittest.TestCase):
         self.assertEqual(sorted(b.keys()),
                          sorted(['1<--pig<--fish<--a', '4<--cat', '1<--dog', '1<--pig<--fish<--b', '5']))
 
+    def test_flatten_function_TypeError(self):
+        """flatten, check the try:except: at the top"""
+        # interesting behavior on what is created
+        self.assertEqual(dm.flatten(np.arange(5)),
+                         {0: 0, 1: 1, 2: 2, 3: 3, 4: 4})
+
     def test_unflatten_function(self):
         """Unflatten should unflatten a flattened SpaceData"""
         a = dm.SpaceData()
@@ -110,6 +117,21 @@ class SpaceDataTests(unittest.TestCase):
         self.assertEqual(sorted(a['1'].keys()), sorted(c['1'].keys()))
         self.assertEqual(sorted(a['1']['pig'].keys()), sorted(c['1']['pig'].keys()))
         self.assertEqual(sorted(a['1']['pig']['fish'].keys()), sorted(c['1']['pig']['fish'].keys()))
+
+    def test_unflatten_function_TypeError(self):
+        """unflatten, check the try:except: at the top"""
+        # interesting behavior on what is created
+        self.assertEqual(dm.unflatten(np.arange(5)),
+                         {0: 0, 1: 1, 2: 2, 3: 3, 4: 4})
+
+    def test_unflatten_function_nonflat(self):
+        """unflatten will error for a nested input"""
+        a = dm.SpaceData()
+        a['1'] = dm.SpaceData(dog=5, pig=dm.SpaceData(fish=dm.SpaceData(a='carp', b='perch')))
+        a['4'] = dm.SpaceData(cat='kitty')
+        a['5'] = 4
+        with self.assertRaises(TypeError):
+            dm.unflatten(a)
 
     def test_flatten_method(self):
         """Flatten should flatted a nested dict"""

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -552,6 +552,15 @@ class dmarrayTests(unittest.TestCase):
         np.testing.assert_equal(tst, ans)
         self.assertEqual(tst.dtype, ans.dtype)
 
+    def test_dmfilled_recarray(self):
+        """dmfilled should fill a recarray"""
+        dt = [('foo', 'f4'), ('bar', 'i2')]
+        tst = dm.dmfilled(4, fillval=3, dtype=dt)
+        a = np.empty((4, ), dt)
+        a.fill(3)
+        ans = dm.dmarray(a)
+        np.testing.assert_equal(tst, ans)
+
     def test_toRecArray_contents(self):
         '''a record array can be created from a SpaceData, keys and values equal'''
         sd = dm.SpaceData()


### PR DESCRIPTION
- [X ] Pull request has descriptive title
- [ X] Pull request gives overview of changes
- [ X] New code has inline comments where necessary
- [ n/a] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ n/a] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ X ] New features and bug fixes should have unit tests
- [ X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

Increased unit test coverage for `datamodel.py`, see #305 and #438 