### PR TITLE
empiricals: expose getMagnetopause in docs

### DIFF
--- a/Doc/source/empiricals.rst
+++ b/Doc/source/empiricals.rst
@@ -14,6 +14,7 @@ empiricals - module with heliospheric empirical modules
     getDststar
     getExpectedSWTemp
     getLmax
+    getMagnetopause
     getMPstandoff
     getPlasmaPause
     getSolarProtonSpectra


### PR DESCRIPTION
This PR adds `getMagnetopause` to `empiricals.rst` so it shows up in the docs.  Closes #489

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
