### PR TITLE
Fix bootHisto kwarg passthrough

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
+toolbox
+ - Fix bootHisto passing of kwargs to histogram and bar.
 
 Changes in Version 0.2.2 (2020-12-29)
 =====================================

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -13,6 +13,15 @@ contains more detail.
 0.2 Series
 ==========
 
+0.2.3 (2021-xx-xx)
+------------------
+
+Major bugfixes
+**************
+
+The passing of keyword arguments from :func:`~spacepy.toolbox.bootHisto`
+to :func:`numpy.histogram` and :func:`matplotlib.pyplot.bar` has been fixed.
+
 0.2.2 (2020-12-29)
 ------------------
 

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1777,6 +1777,10 @@ def bootHisto(data, inter=90., n=1000, seed=None,
     All other keyword arguments are passed to :func:`numpy.histogram`
     or :func:`matplotlib.pyplot.bar`.
 
+    .. versionchanged:: 0.2.3
+       This argument pass-through did not work in earlier versions of
+       SpacePy.
+
     Parameters
     ==========
 
@@ -1814,6 +1818,8 @@ def bootHisto(data, inter=90., n=1000, seed=None,
 
     Notes
     =====
+    .. versionadded:: 0.2.1
+
     The confidence intervals are calculated for each bin individually and thus
     the resulting low/high histograms may not have actually occurred in the
     calculation from the surrogates. If using a probability density histogram,
@@ -1841,9 +1847,9 @@ def bootHisto(data, inter=90., n=1000, seed=None,
     import spacepy.poppy
     histogram_allowed_kwargs = (
         'bins', 'range', 'normed', 'weights', 'density')
-    histogram_kwargs = {k: v for k, v in kwargs
+    histogram_kwargs = {k: v for k, v in kwargs.items()
                         if k in histogram_allowed_kwargs}
-    bar_kwargs = {k: v for k, v in kwargs
+    bar_kwargs = {k: v for k, v in kwargs.items()
                   if k not in histogram_allowed_kwargs}
     sample, bin_edges = np.histogram(data, **histogram_kwargs)
     histogram_kwargs['bins'] = bin_edges

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -461,6 +461,25 @@ class SimpleFunctionTests(unittest.TestCase):
             [12.,  56., 168., 307., 295., 181.,  85.,  14.,   0.,   5.],
             ci_high, atol=2, rtol=1e-2)
 
+    def testBootHistoBins(self):
+        """Bootstrap histogram known output for known input, specify bins"""
+        numpy.random.seed(28420)
+        data = numpy.random.randn(1000)
+        bin_edges, ci_low, ci_high, sample = spacepy.toolbox.bootHisto(
+            data, n=1000, seed=28420, bins=numpy.arange(-5., 6.))
+        numpy.testing.assert_array_equal(
+            [-5., -4, -3, -2, -1, 0, 1, 2, 3, 4, 5],
+            bin_edges)
+        numpy.testing.assert_equal(
+            [  0,   2,  18, 143, 358, 328, 131,  18,   1,   1], sample)
+        #Chunk-check as above
+        numpy.testing.assert_allclose(
+            [ 0.,  0., 11.,  125.,  333.,  304.,  114., 11.,  0.,  0.],
+            ci_low, atol=2, rtol=1e-2)
+        numpy.testing.assert_allclose(
+            [ 0.,  5., 25.,  161.,  383.,  353.,  149., 25.,  3.,  3.],
+            ci_high, atol=2, rtol=1e-2)
+
     def test_logspace(self):
         """logspace should return know answer for known input"""
         try:


### PR DESCRIPTION
[bootHisto](https://spacepy.github.io/autosummary/spacepy.toolbox.bootHisto.html#spacepy.toolbox.bootHisto) is supposed to pass kwargs through either to `numpy.histogram` (for kwargs it recognizes as such) or `plt.bar`. Unfortunately this was never tested and so, of course, it never worked. This PR adds a test and fix.

While I was at it I documented the version where this function showed up. I didn't retroactively fix the release notes because that will probably require some further overview in the future anyhow.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

