### PR TITLE
datamodel.readJSONheadedASCII allows a gzip input file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,7 @@ coordinates
 datamodel
  - Fix in SpaceData.toXXX() methods which would fail in some cases, now work as intended
  - Documentation update and default units change in createISTPattrs
+ - readJSONheadedASCII, readJSONMetadata can now accept gzip'ed files
 datamanager
  - New function "rebin", rebin an axis of an array by contents of another
 irbempy

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,7 +39,6 @@ coordinates
 datamodel
  - Fix in SpaceData.toXXX() methods which would fail in some cases, now work as intended
  - Documentation update and default units change in createISTPattrs
- - readJSONheadedASCII, readJSONMetadata can now accept gzip'ed files
 datamanager
  - New function "rebin", rebin an axis of an array by contents of another
 irbempy

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -12,7 +12,6 @@ This document presents user-visible changes in each release of SpacePy.
 ==========
 0.5.0 (2022-xx-xx)
 ------------------
-
 This release marks the end of all support for Python 2. SpacePy now
 requires Python 3.6 or later. Minimum supported versions for other
 dependencies were also increased; see :ref:`release_0_5_0_deps` for details.
@@ -36,6 +35,12 @@ SpacePy 0.5.0. Minimum versions are:
   * matplotlib 3.1
   * numpy 1.15.1
   * scipy 1.0
+
+New features
+************
+`~.datamodel.readJSONheadedASCII` and `~.datamodel.readJSONMetadata`
+now support reading from gzipped input files; filenames ending with
+``.gz`` are assumed to be gzipped.
 
 0.4 Series
 ==========

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1324,7 +1324,7 @@ def readJSONMetadata(fname, **kwargs):
     fname : str
         Filename to read metadata from
 
-        .. versionchanged:: 0.2.2
+        .. versionchanged:: 0.5.0
                 Filename can now be a .gz to indicate the file is gzipped
 
     Other Parameters
@@ -1392,7 +1392,7 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
     fname : str or list
         Filename(s) to read data from
 
-            .. versionchanged:: 0.2.2
+            .. versionchanged:: 0.5.0
                 Filename can now be a .gz to indicate the file is gzipped
 
     Other Parameters

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -162,6 +162,7 @@ The file looks like:
 from __future__ import division
 import copy
 import datetime
+import gzip
 import itertools
 import json
 from functools import partial
@@ -1323,6 +1324,9 @@ def readJSONMetadata(fname, **kwargs):
     fname : str
         Filename to read metadata from
 
+        .. versionchanged:: 0.2.2
+                Filename can now be a .gz to indicate the file is gzipped
+
     Other Parameters
     ----------------
     verbose : bool (optional)
@@ -1338,11 +1342,8 @@ def readJSONMetadata(fname, **kwargs):
     else:
         # also possible in an exploration sense utilizing UnicodeDecodeError
         if fname.endswith('.gz'):
-            import gzip
-            gzh = gzip.GzipFile(filename=fname)
-            lines = gzh.read()
-            gzh.close()
-
+            with gzip.GzipFile(filename=fname) as gzh:
+                lines = gzh.read()
         else:
             with open(fname, 'r') as f:
                 lines = f.read()
@@ -1393,6 +1394,9 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
     ----------
     fname : str or list
         Filename(s) to read data from
+
+            .. versionchanged:: 0.2.2
+                Filename can now be a .gz to indicate the file is gzipped
 
     Other Parameters
     ----------------
@@ -1480,10 +1484,8 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
     for fn in fname:
         if not filelike:
             if fn.endswith('.gz'):
-                import gzip
-                gzh = gzip.GzipFile(filename=fn)
-                mdata = innerloop(gzh, mdata, mdata_copy)
-                gzh.close()
+                with gzip.GzipFile(filename=fn) as gzh:
+                    mdata = innerloop(gzh, mdata, mdata_copy)
             else:
                 with open(fn, 'rb') as fh: # fixes windows bug with seek()
                     mdata = innerloop(fh, mdata, mdata_copy)

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1336,12 +1336,23 @@ def readJSONMetadata(fname, **kwargs):
     if hasattr(fname, 'read'):
         lines = fname.read()
     else:
-        with open(fname, 'r') as f:
-            lines = f.read()
+        # also possible in an exploration sense utilizing UnicodeDecodeError
+        if fname.endswith('.gz'):
+            import gzip
+            gzh = gzip.GzipFile(filename=fname)
+            lines = gzh.read()
+            gzh.close()
+
+        else:
+            with open(fname, 'r') as f:
+                lines = f.read()
 
     # isolate header
     p_srch = re.compile(r"^#(.*)$", re.M)
-    hreg = re.findall(p_srch, lines)
+    try: # from gzip binary, gzip
+        hreg = re.findall(p_srch, lines.decode('latin-1'))
+    except AttributeError:
+        hreg = re.findall(p_srch, lines)
     header = "".join(hreg)
 
     # isolate JSON field

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1340,9 +1340,9 @@ def readJSONMetadata(fname, **kwargs):
     if hasattr(fname, 'read'):
         lines = fname.read()
     else:
-        # also possible in an exploration sense utilizing UnicodeDecodeError
         if fname.endswith('.gz'):
-            with gzip.GzipFile(filename=fname) as gzh:
+            kwargs = {} if str is bytes else {'mode': 'rt', 'encoding': 'latin-1'}
+            with gzip.open(filename=fname, **kwargs) as gzh:
                 lines = gzh.read()
         else:
             with open(fname, 'r') as f:
@@ -1350,10 +1350,7 @@ def readJSONMetadata(fname, **kwargs):
 
     # isolate header
     p_srch = re.compile(r"^#(.*)$", re.M)
-    try:  # from gzip binary, gzip
-        hreg = re.findall(p_srch, lines.decode('latin-1'))
-    except AttributeError:
-        hreg = re.findall(p_srch, lines)
+    hreg = re.findall(p_srch, lines)
     header = "".join(hreg)
 
     # isolate JSON field
@@ -1432,7 +1429,6 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
             del mdata[val] #remove undesired keys
     mdata_copy = dmcopy(mdata)
     def innerloop(fh, mdata, mdata_copy):
-        # also possible in an exploration sense utilizing UnicodeDecodeError
         line = fh.readline()
         if not str is bytes:
             line = line.decode('latin1')
@@ -1484,7 +1480,7 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
     for fn in fname:
         if not filelike:
             if fn.endswith('.gz'):
-                with gzip.GzipFile(filename=fn) as gzh:
+                with gzip.open(filename=fn) as gzh:
                     mdata = innerloop(gzh, mdata, mdata_copy)
             else:
                 with open(fn, 'rb') as fh: # fixes windows bug with seek()

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -841,8 +841,6 @@ class JSONTests(unittest.TestCase):
 
     def readJSONMetadata_keycheck(self, dat):
         """testing of readJSONMetadata to be be reused"""
-        if str is bytes:
-            keys = [unicode(k) for k in self.keys]
         # make sure data has all the keys and no more or less
         for k in dat:
             self.assertTrue(k in self.keys)
@@ -859,37 +857,30 @@ class JSONTests(unittest.TestCase):
     def test_readJSONMetadata_zip(self):
         """readJSONMetadata should read in a zip file"""
         # make a zip file and then remove it when done
+        tmpdirname = tempfile.mkdtemp(suffix='_zip', prefix='readJSONMetadata_')
         try:
-            tmpdirname = tempfile.mkdtemp(suffix='_zip', prefix='readJSONMetadata_')
             archive_name = os.path.join(tmpdirname, os.path.basename(self.filename))
             shutil.copy(self.filename, tmpdirname)
             shutil.make_archive(base_name=archive_name, format='zip', base_dir=tmpdirname)
             dat = dm.readJSONMetadata(archive_name + '.zip')
             self.readJSONMetadata_keycheck(dat)
         finally:
-            try:
-                shutil.rmtree(tmpdirname)
-            except FileNotFoundError:
-                # try triggered before the temp directory could be created, out of disk space?
-                self.fail("Test failed in awkward fashion")
+            shutil.rmtree(tmpdirname)
 
     def test_readJSONMetadata_gzip(self):
         """readJSONMetadata should read in a gzip file"""
         # make a gzip file and then remove it when done
+        tmpdirname = tempfile.mkdtemp(suffix='_gzip', prefix='readJSONMetadata_')
         try:
-            tmpdirname = tempfile.mkdtemp(suffix='_zip', prefix='readJSONMetadata_')
+            gzipname = os.path.join(tmpdirname, os.path.basename(self.filename) + '.gz')
             with open(self.filename, 'rb') as f_in:
-                gzipname = os.path.join(tmpdirname, os.path.basename(self.filename) + '.gz')
                 with gzip.open(gzipname, 'wb') as f_out:
-                    f_out.writelines(f_in)  # py2
+                    tmp = f_in.readlines()
+                    f_out.writelines(tmp)
             dat = dm.readJSONMetadata(gzipname)
             self.readJSONMetadata_keycheck(dat)
         finally:
-            try:
-                shutil.rmtree(tmpdirname)
-            except FileNotFoundError:
-                # try triggered before the temp directory could be created, out of disk space?
-                self.fail("Test failed in awkward fashion")
+            shutil.rmtree(tmpdirname)
 
     def test_readJSONMetadata_badfile(self):
         """readJSONMetadata fails on bad files"""

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -911,7 +911,6 @@ class JSONTests(unittest.TestCase):
                                           [datetime.datetime(2013, 2, 18, 0, 0), datetime.datetime(2013, 2, 18, 0, 5),
                                            datetime.datetime(2013, 2, 18, 0, 0), datetime.datetime(2013, 2, 18, 0, 5)])
 
-
     def test_readJSONheadedASCII(self):
         """readJSONheadedASCII should read the test file"""
         dat = dm.readJSONheadedASCII(self.filename, convert=True)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -810,6 +810,24 @@ class JSONTests(unittest.TestCase):
             spacepy_testing.datadir, '20130218_rbspa_MagEphem_bad.txt')
         self.testdir = tempfile.mkdtemp()
         self.testfile = os.path.join(self.testdir, 'test.cdf')
+        self.keys = ['PerigeePosGeod', 'S_sc_to_pfn', 'S_pfs_to_Bmin', 'Pfs_gsm',
+                     'Pfn_ED_MLAT', 'ED_R', 'Dst', 'DateTime', 'DOY', 'ED_MLON',
+                     'IntModel', 'ApogeePosGeod', 'CD_MLON', 'S_sc_to_pfs',
+                     'GpsTime', 'JulianDate', 'M_ref', 'ED_MLT', 'Pfs_ED_MLAT',
+                     'Bfs_geo', 'Bm', 'Pfn_CD_MLON', 'CD_MLAT', 'Pfs_geo',
+                     'Rsm', 'Pmin_gsm', 'Rgei', 'Rgsm', 'Pfs_CD_MLAT', 'S_total',
+                     'Rgeod_Height', 'Date', 'Alpha', 'M_igrf', 'Pfs_CD_MLT',
+                     'ED_MLAT', 'CD_R', 'PerigeeTimes', 'UTC', 'Pfn_ED_MLT',
+                     'BoverBeq', 'Lsimple', 'Lstar', 'I', 'DipoleTiltAngle',
+                     'K', 'Bmin_gsm', 'S_Bmin_to_sc', 'Bfs_gsm', 'L',
+                     'ApogeeTimes', 'ExtModel', 'Kp', 'Pfs_geod_LatLon',
+                     'MlatFromBoverBeq', 'Pfn_gsm', 'Loss_Cone_Alpha_n', 'Bfn_geo',
+                     'Pfn_CD_MLAT', 'Rgeod_LatLon', 'Pfs_ED_MLT', 'Pfs_CD_MLON',
+                     'Bsc_gsm', 'Pfn_geod_Height', 'Lm_eq', 'Rgse',
+                     'Pfn_geod_LatLon', 'CD_MLT', 'FieldLineType', 'Pfn_CD_MLT',
+                     'Pfs_geod_Height', 'Rgeo', 'InvLat_eq', 'M_used',
+                     'Loss_Cone_Alpha_s', 'Bfn_gsm', 'Pfn_ED_MLON', 'Pfn_geo',
+                     'InvLat', 'Pfs_ED_MLON']
 
     def tearDown(self):
         super(JSONTests, self).tearDown()
@@ -820,32 +838,14 @@ class JSONTests(unittest.TestCase):
     def test_readJSONMetadata(self):
         """readJSONMetadata should read in the file"""
         dat = dm.readJSONMetadata(self.filename)
-        keys = ['PerigeePosGeod', 'S_sc_to_pfn', 'S_pfs_to_Bmin', 'Pfs_gsm',
-                'Pfn_ED_MLAT', 'ED_R', 'Dst', 'DateTime', 'DOY', 'ED_MLON',
-                'IntModel', 'ApogeePosGeod', 'CD_MLON', 'S_sc_to_pfs',
-                'GpsTime', 'JulianDate', 'M_ref', 'ED_MLT', 'Pfs_ED_MLAT',
-                'Bfs_geo', 'Bm', 'Pfn_CD_MLON', 'CD_MLAT', 'Pfs_geo',
-                'Rsm', 'Pmin_gsm', 'Rgei', 'Rgsm', 'Pfs_CD_MLAT', 'S_total',
-                'Rgeod_Height', 'Date', 'Alpha', 'M_igrf', 'Pfs_CD_MLT',
-                'ED_MLAT', 'CD_R', 'PerigeeTimes', 'UTC', 'Pfn_ED_MLT',
-                'BoverBeq', 'Lsimple', 'Lstar', 'I', 'DipoleTiltAngle',
-                'K', 'Bmin_gsm', 'S_Bmin_to_sc', 'Bfs_gsm', 'L',
-                'ApogeeTimes', 'ExtModel', 'Kp', 'Pfs_geod_LatLon',
-                'MlatFromBoverBeq', 'Pfn_gsm', 'Loss_Cone_Alpha_n', 'Bfn_geo',
-                'Pfn_CD_MLAT', 'Rgeod_LatLon', 'Pfs_ED_MLT', 'Pfs_CD_MLON',
-                'Bsc_gsm', 'Pfn_geod_Height', 'Lm_eq', 'Rgse',
-                'Pfn_geod_LatLon', 'CD_MLT', 'FieldLineType', 'Pfn_CD_MLT',
-                'Pfs_geod_Height', 'Rgeo', 'InvLat_eq', 'M_used',
-                'Loss_Cone_Alpha_s', 'Bfn_gsm', 'Pfn_ED_MLON', 'Pfn_geo',
-                'InvLat', 'Pfs_ED_MLON']
         if str is bytes:
-            keys = [unicode(k) for k in keys]
+            keys = [unicode(k) for k in self.keys]
         # make sure data has all the keys and no more or less
         for k in dat:
-            self.assertTrue(k in keys)
-            ind = keys.index(k)
-            del keys[ind]
-        self.assertEqual(len(keys), 0)
+            self.assertTrue(k in self.keys)
+            ind = self.keys.index(k)
+            del self.keys[ind]
+        self.assertEqual(len(self.keys), 0)
 
     def test_readJSONMetadata_badfile(self):
         """readJSONMetadata fails on bad files"""
@@ -854,32 +854,14 @@ class JSONTests(unittest.TestCase):
     def test_readJSONheadedASCII(self):
         """readJSONheadedASCII should read the test file"""
         dat = dm.readJSONheadedASCII(self.filename)
-        keys = ['PerigeePosGeod', 'S_sc_to_pfn', 'S_pfs_to_Bmin', 'Pfs_gsm',
-                'Pfn_ED_MLAT', 'ED_R', 'Dst', 'DateTime', 'DOY', 'ED_MLON',
-                'IntModel', 'ApogeePosGeod', 'CD_MLON', 'S_sc_to_pfs',
-                'GpsTime', 'JulianDate', 'M_ref', 'ED_MLT', 'Pfs_ED_MLAT',
-                'Bfs_geo', 'Bm', 'Pfn_CD_MLON', 'CD_MLAT', 'Pfs_geo',
-                'Rsm', 'Pmin_gsm', 'Rgei', 'Rgsm', 'Pfs_CD_MLAT', 'S_total',
-                'Rgeod_Height', 'Date', 'Alpha', 'M_igrf', 'Pfs_CD_MLT',
-                'ED_MLAT', 'CD_R', 'PerigeeTimes', 'UTC', 'Pfn_ED_MLT',
-                'BoverBeq', 'Lsimple', 'Lstar', 'I', 'DipoleTiltAngle',
-                'K', 'Bmin_gsm', 'S_Bmin_to_sc', 'Bfs_gsm', 'L',
-                'ApogeeTimes', 'ExtModel', 'Kp', 'Pfs_geod_LatLon',
-                'MlatFromBoverBeq', 'Pfn_gsm', 'Loss_Cone_Alpha_n', 'Bfn_geo',
-                'Pfn_CD_MLAT', 'Rgeod_LatLon', 'Pfs_ED_MLT', 'Pfs_CD_MLON',
-                'Bsc_gsm', 'Pfn_geod_Height', 'Lm_eq', 'Rgse',
-                'Pfn_geod_LatLon', 'CD_MLT', 'FieldLineType', 'Pfn_CD_MLT',
-                'Pfs_geod_Height', 'Rgeo', 'InvLat_eq', 'M_used',
-                'Loss_Cone_Alpha_s', 'Bfn_gsm', 'Pfn_ED_MLON', 'Pfn_geo',
-                'InvLat', 'Pfs_ED_MLON']
         if str is bytes:
-            keys = [unicode(k) for k in keys]
+            keys = [unicode(k) for k in self.keys]
         # make sure data has all the keys and no more or less
         for k in dat:
-            self.assertTrue(k in keys)
-            ind = keys.index(k)
-            del keys[ind]
-        self.assertEqual(len(keys), 0)
+            self.assertTrue(k in self.keys)
+            ind = self.keys.index(k)
+            del self.keys[ind]
+        self.assertEqual(len(self.keys), 0)
         dat = dm.readJSONheadedASCII(self.filename, convert=True)
         np.testing.assert_array_equal(dat['DateTime'], [datetime.datetime(2013, 2, 18, 0, 0), datetime.datetime(2013, 2, 18, 0, 5)])
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -870,7 +870,6 @@ class JSONTests(unittest.TestCase):
                 # try triggered before the temp directory could be created, out of disk space?
                 self.fail("Test failed in awkward fashion")
 
-    @unittest.expectedFailure
     def test_readJSONMetadata_gzip(self):
         """readJSONMetadata should read in a gzip file"""
         # make a gzip file and then remove it when done


### PR DESCRIPTION
Per #448 this pull request updates datamodel to allow for gzip input files. Closes #448 . 

The discussion in #448 called out a few nice to haves that are repeated here 
- allowing for zip as well as gzip 
    - this proved problematic based on the interplay of `readJSONheadedASCII` and `readJSONMetadata`
- allowing for mixed lists of input files between regular and gzip
    - this was accomplished and a test added. 

I am happy to add another feature request for zip and tgz files as this PR alone is a useful addition to the capability.    

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

