### PR TITLE
test_empiricals.py: updating test test_getPlasmaPauseCA1992warn

### DIFF
--- a/tests/test_empiricals.py
+++ b/tests/test_empiricals.py
@@ -81,7 +81,7 @@ class empFunctionTests(unittest.TestCase):
     def test_getPlasmaPauseCA1992warn(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always', category=RuntimeWarning)
-            em.getPlasmaPause(self.ticks, model='CA1992', LT=12)
+            em.getPlasmaPause(self.ticks, model='CA1992', LT=12, omnivals=self.omnivals)
         self.assertEqual(1, len(w))
         self.assertEqual(RuntimeWarning, w[0].category)
         self.assertEqual(


### PR DESCRIPTION
Closes #484 

Utilize the test OMNI data rather than assume OMNI data are installed. 

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

