### PR TITLE
Remove on-import messages; change others to warnings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,7 @@ time
  - now and today return UTC times, not local.
  - matplotlib no longer required, including RDT and randomDate.
  - Add support for conversion to/from astropy.time.Time
+ - Warn about out-of-date leapseconds files (configurable option).
 toolbox
  - New function get_url to retrieve data from a URL
  - Change update to retrieve OMNI2 data from SPDF not ViRBO

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Changes in Version 0.2.2 (2020-xx-xx)
 =====================================
 - Document end of support for Python 2
 - Quaternion math functions moved to coordinates module
+- Remove message on first import.
 coordinates
  - Include upstream fix for SPH->RLL coordinate transform
 datamodel

--- a/Doc/source/configuration.rst
+++ b/Doc/source/configuration.rst
@@ -56,6 +56,13 @@ enable_deprecation_warning
   Python behavior. (See :py:mod:`warnings` module for details on custom warning
   filters.)
 
+enable_old_data_warning
+  SpacePy maintains certain databases from external sources, notably the
+  leapsecond database used by :py:mod:`~spacepy.time`. By default
+  :py:exc:`~exceptions.UserWarning` is issued if the leap second database
+  is out of date. Set this option to False to suppress this warning (and
+  warnings about out-of-date data which may be added in the future.)
+
 keepalive
   True to attempt to use HTTP keepalives when downloading data in
   :py:func:`~spacepy.toolbox.update` (default). This is faster when

--- a/Doc/source/configuration.rst
+++ b/Doc/source/configuration.rst
@@ -9,6 +9,12 @@ change between SpacePy releases, so we do not recommend changing the
 configuration file without substantial reason.
 
 ``spacepy.rc`` lives in the per-user SpacePy directory, called ``.spacepy``.
+You can find this directory by::
+
+   >>> import spacepy
+   >>> spacepy.DOT_FLN
+   '/home/username/.spacepy'
+
 On Unix-like operating systems, it is in a user's home directory; on Windows, 
 in the user's Documents and Settings folder. If it doesn't exist, this directory
 (and ``spacepy.rc``) is automatically created when SpacePy is imported.
@@ -23,8 +29,7 @@ contains a single section, ``[spacepy]``.
 The spacepy directory
 =====================
 
-When first imported, spacepy will create a ``.spacepy`` directory in
-your ``$HOME`` folder. If you prefer a different location for this
+If you prefer a different location for the SpacePy
 directory, set the environment variable ``$SPACEPY`` to a location of
 your choice. For example, with a ``csh``, or ``tcsh`` you would::
 
@@ -37,6 +42,9 @@ for the ``bash`` shell you would:
 If you change the default location, make sure you add the environment
 variable ``$SPACEPY`` to your ``.cshrc, .tcshrc,`` or ``.bashrc``
 script.
+
+This directory contains the configuration file and also SpacePy-related
+data, which can be updated with :func:`~spacepy.toolbox.update`.
 
 Available configuration options
 ===============================

--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -17,6 +17,9 @@ Windows, see :doc:`install_windows`.)
 For installing the NASA CDF library to support :mod:`~spacepy.pycdf`,
 see the platform-specific instructions linked below.
 
+The first time a user imports SpacePy, it automatically creates the
+:doc:`configuration directory <configuration>`.
+
 If you need further assistance, you can `open an issue
 <https://github.com/spacepy/spacepy/issues>`_.
 

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -99,7 +99,8 @@ Other changes
 Data sources for leapsecond files and :mod:`~spacepy.omni` Qin-Denton
 files have been updated to provide current sources. If present,
 entries in the :doc:`configuration file <configuration>` will still be
-used instead.
+used instead. A (configurable) warning is issued for out-of-date leapsecond
+files.
 
 The representation of leap second intervals in time systems which
 cannot directly represent them has been changed. Formerly times such

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -378,8 +378,6 @@ else:
         DOT_FLN = os.path.expanduser(os.path.join('~', '.spacepy'))
 rcfile = os.path.join(DOT_FLN, 'spacepy.rc')
 if not os.path.exists(DOT_FLN):
-    print("""SpacePy: Space Science Tools for Python
-  See __licence__ and __citation__ for licensing, and help() for HTML help.""")
     import shutil, sys
     datadir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            'data')
@@ -387,11 +385,7 @@ if not os.path.exists(DOT_FLN):
     os.mkdir(DOT_FLN)
     os.mkdir(dataout)
     shutil.copy2(os.path.join(datadir, 'tai-utc.dat'), dataout)
-    print('Data and configuration installed to ' + DOT_FLN)
     _read_config(rcfile)
-    print('Downloading OMNI database and leap seconds table is recommended:'
-          '\n\timport spacepy.toolbox; spacepy.toolbox.update()')
-    print('Thanks for using SpacePy!')
 else:
     _read_config(rcfile)
 

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -384,7 +384,7 @@ if not os.path.exists(DOT_FLN):
     dataout = os.path.join(DOT_FLN, 'data')
     os.mkdir(DOT_FLN)
     os.mkdir(dataout)
-    shutil.copy(os.path.join(datadir, 'tai-utc.dat'), dataout)
+    shutil.copy2(os.path.join(datadir, 'tai-utc.dat'), dataout)
     print('Data and configuration installed to ' + DOT_FLN)
     _read_config(rcfile)
     print('Downloading OMNI database and leap seconds table is recommended:'

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -317,6 +317,7 @@ def _read_config(rcfile):
                 'psddata_url': 'http://spacepy.lanl.gov/repository/psd_dat.sqlite',
                 'support_notice': str(True),
                 'apply_plot_styles': str(True),
+                'enable_old_data_warning': str(True),
                 }
     #Functions to cast a config value; if not specified, value is a string
     str2bool = lambda x: x.lower() in ('1', 'yes', 'true', 'on')
@@ -325,6 +326,7 @@ def _read_config(rcfile):
               'ncpus': int,
               'support_notice': str2bool,
               'apply_plot_styles': str2bool,
+              'enable_old_data_warning': str2bool,
               }
     #SafeConfigParser deprecated in 3.2. And this is hideous, but...
     if hasattr(ConfigParser, 'SafeConfigParser'):

--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -396,34 +396,18 @@ def omnirange(dbase='QDhourly'):
 # check for omni file during import
 import os, datetime
 from spacepy import DOT_FLN, help
-from spacepy.toolbox import loadpickle
-try:
-    import h5py
-    _ext = '.h5'
-except ImportError:
-    _ext = '.pkl'
+import h5py
 
-#dotfln = os.environ['HOME']+'/.spacepy'
-omnifln = os.path.join(DOT_FLN,'data','omnidata{0}'.format(_ext))
-omni2fln = os.path.join(DOT_FLN,'data','omni2data{0}'.format(_ext))
+omnifln = os.path.join(DOT_FLN,'data','omnidata.h5')
+omni2fln = os.path.join(DOT_FLN,'data','omni2data.h5')
 # Test data is stored relative to the test script
 testfln = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])),
-                       'data', 'OMNItest{0}'.format(_ext))
+                       'data', 'OMNItest.h5')
 if not os.path.isfile(testfln): # Hope it's relative to current!
-    testfln = os.path.join(os.path.abspath('data'), 'OMNItest{0}'.format(_ext))
+    testfln = os.path.join(os.path.abspath('data'), 'OMNItest.h5')
 
-if _ext=='.h5':
-    presentQD = h5py.is_hdf5(omnifln)
-    presentO2 = h5py.is_hdf5(omni2fln)
-    if not (presentQD and presentO2):
-        print("Qin-Denton/OMNI2 data not found in current format. This module has limited functionality.")
-        print("Run spacepy.toolbox.update(QDomni=True) to download data")
-else:
-    presentQD = os.path.isfile(omnifln)
-    presentO2 = os.path.isfile(omni2fln)
-    if not (presentQD and presentO2):
-        print("No Qin-Denton/OMNI2 data found. This module has limited functionality.")
-        print("Run spacepy.toolbox.update(QDomni=True) to download data")
-    else:
-        print("Qin-Denton/OMNI2 data not found in current format. This module has limited functionality.")
-        print("Run spacepy.toolbox.update(QDomni=True) to download data")
+presentQD = h5py.is_hdf5(omnifln)
+presentO2 = h5py.is_hdf5(omni2fln)
+if not (presentQD and presentO2):
+    print("Qin-Denton/OMNI2 data not found in current format. This module has limited functionality.")
+    print("Run spacepy.toolbox.update(QDomni=True) to download data")

--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -59,6 +59,8 @@ range set the keyword argument interp to False.
 """
 import bisect, re, os
 import sys
+import warnings
+
 import numpy as np
 from spacepy.datamodel import SpaceData, dmarray, dmcopy, unflatten, readJSONheadedASCII, dmfilled, fromHDF5
 from spacepy.toolbox import tOverlapHalf, indsFromXrange
@@ -409,5 +411,7 @@ if not os.path.isfile(testfln): # Hope it's relative to current!
 presentQD = h5py.is_hdf5(omnifln)
 presentO2 = h5py.is_hdf5(omni2fln)
 if not (presentQD and presentO2):
-    print("Qin-Denton/OMNI2 data not found in current format. This module has limited functionality.")
-    print("Run spacepy.toolbox.update(QDomni=True) to download data")
+    warnings.warn(
+        "Qin-Denton/OMNI2 data not found in current format."
+        " This module has limited functionality."
+        " Run spacepy.toolbox.update(QDomni=True) to download data.")

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -2284,13 +2284,15 @@ def _read_leaps():
     # Check for out of date. The leap second bulletin comes every
     # six months, and that contains information through the following
     # leap second (end of June/Dec)
-    lastknown = max(
-        mtime, datetime.datetime(int(year[-1]), int(mon[-1]), int(day[-1])))
-    goodthrough = datetime.datetime(lastknown.year + int(lastknown.month > 6),
-                                    1 if lastknown.month > 6 else 7, 1)
-    if datetime.datetime.utcnow() > goodthrough:
-        warnings.warn('Leapseconds may be out of date.'
-                      ' Use spacepy.toolbox.update(leapsecs=True)')
+    if spacepy.config['enable_old_data_warning']:
+        lastknown = max(
+            mtime, datetime.datetime(int(year[-1]), int(mon[-1]), int(day[-1])))
+        goodthrough = datetime.datetime(
+            lastknown.year + int(lastknown.month > 6),
+            1 if lastknown.month > 6 else 7, 1)
+        if datetime.datetime.utcnow() > goodthrough:
+            warnings.warn('Leapseconds may be out of date.'
+                          ' Use spacepy.toolbox.update(leapsecs=True)')
 
     TAIleaps = np.zeros(len(secs))
     TAItup = [''] * len(secs)


### PR DESCRIPTION
This PR removes several messages that show up on SpacePy import and changes a few others to warnings. Closes #346.

- Docs are updated to make information about `DOT_FLN` and the `.spacepy` directory more obvious so this information is apparent despite the loss of the first-import message (ac9db898ba1a1bfd9d88d1091c355ea09d648cb7)
- The no OMNI data message is now a warning (trappable) instead of a print statement (a3e41372a1d513354c82908ec084fe351baa6d60). In order to make this less of a mess, this no longer distinguishes between "no HDF5 OMNI data" and "no OMNI data at all" (546a7c01fb6ed6c9985830b45226589fb60fcc20); we stopped using the pickle in 2013 (195704003a775e59726e09a675726e2330eeb7f4).
- To compensate for not having a general `update` message on first import, `time` now checks if the leapsecond file is out of date (defined as "is it possible there was a leapsecond between the last one in the file and now?") (f25c755b21157fd741825d5078c8002919539c23) This requires preserving the mtime on `tai-utc.dat` when first imported (9718f31117c5a144da6acc0c55574d5bc566d9cc). I made this warning configurable (6c50667714c3305eed2f4e48c683ae0b591c8410) but honestly I wonder if that's overkill.
- Finally, with all these other messages in place, the first-import print statement is axed (77062488dab504a2162af083186141d078bf7e1c)

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

The new functionality in here is actually pretty minor, and making unit tests seems more effort than it's worth (it would involve doing a bunch of setting environment variables, making temporary directories, and `reload`ing SpacePy over and over). So I decided to skip unit tests for these warnings.