### PR TITLE
time: minor update in _days1958totai(), Closes #462

### DIFF
--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -2486,13 +2486,13 @@ def _days1958totai(days, leaps='rubber', midnight=False):
     # Seconds from the start of naive day.
     ssd = (days - dayint) * daylen # Mod does wrong thing if negative
     # Index TAIUTC for every input. Start of day w/LS is still previous value.
-    taiutcidx = ldidx - np.require(leap_sec_day, dtype=np.intc)
+    taiutcidx = ldidx - np.require(leap_sec_day, dtype=np.intp)
     # Keep small number adds together: ssd and leapseconds.
     taiout = daystart + (ssd + off + taiutc[taiutcidx])
     if leaps == 'drop':
         # Any times after leap-second skip need an extra second.
         taiutcidx += np.require(leap_sec_day & (taiout >= leap_tai[ldidx]),
-                                dtype=np.integer)
+                                dtype=np.intp)
         # Recalculate to keep small-number addition together
         taiout = daystart + (ssd + off + taiutc[taiutcidx])
     return taiout


### PR DESCRIPTION
Really minor update to _days1958totai() to Close #462 , I greped around and `np.integer` and `np.float` to not appear anywhere else in the code base. 

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

I cannot think of a good way to add a unittest for this. I'm all ears if anyone has ideas. 
