### PR TITLE
empiricals.py: getPlasmaPause() raising a warning rather than a print

### DIFF
--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -123,7 +123,7 @@ def getPlasmaPause(ticks, model='M2002', LT='all', omnivals=None):
 
     if model == 'CA1992':
         if LT != 'all':
-            warnings.warn(RuntimeWarning('No LT dependence currently supported for CA1992 model'))
+            warnings.warn('No LT dependence currently supported for CA1992 model', RuntimeWarning)
     if model not in model_list:
         raise ValueError("Please specify a valid model:\n{0}".format(' or '.join(model_list)))
 

--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -75,12 +75,12 @@ def getPlasmaPause(ticks, model='M2002', LT='all', omnivals=None):
     """
     Plasmapause location model(s)
 
-    CA1992 -- Carpenter, D. L., and R. R. Anderson, An ISEE/whistler 
-    model of equatorial electron density in the magnetosphere, 
+    CA1992 -- Carpenter, D. L., and R. R. Anderson, An ISEE/whistler
+    model of equatorial electron density in the magnetosphere,
     J. Geophys. Res., 97, 1097, 1992.
-    M2002 -- Moldwin, M. B., L. Downward, H. K. Rassoul, R. Amin, 
-    and R. R. Anderson, A new model of the location of the plasmapause: 
-    CRRES results, J. Geophys. Res., 107(A11), 1339, 
+    M2002 -- Moldwin, M. B., L. Downward, H. K. Rassoul, R. Amin,
+    and R. R. Anderson, A new model of the location of the plasmapause:
+    CRRES results, J. Geophys. Res., 107(A11), 1339,
     doi:10.1029/2001JA009211, 2002.
     RT1970 -- Rycroft, M. J., and J. O. Thomas, The magnetospheric
     plasmapause and the electron density trough at the alouette i
@@ -99,6 +99,11 @@ def getPlasmaPause(ticks, model='M2002', LT='all', omnivals=None):
         requested local time sector, 'all' is valid option
     omnivals : spacepy.datamodel.SpaceData, dict
         dict-like containing UTC (datetimes) and Kp keys
+
+    Warns
+    =====
+    RuntimeWarning
+        If the CA1992 model is called with LT as it is not implemented 
 
     Returns
     =======

--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -12,10 +12,12 @@ Copyright 2010 Los Alamos National Security, LLC.
 """
 from __future__ import division
 import datetime
+import warnings
+
 from functools import partial
 import numpy as np
-
 import scipy.integrate as integ
+
 from spacepy import help
 import spacepy.datamodel as dm
 import spacepy.toolbox as tb
@@ -120,8 +122,8 @@ def getPlasmaPause(ticks, model='M2002', LT='all', omnivals=None):
     model_list = ['CA1992', 'M2002', 'RT1970']
 
     if model == 'CA1992':
-        if LT!='all':
-            print('No LT dependence currently supported for this model')
+        if LT != 'all':
+            warnings.warn(RuntimeWarning('No LT dependence currently supported for CA1992 model'))
     if model not in model_list:
         raise ValueError("Please specify a valid model:\n{0}".format(' or '.join(model_list)))
 

--- a/tests/test_empiricals.py
+++ b/tests/test_empiricals.py
@@ -2,7 +2,8 @@
 #!/usr/bin/env python2.6
 
 import unittest
-import datetime as dt
+import warnings
+
 import dateutil.parser as dup
 import numpy as np
 import spacepy.time as spt
@@ -36,7 +37,7 @@ class empFunctionTests(unittest.TestCase):
         real_ans = np.array([ 5.46199999,  5.27800001,  5.00200002,  5.00200002,  5.00200002,
                               5.00200002,  4.54200002,  4.54200002,  4.54200002,  4.54200002,
                               4.54200002])
-        ans = em.getPlasmaPause(self.ticks, 'CA1992', omnivals=self.omnivals)
+        ans = em.getPlasmaPause(self.ticks, 'CA1992', LT='all', omnivals=self.omnivals)
         np.testing.assert_almost_equal(real_ans, ans)
 
     def test_getPlasmaPause_regress3(self):
@@ -76,6 +77,16 @@ class empFunctionTests(unittest.TestCase):
         #check for fail on omnivals without correct inputs
         spam1 = lambda: em.getPlasmaPause(self.ticks, omnivals={'Kp': [2.7]*10})
         self.assertRaises(KeyError, spam1)
+
+    def test_getPlasmaPauseCA1992warn(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', category=RuntimeWarning)
+            em.getPlasmaPause(self.ticks, model='CA1992', LT=12)
+        self.assertEqual(1, len(w))
+        self.assertEqual(RuntimeWarning, w[0].category)
+        self.assertEqual(
+            'No LT dependence currently supported for CA1992 model',
+            str(w[0].message))
 
     def test_getLmax(self):
         """getLmax should give known results (regression)"""


### PR DESCRIPTION
`getPlasmaPause` now raises `RuntimeWarning`, closes #474 

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

Unit test added, minor enough did not modify CHANGELOG

