### PR TITLE
setup: Skip the Raspberry Pi check on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -568,7 +568,8 @@ class build(_build):
         if fcompiler == 'gnu':
             if bit == 64:
                 compflags = '-m64 ' + compflags
-        if fcompiler == 'gnu95' and not os.uname()[4].startswith('arm'):
+        if not sys.platform.startswith('win') and fcompiler == 'gnu95' \
+           and not os.uname()[4].startswith('arm'):
             # Raspberry Pi doesn't have this switch and assumes 32-bit
             compflags = '-m{0} '.format(bit) + compflags
         if fcompiler.startswith('intel'):


### PR DESCRIPTION
#433 fixed the build on Raspberry Pi by doing a `uname` check. Windows doesn't have `uname`, so this broke the build on Windows. Didn't catch it because #55. This PR just checks for Windows before checking uname.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

No changelog/release notes entry because this wasn't released.
