### PR TITLE
setup: Find f2py when hidden by Macports 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Changes in Version 0.2.3 (2020-xx-xx)
+=====================================
+- Fixed setup.py not finding f2py on some OSX installs
+
 Changes in Version 0.2.2 (2020-xx-xx)
 =====================================
 - Document end of support for Python 2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,9 @@
-Changes in Version 0.2.3 (2020-xx-xx)
-=====================================
-- Fixed setup.py not finding f2py on some OSX installs
-
 Changes in Version 0.2.2 (2020-xx-xx)
 =====================================
 - Document end of support for Python 2
 - Quaternion math functions moved to coordinates module
 - Remove message on first import.
+- Fixed setup.py not finding f2py on some OSX installs
 coordinates
  - Include upstream fix for SPH->RLL coordinate transform
 datamodel

--- a/setup.py
+++ b/setup.py
@@ -152,11 +152,12 @@ def default_f2py():
     """
     interpdir, interp = os.path.split(sys.executable)
     if interp[0:6] == 'python':
-        vers = "{0.major:01d}.{0.minor:01d}".format(sys.version_info)
-        suffixes = [interp[6:], '-' + interp[6:], vers, '-' + vers]
+        suffixes = [interp[6:], '-' + interp[6:]]
         if '.' in interp[6:]: #try slicing off suffix-of-suffix (e.g., exe)
             suffix = interp[6:-(interp[::-1].index('.') + 1)]
             suffixes.extend([suffix, '-' + suffix])
+        vers = "{0.major:01d}.{0.minor:01d}".format(sys.version_info)
+        suffixes.extend([vers, '-'+vers])
         candidates = ['f2py' + s for s in suffixes]
         for candidate in candidates:
             for c in [candidate, candidate + '.py']:

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,8 @@ def default_f2py():
     """
     interpdir, interp = os.path.split(sys.executable)
     if interp[0:6] == 'python':
-        suffixes = [interp[6:], '-' + interp[6:]]
+        vers = "{0.major:01d}.{0.minor:01d}".format(sys.version_info)
+        suffixes = [interp[6:], '-' + interp[6:], vers, '-' + vers]
         if '.' in interp[6:]: #try slicing off suffix-of-suffix (e.g., exe)
             suffix = interp[6:-(interp[::-1].index('.') + 1)]
             suffixes.extend([suffix, '-' + suffix])
@@ -162,8 +163,8 @@ def default_f2py():
                 for d in os.environ['PATH'].split(os.pathsep):
                     if os.path.isfile(os.path.join(d, c)):
                         return c
-                    if os.path.isfile(os.path.join(interpdir, c)):
-                        return os.path.join(interpdir, c) #need full path
+                if os.path.isfile(os.path.join(interpdir, c)):
+                    return os.path.join(interpdir, c) #need full path
     if sys.platform == 'win32':
         return 'f2py.py'
     else:


### PR DESCRIPTION
## PR Checklist

This PR updates setup.py to help it find f2py versions that are "hidden" by MacPorts' `select` command.  It uses sys.version_info to build more f2py* and f2py-* paths that are searched in `default_f2py`.

Additionally, a tabbing error was corrected to reduce redundant searches.

This pull closes #456.

- [ x] Pull request has descriptive title
- [ x] Pull request gives overview of changes
- [ x] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ x] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [ ] New features and bug fixes should have unit tests
- [ x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

