### PR TITLE
 Fix on pybats filename parsing on Windows for filenames w/directories.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@ pybats
  - ram.PressureFile fixed for Python 3.x failures
  - Corrected MLT labels in ram.RamSat plotting
  - rim.Iono objects now load poorly-formatted files; rim.fix_format deprecated
+ - Fix reading of files with absolute paths on Windows.
 time
  - Fix handling of leapseconds before 1961.
  - For types that cannot represent leapseconds (e.g. UTC datetime), time

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -113,6 +113,8 @@ convenience functions for customizing plots.
 __contact__ = 'Dan Welling, dwelling@umich.edu'
 
 # Global imports (used ubiquitously throughout this module.
+import os.path
+
 from spacepy.datamodel import dmarray, SpaceData
 import spacepy.plot.apionly
 import spacepy.plot as spu
@@ -165,7 +167,7 @@ def parse_filename_time(filename):
     from datetime import timedelta
     import re
 
-    filename = filename.split('/')[-1]
+    filename = os.path.basename(filename)
     
     # Look for date/time:
     if '_e' in filename:

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -38,11 +38,14 @@ class TestParseFileTime(unittest.TestCase):
     files = ['mag_grid_e20130924-232600.out',
              'y=0_mhd_1_e20130924-220500-054.out',
              'y=0_mhd_2_t00001430_n00031073.out',
-             'z=0_mhd_2_t00050000_n00249620.out']
+             'z=0_mhd_2_t00050000_n00249620.out',
+             os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                          'data', 'pybats_test', 'mag_grid_ascii.out'),
+    ]
     dates = [dt(2013,9,24,23,26,0), dt(2013,9,24,22, 5,0),
-             None, None]
-    times = [None, None, 870, 18000]
-    iters = [None, None, 31073, 249620]
+             None, None, None]
+    times = [None, None, 870, 18000, None]
+    iters = [None, None, 31073, 249620, None]
 
     def testParse(self):
         from spacepy.pybats import parse_filename_time
@@ -255,7 +258,7 @@ class TestMagGrid(unittest.TestCase):
     def testOpen(self):
         # Open both binary and ascii versions of same data.
         # Ensure expected values are loaded.
-        m1 = pbs.MagGridFile(os.path.join(self.pth, 'data/', 'pybats_test', 'mag_grid_ascii.out'),
+        m1 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_ascii.out'),
                               format='ascii')
         m2 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_binary.out'))
 


### PR DESCRIPTION
`pybats.parse_filename_time` assumed the path separator was a `/` and thus broke on Windows. This PR adds a test for that case and fixes the problem with `os.path`.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
