### PR TITLE
Correct MLT labeling in pybats.ram.RamSat flux plots

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@ pybats
  - Bats2d.add_b_magsphere and add_stream_scatter now have kwargs for adding arrows on ray traces
  - Updates to ram.RamSat including omnidirectional flux calculation
  - ram.PressureFile fixed for Python 3.x failures
+ - Corrected MLT labels in ram.RamSat plotting
  - rim.Iono objects now load poorly-formatted files; rim.fix_format deprecated
 time
  - Fix handling of leapseconds before 1961.

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy.io import netcdf
 
 from spacepy.datamodel import dmarray, SpaceData
+import spacepy.toolbox as tb
 import spacepy.plot.apionly
 from spacepy.plot import set_target, smartTimeTicks, applySmartTimeTicks
 from spacepy.pybats import PbData
@@ -661,11 +662,10 @@ class RamSat(SpaceData):
         y = self['SM_xyz'][index,1]
         z = self['SM_xyz'][index,2]
         R = np.sqrt(y**2 + x**2 + z**2)
-        Mlat  = 180.0*np.arcsin(z/R)/np.pi
-        theta = 180.0*np.sign(y)*np.arccos(x/np.sqrt(y**2+x**2))/np.pi
-        theta = np.mod(theta, 360.0)
-        locHr = np.floor(theta/15.0)
-        locMn = int(60.0 * (theta/15.0 - locHr))
+        Mlat  = np.rad2deg(np.arcsin(z/R))
+        fltMLT = tb.rad2mlt(np.arctan2(y, x)) % 24
+        locHr = np.floor(fltMLT).astype(int)
+        locMn = np.round((fltMLT - locHr)*60).astype(int)
 
         # Build format string.
         fmtstring = \

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -8,6 +8,7 @@ Copyright 2015 University of Michigan
 
 import matplotlib
 matplotlib.use('Agg')
+from matplotlib import dates
 
 import datetime as dt
 import glob
@@ -603,6 +604,14 @@ class RampyTests(unittest.TestCase):
         data.create_omniflux(check=False)
         testarr = np.array(data['omniH'][0].data)
         numpy.testing.assert_array_almost_equal(regrH, testarr)
+
+    def test_RamSat_orbit_formatter(self):
+        '''Test label variables are as expected'''
+        data = ram.RamSat(self.testfile)
+        tst_time = matplotlib.dates.date2num(dt.datetime(2012, 10, 29, 0, 2))
+        fmtstr = data._orbit_formatter(tst_time, None)
+        expected = '00:02 UT\n04:35 MLT\n-13.4$^{\circ}$ MLat\nR=5.05 $R_{E}$'
+        self.assertEqual(expected, fmtstr)
 
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
In `spacepy.pybats.ram.RamSat` the `add_omniflux_plot` method produces MLT labels that are offset by 12 hours (i.e. offset of pi radians in the azimuthal coordinate.

The issue was found when plotting simulation output and comparing to Van Allen Probes. It can be reproduced with the test file though.
Inspecting the test file `tests/data/pybats_test/ramsat_test.nc` the approximate SM position is [-1.78, -4.58, -1.17]. Since X is positive sunward and Y is positive duskward, this should imply an MLT in the morning. Calling `_orbit_formatter` yielded an MLT label of `16:35 MLT`.

The new fix:
1. removes the custom MLT calculation and calls `spacepy.toolbox.rad2mlt`.
2. adds a test to check that the output string for plot labeling is as expected given the test file


- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)