### PR TITLE
Update spectrogram tests for main test runner

### DIFF
--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -11,6 +11,7 @@ import warnings
 
 import numpy as np
 import datetime
+import matplotlib.dates as mdates
 
 import spacepy.datamodel as dm
 import spacepy.toolbox as tb
@@ -21,7 +22,7 @@ from spacepy.plot import Spectrogram
 import spacepy.plot
 
 
-__all__ = ['spectrogramTests']
+__all__ = ['spectrogramTests', 'spectrogramDateTests']
 
 class spectrogramTests(unittest.TestCase):
     def setUp(self):
@@ -80,8 +81,7 @@ class spectrogramTests(unittest.TestCase):
             if key == 'variables':
                 self.assertEqual(a.specSettings[key], ans[key])
             else:
-                # np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
-                np.testing.assert_almost_equal(a.specSettings[key], ans[key],  decimal=7)
+                np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
         self.assertRaises(NotImplementedError, a.add_data, self.data)
 
 
@@ -102,8 +102,7 @@ class spectrogramTests(unittest.TestCase):
             if key == 'variables':
                 self.assertEqual(a.specSettings[key], ans[key])
             else:
-                # np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
-                np.testing.assert_almost_equal(a.specSettings[key], ans[key], decimal=8)
+                np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
 
     def test_add_data(self):
         """run it and check that add_data correctly"""
@@ -137,11 +136,8 @@ class spectrogramDateTests(unittest.TestCase):
     def test_defaults(self):
         """run it and check that defaults were set correctly"""
         a = Spectrogram(self.data, variables=self.kwargs['variables'])
-        ans = {'bins': [dm.dmarray([730120.0, 730135.30769231, 730150.61538462,
-                                    730165.92307692, 730181.23076923, 730196.53846154,
-                                    730211.84615385, 730227.15384615, 730242.46153846,
-                                    730257.76923077, 730273.07692308, 730288.38461538,
-                                    730303.69230769, 730319.]),
+        ans = {'bins': [dm.dmarray(np.linspace(mdates.date2num(self.data['xval'][0]),
+                                               mdates.date2num(self.data['xval'][-1]), 14)),
                         dm.dmarray([0.00169679, 0.07848775, 0.1552787, 0.23206965, 0.30886061,
                                     0.38565156, 0.46244251, 0.53923347, 0.61602442, 0.69281538,
                                     0.76960633, 0.84639728, 0.92318824, 0.99997919])],
@@ -153,11 +149,9 @@ class spectrogramDateTests(unittest.TestCase):
                 self.assertEqual(a.specSettings[key], ans[key])
             else:
                 if key == 'bins':
-#                    np.testing.assert_allclose(a.specSettings[key], ans[key], atol=1e-2, rtol=1e-3)
-                    np.testing.assert_almost_equal(a.specSettings[key], ans[key], decimal=2)
+                    np.testing.assert_allclose(a.specSettings[key], ans[key], atol=1e-2, rtol=1e-3)
                 else:
-#                    np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
-                    np.testing.assert_almost_equal(a.specSettings[key], ans[key], decimal=6)
+                    np.testing.assert_allclose(a.specSettings[key], ans[key], rtol=1e-5)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`test_all.py` is used as the main test runner, when called from `test_all.py` the `spectrogramDateTests` class wasn't being run.
This masked the failure of that test due to the update of the reference epoch in `matplotlib.dates`.

This PR:
- adds `spectrogramDateTests` to the `__all__` so it gets called from the master runner
- sets expected date numbers for bin edges using `numpy.linspace` rather than hardcoding, so the epoch used doesn't break the test
- re-enables the `assert_allclose` testing that was disabled in 8b083f06d6b6d45eff0e064bfe6fc2bfd38437ab for numpy 1.4 compatibility

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)