### PR TITLE
Fix paranoia of leapsecond out-of-date warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
+time
+ - Fix warning for out-of-date leapseconds.
 toolbox
  - Fix bootHisto passing of kwargs to histogram and bar.
 

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -18,9 +18,11 @@ contains more detail.
 
 Major bugfixes
 **************
-
 The passing of keyword arguments from :func:`~spacepy.toolbox.bootHisto`
 to :func:`numpy.histogram` and :func:`matplotlib.pyplot.bar` has been fixed.
+
+The check for out-of-date leapseconds in :mod:`~spacepy.time` has been
+fixed (previously warned even when the file was up to date.)
 
 0.2.2 (2020-12-29)
 ------------------

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -696,6 +696,8 @@ class TimeFunctionTests(unittest.TestCase):
 
 class TimeClassTests(unittest.TestCase):
 
+    longMessage = True
+
     def test_TAIinit(self):
         """test that Ticktock can be made from TAI input"""
         t0 = 1663236947
@@ -1511,6 +1513,25 @@ class TimeClassTests(unittest.TestCase):
         actual = [(int(y), int(m), int(d))
                   for y, m, d in zip(t.year, t.mon, t.day)][:14]
         numpy.testing.assert_equal(expected, actual)
+
+    def test_leapsgood(self):
+        """Test the check for out-of-date leapseconds"""
+        # Each case is current time, file mtime, lastleap, leapsgood (or not)
+        # Last leap must be july or january
+        cases = [[(2021, 1, 5), (2020, 12, 26), (2017, 1, 1), True],
+                 [(2021, 7, 5), (2020, 12, 26), (2017, 1, 1), False],
+                 [(2021, 7, 5), (2020, 12, 26), (2020, 7, 1), False],
+                 [(2021, 7, 5), (2020, 12, 26), (2021, 7, 1), True],
+                 [(2020, 12, 26), (2020, 12, 24), (2017, 1, 1), True],
+                 [(2018, 6, 2), (2018, 5, 12), (2017, 1, 1), True],
+                 [(2018, 6, 2), (2017, 5, 12), (2017, 1, 1), False],
+                 [(2017, 6, 2), (2017, 5, 12), (2017, 1, 1), True],
+                 ]
+        for caseno, caseinfo in enumerate(cases):
+            currtime, filetime, lastleap, isgood = caseinfo
+            self.assertEqual(isgood, t._leapsgood(
+                datetime.datetime(*currtime), datetime.datetime(*filetime),
+                datetime.datetime(*lastleap)), 'Case {}'.format(caseno))
 
     def test_diffAcrossLeaps(self):
         """Do TAI differences across the first leapsecond"""


### PR DESCRIPTION
This PR fixes the leapsecond out-of-date warning and also adds tests (since clearly coding it blind without tests was not the way to go.) Closes #473.

I went ahead and put in a release notes entry for it in the "major bugs" section; which is overkill but it's also a highly visible bug.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
