### PR TITLE
time.py: fix doc issue crashing sphinx in come cases

### DIFF
--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1798,7 +1798,7 @@ class Ticktock(MutableSequence):
 
         See Also
         ========
-        datetime.date.today()
+        datetime.date.today
 
         """
         warnings.warn('today() returns UTC day as of 0.2.2.',


### PR DESCRIPTION
I still don't understand why this has only recently become an issue but this fixes it and is correct anyway. Closes #451. 

The see also in docs should not be an evaluated function. `datetime.date.today()` vs `datetime.date.today`

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

