### PR TITLE
Simple GH actions config to make the workflow show up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+# Minimal workflow to get in the GitHub system so can implement CI later
+
+name: CI
+
+on:
+  pull_request:
+    branches: [ $default-branch ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2


### PR DESCRIPTION
A GitHub actions workflow won't show up in the UI until it's merged to master and run a single time. This is a very simple workflow that just checks out the repo and does nothing else, so we can merge it to master and activate the workflow. After that, workflow updates in PRs should run properly, which will allow me to complete #495 and ultimately close #455.

This was tested by merging to master on my fork and verifying the action showed up (then force-pushing to my fork to clean up, which won't be necessary here.)

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
