### PR TITLE
Unittest helper module; test warnings; test and document against built SpacePy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
     - name: Install and run tests
       working-directory: ${{ github.workspace }}
       run: |
-        python setup.py install
+        python setup.py build
         cd tests; . ${HOME}/cdf/bin/definitions.B; xvfb-run python test_all.py -v
 
 # See https://github.community/t/status-check-for-a-matrix-jobs/127354/7

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
+tests
+ - Add spacepy_testing module to provide helper functions for testing.
 time
  - Fix warning for out-of-date leapseconds.
 toolbox

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
 tests
  - Add spacepy_testing module to provide helper functions for testing.
+ - Add assertWarns and assertDoesntWarn context managers.
 time
  - Fix warning for out-of-date leapseconds.
 toolbox

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -11,17 +11,26 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import os
+import os.path
+import sys
+import sysconfig
 
 #This is a hack to take the sphinx script's path out and just use standard
 #paths.
 sys.path.append(sys.path.pop(0))
 # Put in the unit test directory path, so spacepy_testing can be documented.
 sys.path.append(os.path.abspath(os.path.join('..', '..', 'tests')))
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
+# Add build directory to the path, preferring version-specific.
+buildbase = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'build'))
+for pth in ('lib.{0}-{1}.{2}'.format(sysconfig.get_platform(),
+                                     *sys.version_info[:2]),
+            'lib'):
+    buildpath = os.path.join(buildbase, pth)
+    if os.path.isdir(buildpath):
+        if not buildpath in sys.path:
+            sys.path.insert(0, buildpath)
 
 # -- General configuration -----------------------------------------------------
 

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -16,6 +16,8 @@ import sys, os
 #This is a hack to take the sphinx script's path out and just use standard
 #paths.
 sys.path.append(sys.path.pop(0))
+# Put in the unit test directory path, so spacepy_testing can be documented.
+sys.path.append(os.path.abspath(os.path.join('..', '..', 'tests')))
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -98,6 +98,7 @@ For those developing SpacePy, plus tips for all Python developers.
     tips
     dep_versions
     doc_standard
+    tests
     ci
 
 .. _module_reference:

--- a/Doc/source/tests.rst
+++ b/Doc/source/tests.rst
@@ -14,7 +14,20 @@ The spacepy_testing module
 The ``spacepy_testing`` module contains utilities for assistance with
 testing SpacePy. It is not installed as part of SpacePy and is thus
 only importable from the unit test scripts themselves (which are in the
-same directory.)
+same directory). All unit test scripts import this module, and should
+do so before importing any spacepy modules to ensure pathing is correct.
+
+On import, :func:`~spacepy_testing.add_build_to_path` is run so that
+the ``build`` directory is added to the Python search path. This means
+the tests run against the latest build, not the installed version. Remove
+the build directory to run against the installed version instead. The build
+directory does not completely separate out Python versions, so removing
+the build directory (and rebuilding) is recommended when switching Python
+versions.
+
+Build the package before running the tests::
+
+  python setup.py build
 
 .. contents::
    :local:
@@ -30,6 +43,17 @@ Classes
 
     assertWarns
     assertDoesntWarn
+
+Functions
+---------
+
+|
+
+.. autosummary::
+    :template: clean_function.rst
+    :toctree: autosummary
+
+    add_build_to_path
 
 Data
 ----

--- a/Doc/source/tests.rst
+++ b/Doc/source/tests.rst
@@ -19,9 +19,22 @@ same directory.)
 .. contents::
    :local:
 
+Classes
+-------
+
+|
+
+.. autosummary::
+    :template: clean_class.rst
+    :toctree: autosummary
+
+    assertWarns
+    assertDoesntWarn
 
 Data
 ----
+
+|
 
 .. autosummary::
    :toctree: autosummary

--- a/Doc/source/tests.rst
+++ b/Doc/source/tests.rst
@@ -42,14 +42,6 @@ Data
    datadir
    testsdir
 
-.. attribute:: datadir
-
-   Directory containing the unit test data.
-
-.. attribute:: testsdir
-
-   Directory containing the unit test scripts.
-
 --------------------------
 
 :Release: |version|

--- a/Doc/source/tests.rst
+++ b/Doc/source/tests.rst
@@ -1,0 +1,43 @@
+==========
+Unit tests
+==========
+
+
+.. contents::
+   :local:
+
+The spacepy_testing module
+==========================
+
+.. module:: spacepy_testing
+
+The ``spacepy_testing`` module contains utilities for assistance with
+testing SpacePy. It is not installed as part of SpacePy and is thus
+only importable from the unit test scripts themselves (which are in the
+same directory.)
+
+.. contents::
+   :local:
+
+
+Data
+----
+
+.. autosummary::
+   :toctree: autosummary
+
+   datadir
+   testsdir
+
+.. attribute:: datadir
+
+   Directory containing the unit test data.
+
+.. attribute:: testsdir
+
+   Directory containing the unit test scripts.
+
+--------------------------
+
+:Release: |version|
+:Doc generation date: |today|

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -49,7 +49,7 @@ do
     pip install ${NUMPY} ${PIPLIST}
     rm -rf build
     # Make sure not building against user's version of libraries
-    PYTHONNOUSERSITE=1 PYTHONPATH= python setup.py install
+    PYTHONNOUSERSITE=1 PYTHONPATH= python setup.py build
     pushd tests
     echo Python ${PYVER}
     echo ${NUMPY} ${PIPLIST}

--- a/spacepy/LANLstar.py
+++ b/spacepy/LANLstar.py
@@ -21,15 +21,7 @@ import os.path
 import sys
 import warnings
 
-try:
-    import ffnet
-except ImportError:
-    if 'sphinx' in sys.argv[0]:
-        warnings.warn('LANLstar requires ffnet. '
-                      'You appear to be building docs, so ignoring this error.')
-    else:
-        raise RuntimeError(
-            'LANLstar requires ffnet (http://ffnet.sourceforge.net/)')
+import ffnet
 import numpy as np
 from . import toolbox
 

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -169,6 +169,9 @@ def deprecated(version, message, docstring=None):
     The function will work but will not have proper argument names listed
     in e.g. ``help``.
 
+    This warning will show as coming from SpacePy, not the deprecated
+    function.
+
     Examples
     ========
         >>> import spacepy

--- a/spacepy/irbempy/irbempy.py
+++ b/spacepy/irbempy/irbempy.py
@@ -27,14 +27,7 @@ import numpy as np
 from spacepy import help, config
 import spacepy.coordinates as spc
 import spacepy.datamodel as dm
-try:
-    from . import irbempylib as oplib
-except ImportError:
-    if 'sphinx' in sys.argv[0]:
-        warnings.warn('Could not import irbempylib. '
-                      'You appear to be building docs, so ignoring this error.')
-    else:
-        raise
+from . import irbempylib as oplib
 import spacepy.toolbox as tb
 
 #check whether TS07_DATA_PATH is set, if not then set to spacepy's installed data directory

--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -403,9 +403,13 @@ import h5py
 omnifln = os.path.join(DOT_FLN,'data','omnidata.h5')
 omni2fln = os.path.join(DOT_FLN,'data','omni2data.h5')
 # Test data is stored relative to the test script
-testfln = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])),
-                       'data', 'OMNItest.h5')
-if not os.path.isfile(testfln): # Hope it's relative to current!
+try:
+    import spacepy_testing
+    testfln = os.path.join(spacepy_testing.datadir, 'OMNItest.h5')
+except ImportError:
+    testfln = None
+if testfln is None or not os.path.isfile(testfln):
+    # Hope it's relative to current!
     testfln = os.path.join(os.path.abspath('data'), 'OMNItest.h5')
 
 presentQD = h5py.is_hdf5(omnifln)

--- a/spacepy/pybats/trace2d.py
+++ b/spacepy/pybats/trace2d.py
@@ -13,14 +13,7 @@ import warnings
 import numpy
 from .. import lib
 
-try:
-    assert(lib.have_libspacepy)
-except:
-    if 'sphinx' in sys.argv[0]:
-        warnings.warn('libspacepy not found. '
-                      'You appear to be building docs, so ignoring this error.')
-    else:
-        raise
+assert(lib.have_libspacepy)
 
 
 def _trace2d_common(func, fieldx, fieldy, xstart, ystart, gridx, gridy,

--- a/tests/integration_all.py
+++ b/tests/integration_all.py
@@ -12,6 +12,7 @@ Copyright 2019 SpacePy contributors
 
 import unittest
 
+import spacepy_testing
 from integration_omni import *
 from integration_toolbox import *
 

--- a/tests/integration_omni.py
+++ b/tests/integration_omni.py
@@ -8,6 +8,7 @@ Copyright 2019 SpacePy contributors
 import unittest
 
 import numpy.testing
+import spacepy_testing
 import spacepy
 import spacepy.omni
 import spacepy.time

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -19,6 +19,7 @@ import tempfile
 import threading
 import unittest
 
+import spacepy_testing
 import spacepy.toolbox
 
 

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -9,3 +9,7 @@ import os.path
 
 
 testsdir = os.path.dirname(os.path.abspath(__file__))
+"""Directory containing the unit test scripts"""
+
+datadir = os.path.join(testsdir, 'data')
+"""Directory containing unit test data"""

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -6,6 +6,9 @@ This module is importable from test scripts that are in this directory.
 """
 
 import os.path
+import re
+import sys
+import warnings
 
 
 testsdir = os.path.dirname(os.path.abspath(__file__))
@@ -13,3 +16,160 @@ testsdir = os.path.dirname(os.path.abspath(__file__))
 
 datadir = os.path.join(testsdir, 'data')
 """Directory containing unit test data"""
+
+
+class assertWarns(warnings.catch_warnings):
+    """Tests that a warning is raised.
+
+    Use as a context manager.  Code within the context manager block
+    will be executed and, on exit from the block, all warnings issued
+    during execution of the block will be checked to see if the warning
+    specified was issued.
+
+    :class:`assertWarns` requires that the matched warning be issued *exactly
+    once* within the context manager, or the test function will fail (whether
+    the warning was issued not at all, or multiple times).
+    :class:`assertDoesntWarn` requires that matched warnings are not issued
+    at all.
+
+    All other warnings are issued as normal, although the warning will not
+    be shown (e.g. printed) until the exit of the context manager. If
+    code within the context manager issues an exception, the test for
+    warnings will be skipped (test failure will not be issued), and all
+    warnings shown before the exception propagates up the stack.
+
+    The parameters determining which warning to match refer to the code that
+    actually issues the warning, not the code being warned. E.g. if code
+    calls a deprecated function, and the deprecated function issues a
+    ``DeprecationWarning``, what is matched is the code in the deprecated
+    function, not the caller.
+
+    Parameters
+    ----------
+    test : unittest.TestCase
+        The test case from which this is being called, almost always
+        ``self`` (so the :meth:`~unittest.TestCase.fail` method is available).
+
+    action : {None, 'default', 'error', 'ignore', 'always', 'module', 'once'}
+        If specified (i.e. not ``None``), a warning filter matching the
+        specified warning will be added to the filter before executing the
+        block. ``always`` is generally recommended to make sure the tested
+        warning will be raised. If ``always`` is specified, on Python 2 the log
+        of previously-issued warnings will be edited to work around a
+        `Python bug <https://stackoverflow.com/questions/56821539/>`_. In this
+        case using ``module`` is strongly recommended to minimize the impact
+        of this editing. This filter will be removed on completion of the
+        block.
+
+    message : str, optional
+        Regular expression to match the start of warning message. Default
+        is to match all.
+
+    category : type, optional
+        Matches if the warning is an instance of this type or a subclass.
+        Default is the base `Warning` type (matches all warnings).
+
+    module : str, optional
+        Regular expression to match the start of the name of the module
+        from which the warning is issued. This is primarily used in setting
+        up the warnings filter; matching the module to determine if the
+        desired warning was issued is based on filename and may not work
+        for modules built into the interpreter. Default is to match all.
+
+    lineno : int, optional
+        Line number from which the warning was issued. This is rarely
+        useful since it will change from version to version. Default (0) will
+        match all lines.
+
+    See Also
+    --------
+    warnings.filterwarnings :
+        The ``action``, ``message``, ``category``, ``module``, and
+        ``lineno`` parameters are based on the filter specifications.
+
+    Examples
+    --------
+    This class is primarily useful as part of a test suite, and cannot
+    be easily demonstrated through interactive examples. See the tests
+    of it in ``test_testing.py`` and its usage throughout the test suite.
+    """
+    requireWarning = True
+    """If True, requires that the matching warning be issued (i.e. fail
+       if the warning isn't issued.) If False, fail if warning is issued."""
+    def __init__(self, test, action=None, message='', category=Warning,
+                 module='', lineno=0):
+        self._filterspec = (action, message, category, module, lineno)
+        self._testcase = test
+        super(assertWarns, self).__init__(record=True)
+
+    def __enter__(self):
+        """Enter the context manager, called at start of block."""
+        self._log = super(assertWarns, self).__enter__()
+        """Log of warnings issued within context block."""
+        if self._filterspec[0] is not None:
+            warnings.filterwarnings(*self._filterspec)
+        if self._filterspec[0] == 'always' and sys.version_info[0:2] == (2, 7):
+            # Bug in 2.7: 'always' doesn't work if warning was previously
+            # issued, so remove any record of it being issued, which
+            # is stored by module.
+            msg_pat = re.compile(self._filterspec[1], re.I)
+            cat = self._filterspec[2]
+            mod_pat = re.compile(self._filterspec[3])
+            for m in list(sys.modules):
+                if mod_pat.match(m)\
+                   and hasattr(sys.modules[m], '__warningregistry__'):
+                    reg = sys.modules[m].__warningregistry__
+                    for k in list(reg.keys()):
+                        if msg_pat.match(k[0]) and issubclass(k[1], cat):
+                            del reg[k]
+                            break
+
+    def __exit__(self, *exc_info):
+        """Exit context manager, called at exit of block"""
+        retval = super(assertWarns, self).__exit__(*exc_info)
+        if exc_info[0] is not None: # Exception in handling, show all warnings
+            for w in self._log:
+                warnings.showwarning(
+                    w.message, w.category, w.filename, w.lineno)
+            return retval
+        n_match = 0 # Number of matching warnings
+        msg_pat = re.compile(self._filterspec[1], re.I)
+        cat = self._filterspec[2]
+        mod_pat = self._filterspec[3]
+        matchall = not mod_pat #Empty pattern, match all modules
+        mod_pat = re.compile(mod_pat)
+        lineno = int(self._filterspec[4])
+        # show_warnings isn't given the module, just the filename,
+        # so find filenames of desired modules.
+        mod_files = []
+        for m in list(sys.modules):
+            if mod_pat.match(m) and hasattr(sys.modules[m], '__file__'):
+                fnl = sys.modules[m].__file__
+                if fnl is None:
+                    continue
+                fnl = fnl.lower()
+                if fnl.endswith(('.pyc', '.pyo')):
+                    fnl = fnl[:-1]
+                mod_files.append(fnl)
+        for w in self._log:
+            if issubclass(w.category, cat) \
+               and (matchall or w.filename in mod_files) \
+               and msg_pat.match(str(w.message)) and lineno in (0, w.lineno):
+                n_match += 1
+            else:
+                warnings.showwarning(
+                    w.message, w.category, w.filename, w.lineno)
+        if self.requireWarning:
+            if n_match == 0:
+                self._testcase.fail('Warning not issued.')
+            elif n_match > 1:
+                self._testcase.fail('Warning issued {} times.'.format(n_match))
+        elif n_match:
+            self._testcase.fail('Warning was issued.')
+
+
+class assertDoesntWarn(assertWarns):
+    __doc__ = 'Tests that a warning is not raised.' \
+              + assertWarns.__doc__[assertWarns.__doc__.index('\n'):]
+    requireWarning = False
+    pass

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+"""Helper functions for SpacePy unit tests
+
+This module is importable from test scripts that are in this directory.
+"""
+
+import os.path
+
+
+testsdir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -73,11 +73,12 @@ class assertWarns(warnings.catch_warnings):
         The test case from which this is being called, almost always
         ``self`` (so the :meth:`~unittest.TestCase.fail` method is available).
 
-    action : {None, 'default', 'error', 'ignore', 'always', 'module', 'once'}
-        If specified (i.e. not ``None``), a warning filter matching the
-        specified warning will be added to the filter before executing the
-        block. ``always`` is generally recommended to make sure the tested
-        warning will be raised. If ``always`` is specified, on Python 2 the log
+    action : {'always', ``None``, 'default', 'error', 'ignore', 'module',
+              'once'}
+        Unless ``None``, a warning filter matching the specified warning will
+        be added to the filter before executing the block. 'always'
+        (default) is generally recommended to make sure the tested
+        warning will be raised. If 'always' is specified, on Python 2 the log
         of previously-issued warnings will be edited to work around a
         `Python bug <https://stackoverflow.com/questions/56821539/>`_. In this
         case using ``module`` is strongly recommended to minimize the impact
@@ -119,7 +120,7 @@ class assertWarns(warnings.catch_warnings):
     requireWarning = True
     """If True, requires that the matching warning be issued (i.e. fail
        if the warning isn't issued.) If False, fail if warning is issued."""
-    def __init__(self, test, action=None, message='', category=Warning,
+    def __init__(self, test, action='always', message='', category=Warning,
                  module='', lineno=0):
         self._filterspec = (action, message, category, module, lineno)
         self._testcase = test

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -61,11 +61,12 @@ class assertWarns(warnings.catch_warnings):
     warnings will be skipped (test failure will not be issued), and all
     warnings shown before the exception propagates up the stack.
 
-    The parameters determining which warning to match refer to the code that
-    actually issues the warning, not the code being warned. E.g. if code
-    calls a deprecated function, and the deprecated function issues a
-    ``DeprecationWarning``, what is matched is the code in the deprecated
-    function, not the caller.
+    The parameters determining which warning to match are for the code
+    referenced in the warning, not necessarily the code being warned.
+    E.g. if code calls a deprecated function, and the deprecated function
+    issues a ``DeprecationWarning``, what is matched may be the code in the
+    deprecated function, not the caller; see the ``stacklevel`` parameter
+    to :func:`~warnings.warn` for how this may be changed.
 
     Parameters
     ----------

--- a/tests/test_ae9ap9.py
+++ b/tests/test_ae9ap9.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 
 from spacepy import ae9ap9
+import spacepy_testing
 
 __all__ = ['ae9ap9Tests', ]
 
@@ -29,8 +30,9 @@ class ae9ap9Tests(unittest.TestCase):
     
     def setUp(self):
         super(ae9ap9Tests, self).setUp()
-        pth = os.path.dirname(os.path.abspath(__file__))
-        self.datafiles = glob.glob(os.path.join(pth, 'data', 'Run1.AE9.CLoutput_mc_fluence_agg_pctile_??.txt'))
+        self.datafiles = glob.glob(os.path.join(
+            spacepy_testing.datadir,
+            'Run1.AE9.CLoutput_mc_fluence_agg_pctile_??.txt'))
         
     def tearDown(self):
         super(ae9ap9Tests, self).tearDown()

--- a/tests/test_ae9ap9.py
+++ b/tests/test_ae9ap9.py
@@ -17,8 +17,8 @@ import shutil
 import tempfile
 import unittest
 
-from spacepy import ae9ap9
 import spacepy_testing
+from spacepy import ae9ap9
 
 __all__ = ['ae9ap9Tests', ]
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -35,6 +35,7 @@ from test_plot_utils import *
 from test_rst import *
 from test_lib import *
 from test_ae9ap9 import *
+from test_testing import *
 # add others here as they are written
 
 if __name__ == '__main__':

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     import unittest as ut
 
+import spacepy_testing
+
 from test_pybats import *
 from test_time import *
 from test_empiricals import *

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,6 +10,7 @@ Copyright 2012 Los Alamos National Security, LLC.
 import unittest
 import warnings
 
+import spacepy_testing
 import spacepy
 
 
@@ -36,14 +37,9 @@ class SpacepyFuncTests(unittest.TestCase):
             "            this will test things\n"
             "            ",
             testfunc.__doc__)
-        with warnings.catch_warnings(record=True) as w:
-            #make sure to catch expected warnings
-            warnings.filterwarnings('always', 'pithy message',
-                                    DeprecationWarning, 'spacepy$')
+        with spacepy_testing.assertWarns(self, 'always', 'pithy message$',
+                                         DeprecationWarning, r'spacepy$'):
             self.assertEqual(2, testfunc(1))
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual('pithy message', str(w[0].message))
 
     def testDeprecationNone(self):
         """Test the deprecation decorator with no docstring"""
@@ -55,13 +51,9 @@ class SpacepyFuncTests(unittest.TestCase):
             "    .. deprecated:: 0.1\n"
             "       pithy message",
             testfunc.__doc__)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', 'pithy message',
-                                    DeprecationWarning, 'spacepy$')
+        with spacepy_testing.assertWarns(self, 'always', 'pithy message$',
+                                         DeprecationWarning, r'spacepy$'):
             self.assertEqual(2, testfunc(1))
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual('pithy message', str(w[0].message))
 
     def testDeprecationDifferentIndent(self):
         """Test the deprecation decorator, first line indented differently"""
@@ -101,13 +93,9 @@ class SpacepyFuncTests(unittest.TestCase):
             "            this will test things\n"
             "            ",
             testfunc.__doc__)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', 'pithy message',
-                                    DeprecationWarning, 'spacepy$')
+        with spacepy_testing.assertWarns(self, 'always', 'pithy message$',
+                                         DeprecationWarning, r'spacepy$'):
             self.assertEqual(2, testfunc(1))
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual('pithy message', str(w[0].message))
 
 
 if __name__ == '__main__':

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -37,7 +37,7 @@ class SpacepyFuncTests(unittest.TestCase):
             "            this will test things\n"
             "            ",
             testfunc.__doc__)
-        with spacepy_testing.assertWarns(self, 'always', 'pithy message$',
+        with spacepy_testing.assertWarns(self, 'always', r'pithy message$',
                                          DeprecationWarning, r'spacepy$'):
             self.assertEqual(2, testfunc(1))
 
@@ -51,7 +51,7 @@ class SpacepyFuncTests(unittest.TestCase):
             "    .. deprecated:: 0.1\n"
             "       pithy message",
             testfunc.__doc__)
-        with spacepy_testing.assertWarns(self, 'always', 'pithy message$',
+        with spacepy_testing.assertWarns(self, 'always', r'pithy message$',
                                          DeprecationWarning, r'spacepy$'):
             self.assertEqual(2, testfunc(1))
 
@@ -93,7 +93,7 @@ class SpacepyFuncTests(unittest.TestCase):
             "            this will test things\n"
             "            ",
             testfunc.__doc__)
-        with spacepy_testing.assertWarns(self, 'always', 'pithy message$',
+        with spacepy_testing.assertWarns(self, 'always', r'pithy message$',
                                          DeprecationWarning, r'spacepy$'):
             self.assertEqual(2, testfunc(1))
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -39,7 +39,7 @@ class SpacepyFuncTests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             #make sure to catch expected warnings
             warnings.filterwarnings('always', 'pithy message',
-                                    DeprecationWarning, '^spacepy')
+                                    DeprecationWarning, 'spacepy$')
             self.assertEqual(2, testfunc(1))
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
@@ -57,7 +57,7 @@ class SpacepyFuncTests(unittest.TestCase):
             testfunc.__doc__)
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', 'pithy message',
-                                    DeprecationWarning, '^spacepy')
+                                    DeprecationWarning, 'spacepy$')
             self.assertEqual(2, testfunc(1))
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)
@@ -103,7 +103,7 @@ class SpacepyFuncTests(unittest.TestCase):
             testfunc.__doc__)
         with warnings.catch_warnings(record=True) as w:
             warnings.filterwarnings('always', 'pithy message',
-                                    DeprecationWarning, '^spacepy')
+                                    DeprecationWarning, 'spacepy$')
             self.assertEqual(2, testfunc(1))
         self.assertEqual(1, len(w))
         self.assertEqual(DeprecationWarning, w[0].category)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -6,6 +6,7 @@ import os
 import datetime
 from numpy import array
 import numpy as np
+import spacepy_testing
 from spacepy.time import Ticktock
 try:
     import spacepy.irbempy as ib

--- a/tests/test_data_assimilation.py
+++ b/tests/test_data_assimilation.py
@@ -10,6 +10,7 @@ Copyright 2010-2012 Los Alamos National Security, LLC.
 import unittest
 
 import numpy
+import spacepy_testing
 import spacepy.toolbox as tb
 import spacepy.data_assimilation as da
 

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -21,6 +21,7 @@ import warnings
 import numpy.random
 import numpy.testing
 
+import spacepy_testing
 import spacepy.datamanager
 
 
@@ -31,10 +32,8 @@ __all__ = ["RePathTests", "DataManagerFunctionTests",
 class DataManagerClassTests(unittest.TestCase):
     def test_files_matching(self):
         """Files matching a format"""
-        pth = os.path.dirname(os.path.abspath(__file__))
-        dirlist = [os.path.join(pth, 'data', 'datamanager_test', '1'),
-                   os.path.join(pth, 'data', 'datamanager_test', '2'),
-                   ]
+        pth = os.path.join(spacepy_testing.datadir, 'datamanager_test')
+        dirlist = [os.path.join(pth, '1'), os.path.join(pth, '2')]
         cases = [
             {'files1': ['rbspa_ect-hope-sci-L2_20150409_v4.0.0.cdf',
                         'rbspa_ect-hope-sci-L2_20150410_v4.0.0.cdf'],

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -24,6 +24,7 @@ except ImportError:
 import sys
 import warnings
 
+import spacepy_testing
 import spacepy.datamodel as dm
 import spacepy.time as spt
 import numpy as np
@@ -781,9 +782,10 @@ class converterTestsCDF(unittest.TestCase):
 class JSONTests(unittest.TestCase):
     def setUp(self):
         super(JSONTests, self).setUp()
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-        self.filename = os.path.join(self.pth, 'data', '20130218_rbspa_MagEphem.txt')
-        self.filename_bad = os.path.join(self.pth, 'data', '20130218_rbspa_MagEphem_bad.txt')
+        self.filename = os.path.join(
+            spacepy_testing.datadir, '20130218_rbspa_MagEphem.txt')
+        self.filename_bad = os.path.join(
+            spacepy_testing.datadir, '20130218_rbspa_MagEphem_bad.txt')
         self.testdir = tempfile.mkdtemp()
         self.testfile = os.path.join(self.testdir, 'test.cdf')
 

--- a/tests/test_empiricals.py
+++ b/tests/test_empiricals.py
@@ -6,6 +6,7 @@ import warnings
 
 import dateutil.parser as dup
 import numpy as np
+import spacepy_testing
 import spacepy.time as spt
 import spacepy.toolbox as tb
 import spacepy.empiricals as em
@@ -79,14 +80,11 @@ class empFunctionTests(unittest.TestCase):
         self.assertRaises(KeyError, spam1)
 
     def test_getPlasmaPauseCA1992warn(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=RuntimeWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'No LT dependence currently supported for CA1992 model',
+                RuntimeWarning, r'spacepy\.empiricals$'):
             em.getPlasmaPause(self.ticks, model='CA1992', LT=12, omnivals=self.omnivals)
-        self.assertEqual(1, len(w))
-        self.assertEqual(RuntimeWarning, w[0].category)
-        self.assertEqual(
-            'No LT dependence currently supported for CA1992 model',
-            str(w[0].message))
 
     def test_getLmax(self):
         """getLmax should give known results (regression)"""

--- a/tests/test_irbempy.py
+++ b/tests/test_irbempy.py
@@ -7,6 +7,7 @@ Copyright 2010-2012 Los Alamos National Security, LLC.
 """
 
 import unittest
+import spacepy_testing
 import spacepy
 import spacepy.omni
 import spacepy.time

--- a/tests/test_lanlstar.py
+++ b/tests/test_lanlstar.py
@@ -11,6 +11,7 @@ import os.path
 import sys
 import unittest
 
+import spacepy_testing
 import spacepy
 import spacepy.LANLstar as sl
 import numpy

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -14,6 +14,7 @@ import warnings
 import numpy
 import numpy.testing
 
+import spacepy_testing
 import spacepy.lib
 
 

--- a/tests/test_omni.py
+++ b/tests/test_omni.py
@@ -12,6 +12,7 @@ import unittest
 from numpy import array
 import numpy.testing
 
+import spacepy_testing
 import spacepy
 import spacepy.omni as om
 

--- a/tests/test_plot_utils.py
+++ b/tests/test_plot_utils.py
@@ -21,6 +21,7 @@ import matplotlib.dates
 import matplotlib.pyplot as plt
 import numpy
 import numpy.testing
+import spacepy_testing
 import spacepy.plot.utils
 import spacepy.time as st
 import spacepy.toolbox as tb

--- a/tests/test_poppy.py
+++ b/tests/test_poppy.py
@@ -19,6 +19,7 @@ import unittest
 import numpy
 import numpy.random
 import scipy.special
+import spacepy_testing
 try:
     import poppy
 except ImportError:

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -18,6 +18,7 @@ import unittest
 import numpy as np
 import numpy.testing
 
+import spacepy_testing
 import spacepy.pybats      as pb
 import spacepy.pybats.bats as pbs
 import spacepy.pybats.ram  as ram
@@ -39,8 +40,8 @@ class TestParseFileTime(unittest.TestCase):
              'y=0_mhd_1_e20130924-220500-054.out',
              'y=0_mhd_2_t00001430_n00031073.out',
              'z=0_mhd_2_t00050000_n00249620.out',
-             os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          'data', 'pybats_test', 'mag_grid_ascii.out'),
+             os.path.join(spacepy_testing.datadir,
+                          'pybats_test', 'mag_grid_ascii.out'),
     ]
     dates = [dt(2013,9,24,23,26,0), dt(2013,9,24,22, 5,0),
              None, None, None]
@@ -64,12 +65,11 @@ class TestIdlFile(unittest.TestCase):
     knownMhdXmax = 31.0
     knownMhdXmin = -220.0
     knownMhdZlim = 124.0
-    def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
 
     def testBinary(self):
         # Open file:
-        mhd = pb.IdlFile(os.path.join(self.pth, 'data', 'pybats_test', 'y0_binary.out'))
+        mhd = pb.IdlFile(os.path.join(spacepy_testing.datadir,
+                                      'pybats_test', 'y0_binary.out'))
 
         # Test units are loaded correctly:
         for v in mhd:
@@ -84,7 +84,8 @@ class TestIdlFile(unittest.TestCase):
             
     def testAscii(self):
         # Open file:
-        mhd = pb.IdlFile(os.path.join(self.pth, 'data', 'pybats_test', 'y0_ascii.out'),
+        mhd = pb.IdlFile(os.path.join(
+            spacepy_testing.datadir, 'pybats_test', 'y0_ascii.out'),
                          format='ascii')
 
         # Test units are loaded correctly:
@@ -101,7 +102,8 @@ class TestIdlFile(unittest.TestCase):
     def testReadAsciiAsBin(self):
         """Read an ASCII file as a binary"""
         try:
-            data = pb.IdlFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_ascii.out'),
+            data = pb.IdlFile(os.path.join(
+                spacepy_testing.datadir, 'pybats_test', 'mag_grid_ascii.out'),
                               format='bin', header=None, keep_case=True)
         except EOFError as e:
             msg = str(e)
@@ -120,14 +122,11 @@ class TestRim(unittest.TestCase):
               's_Iup'  :0.2517603660687805,
               's_Idown':-0.2517603668899454}
     
-    def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-
     def testReadZip(self):
         from spacepy.pybats import rim
 
         # Open file:
-        iono=rim.Iono(os.path.join(self.pth, 'data', 'pybats_test',
+        iono=rim.Iono(os.path.join(spacepy_testing.datadir, 'pybats_test',
                                    'it000321_104510_000.idl.gz'))
         
 
@@ -139,7 +138,7 @@ class TestRim(unittest.TestCase):
 
         try:
             # Unzip file and create a copy of it:
-            name_in = os.path.join(self.pth, 'data', 'pybats_test',
+            name_in = os.path.join(spacepy_testing.datadir, 'pybats_test',
                                    'it000321_104510_000.idl.gz')
             name_out= name_in[:-3]
             with gzip.open(name_in, 'rb') as f_in, open(name_out, 'wb') as f_out:
@@ -154,14 +153,14 @@ class TestRim(unittest.TestCase):
     def testReadWrapped(self):
         '''Test reading files where entries are wrapped over multiple lines.'''
         from spacepy.pybats import rim
-        iono = rim.Iono(os.path.join(self.pth, 'data', 'pybats_test',
+        iono = rim.Iono(os.path.join(spacepy_testing.datadir, 'pybats_test',
                                      'it_wrapped.idl.gz'))
                 
     def testIonoCalc(self):
         '''Test calculations made by rim.Iono objects.'''
         from spacepy.pybats import rim
 
-        iono = rim.Iono(os.path.join(self.pth, 'data', 'pybats_test',
+        iono = rim.Iono(os.path.join(spacepy_testing.datadir, 'pybats_test',
                                      'it000321_104510_000.idl.gz'))
         iono.calc_I()
         for key in self.knownI:
@@ -172,7 +171,7 @@ class TestRim(unittest.TestCase):
         import matplotlib as mpl
         import matplotlib.pyplot as plt
         
-        iono = rim.Iono(os.path.join(self.pth, 'data', 'pybats_test',
+        iono = rim.Iono(os.path.join(spacepy_testing.datadir, 'pybats_test',
                                      'it000321_104510_000.idl.gz'))
         out = iono.add_cont('n_jr', add_cbar=True)
 
@@ -186,8 +185,7 @@ class TestBats2d(unittest.TestCase):
     Test functionality of Bats2d objects.
     '''
     def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-        self.mhd = pbs.Bats2d(os.path.join(self.pth, 'data', 'pybats_test', 'y0_binary.out'))
+        self.mhd = pbs.Bats2d(os.path.join(spacepy_testing.datadir, 'pybats_test', 'y0_binary.out'))
     
     def testCalc(self):
         # Test all calculations:
@@ -195,7 +193,8 @@ class TestBats2d(unittest.TestCase):
         
     def testMultispecies(self):
         # Open file:
-        mhd = pbs.Bats2d(os.path.join(self.pth, 'data', 'pybats_test', 'cut_multispecies.out'), format='ascii')
+        mhd = pbs.Bats2d(os.path.join(spacepy_testing.datadir, 'pybats_test',
+                                      'cut_multispecies.out'), format='ascii')
         mspec_varnames='x Rho Ux Uy Uz Bx By Bz P OpRho OpUx OpUy OpUz OpP jx jy jz g rbody cuty cutz'.split()
         mspec_units='km Mp/cc km/s km/s km/s nT nT nT nPa Mp/cc km/s km/s km/s nPa uA/m2 uA/m2 uA/m2'.split()
         knownMultispecUnits = dict(zip(mspec_varnames,
@@ -252,15 +251,14 @@ class TestMagGrid(unittest.TestCase):
     knownDbhMax = 8.07703468843
     knownPedMax = 2.783385368
 
-    def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-
     def testOpen(self):
         # Open both binary and ascii versions of same data.
         # Ensure expected values are loaded.
-        m1 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_ascii.out'),
+        m1 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
+                                          'pybats_test', 'mag_grid_ascii.out'),
                               format='ascii')
-        m2 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_binary.out'))
+        m2 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
+                                          'pybats_test', 'mag_grid_binary.out'))
 
         self.assertAlmostEqual(self.knownDbnMax, m1['dBn'].max())
         self.assertAlmostEqual(self.knownPedMax, m1['dBnPed'].max())
@@ -271,8 +269,10 @@ class TestMagGrid(unittest.TestCase):
         # Open both binary and ascii versions of same data
         # without specifying the type.
         # Ensure expected values are loaded.
-        m1 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_ascii.out'))
-        m2 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_binary.out'))
+        m1 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
+                                          'pybats_test', 'mag_grid_ascii.out'))
+        m2 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
+                                          'pybats_test', 'mag_grid_binary.out'))
 
         self.assertAlmostEqual(self.knownDbnMax, m1['dBn'].max())
         self.assertAlmostEqual(self.knownPedMax, m1['dBnPed'].max())
@@ -282,9 +282,11 @@ class TestMagGrid(unittest.TestCase):
     def testCalc(self):
         # Open both binary and ascii versions of same data.
         # Ensure calculations give expected values.
-        m1 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_ascii.out'),
+        m1 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
+                                          'pybats_test', 'mag_grid_ascii.out'),
                               format='ascii')
-        m2 = pbs.MagGridFile(os.path.join(self.pth, 'data', 'pybats_test', 'mag_grid_binary.out'))
+        m2 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
+                                          'pybats_test', 'mag_grid_binary.out'))
 
         # Calculation of H-component:
         m1.calc_h()
@@ -297,7 +299,6 @@ class TestSatOrbit(unittest.TestCase):
     Test reading and writing of satellite orbit files.
     '''
     def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
         # Create 5 minutes of fake data:
         self.start = dt.datetime(2000,1,1)
         self.time = np.array([self.start+dt.timedelta(minutes=i)
@@ -349,7 +350,8 @@ class TestSatOrbit(unittest.TestCase):
         from spacepy.pybats import SatOrbit
         from numpy.testing import assert_array_equal as assert_array
 
-        sat = SatOrbit(os.path.join(self.pth, 'data', 'pybats_test', 'testsat.dat'))
+        sat = SatOrbit(os.path.join(spacepy_testing.datadir, 'pybats_test',
+                                    'testsat.dat'))
 
         # Check header:
         self.assertEqual(sorted(sat.attrs['head']),
@@ -371,12 +373,10 @@ class TestVirtSat(unittest.TestCase):
     knownSatOmax = 1.72270E-04
     knownSatHmax = 1.72235
 
-    def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-
     def testOpen(self):
         # Open file, ensure values are read properly.
-        sat = pbs.VirtSat(os.path.join(self.pth, 'data', 'pybats_test', 'sat_multispecies.sat'))
+        sat = pbs.VirtSat(os.path.join(spacepy_testing.datadir,
+                                       'pybats_test', 'sat_multispecies.sat'))
         self.assertEqual(self.knownSatXmax, sat['x'].max())
         self.assertEqual(self.knownSatPmax, sat['p'].max())
         self.assertEqual(self.knownSatHmax, sat['rhoh'].max())
@@ -384,7 +384,8 @@ class TestVirtSat(unittest.TestCase):
 
     def testCalc(self):
         # Test various unit calculations
-        sat = pbs.VirtSat(os.path.join(self.pth, 'data', 'pybats_test', 'sat_multispecies.sat'))
+        sat = pbs.VirtSat(os.path.join(spacepy_testing.datadir,
+                                       'pybats_test', 'sat_multispecies.sat'))
 
         # Test calculation of species number density:
         sat.calc_ndens()
@@ -396,10 +397,11 @@ class TestImfInput(unittest.TestCase):
     Test reading, writing, and plotting from ImfInput files.
     '''
     def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
         # Files to open:
-        self.file_single = os.path.join(self.pth, 'data', 'pybats_test', 'imf_single.dat')
-        self.file_multi  = os.path.join(self.pth, 'data', 'pybats_test', 'imf_multi.dat')
+        self.file_single = os.path.join(spacepy_testing.datadir,
+                                        'pybats_test', 'imf_single.dat')
+        self.file_multi  = os.path.join(spacepy_testing.datadir,
+                                        'pybats_test', 'imf_multi.dat')
         self.sing = pb.ImfInput(self.file_single)
         self.mult = pb.ImfInput(self.file_multi)
 
@@ -513,8 +515,8 @@ class TestExtraction(unittest.TestCase):
     Test Extraction class by opening a file with known solution.
     '''
     def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-        self.mhd = pbs.Bats2d(os.path.join(self.pth, 'data', 'pybats_test', 'z0_sine.out'))
+        self.mhd = pbs.Bats2d(os.path.join(spacepy_testing.datadir,
+                                           'pybats_test', 'z0_sine.out'))
     
     def testExtract(self):
         analytic = lambda x: 1.+.5*np.cos(x*np.pi/10.)
@@ -534,16 +536,14 @@ class TestGitm(unittest.TestCase):
     shape = (18,18)
     lat1  = 1.48352986
     
-    def setUp(self):
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-
     def testBinary(self):
         '''
         This tests the ability to open a file and correctly read the attributes and 
         variables as well as properly reshape the arrays and remove unused dimensions.
         '''
         # Open 2D file:
-        f = gitm.GitmBin(os.path.join(self.pth, 'data', 'pybats_test', 'gitm_2D.bin'))
+        f = gitm.GitmBin(os.path.join(spacepy_testing.datadir, 'pybats_test',
+                                      'gitm_2D.bin'))
         # Check some critical attributes/values:
         self.assertEqual(self.nVars, f.attrs['nVars'])
         self.assertEqual(self.nLat,  f.attrs['nLat'])
@@ -559,8 +559,8 @@ class RampyTests(unittest.TestCase):
     '''
     def setUp(self):
         super(RampyTests, self).setUp()
-        self.pth = os.path.dirname(os.path.abspath(__file__))
-        self.testfile = os.path.join(self.pth, 'data', 'pybats_test', 'ramsat_test.nc')
+        self.testfile = os.path.join(spacepy_testing.datadir, 'pybats_test',
+                                     'ramsat_test.nc')
 
     def tearDown(self):
         super(RampyTests, self).tearDown()

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -31,6 +31,7 @@ import warnings
 import matplotlib.dates
 import numpy
 import numpy.testing
+import spacepy_testing
 from spacepy import datamodel
 import spacepy.pycdf as cdf
 import spacepy.pycdf.const as const
@@ -690,8 +691,8 @@ class MakeCDF(unittest.TestCase):
     def setUp(self):
         self.testdir = tempfile.mkdtemp()
         self.testfspec = os.path.join(self.testdir, 'foo.cdf')
-        pth = os.path.dirname(os.path.abspath(__file__))
-        self.testmaster = os.path.join(pth, 'po_l1_cam_testc.cdf')
+        self.testmaster = os.path.join(spacepy_testing.testsdir,
+                                       'po_l1_cam_testc.cdf')
 
     def tearDown(self):
         shutil.rmtree(self.testdir)
@@ -1138,16 +1139,14 @@ class CDFTestsBase(unittest.TestCase):
 
 class CDFTests(CDFTestsBase):
     """Tests that involve an existing CDF, read or write"""
-    pth = os.path.dirname(os.path.abspath(__file__))
-    testmaster = os.path.join(pth, 'po_l1_cam_test.cdf')
+    testmaster = os.path.join(spacepy_testing.testsdir, 'po_l1_cam_test.cdf')
     testbase = 'test.cdf'
     expected_digest = '94515e62d38a31ad02f6d435274cbfe7'
 
 
 class ColCDFTests(CDFTestsBase):
     """Tests that involve an existing column-major CDF, read or write"""
-    pth = os.path.dirname(os.path.abspath(__file__))
-    testmaster = os.path.join(pth, 'po_l1_cam_testc.cdf')
+    testmaster = os.path.join(spacepy_testing.testsdir, 'po_l1_cam_testc.cdf')
     testbase = 'testc.cdf'
     expected_digest = '7728439e20bece4c0962a125373345bf'
 

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1080,7 +1080,7 @@ class VarBundleChecks(VarBundleChecksBase):
         bundle.slice(1, [2, 3, 5])
         with spacepy_testing.assertDoesntWarn(
                 self, 'always',
-                'Using a non-tuple sequence for multidimensional indexing',
+                r'Using a non-tuple sequence for multidimensional indexing',
                 FutureWarning, r'spacepy\.pycdf\.istp$'):
             bundle.output(self.outcdf)
         numpy.testing.assert_array_equal(

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -13,6 +13,7 @@ import warnings
 
 import numpy
 import numpy.testing
+import spacepy_testing
 import spacepy
 import spacepy.pycdf
 import spacepy.pycdf.const
@@ -857,8 +858,8 @@ class VarBundleChecksBase(unittest.TestCase):
             self.tempdir, 'source_descriptor_datatype_19990101_v00.cdf'),
                                      create=True)
         spacepy.pycdf.lib.set_backward(True)
-        pth = os.path.dirname(os.path.abspath(__file__))
-        self.incdf = spacepy.pycdf.CDF(os.path.join(pth, self.testfile))
+        self.incdf = spacepy.pycdf.CDF(os.path.join(
+            spacepy_testing.testsdir, self.testfile))
 
     def tearDown(self):
         """Close CDFs; delete output"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1197,14 +1197,18 @@ class VarBundleChecks(VarBundleChecksBase):
         counts = self.incdf['SectorRateScalersCounts'][...]
         counts[counts < 0] = numpy.nan
         #suppress bad value warnings
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', 'Mean of empty slice', RuntimeWarning)
             expected = numpy.nanmean(counts, axis=2)
         expected[numpy.isnan(expected)] = -1e31
         numpy.testing.assert_allclose(
             expected, self.outcdf['SectorRateScalersCounts'][...])
         sigma = self.incdf['SectorRateScalersCountsSigma'][...]
         sigma[sigma < 0] = numpy.nan
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', 'invalid value encountered in divide', RuntimeWarning)
             expected = numpy.sqrt(numpy.nansum(sigma ** 2, axis=2)) \
                         / (~numpy.isnan(sigma)).sum(axis=2)
         expected[numpy.isnan(expected)] = -1e31

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1078,16 +1078,11 @@ class VarBundleChecks(VarBundleChecksBase):
         bundle = spacepy.pycdf.istp.VarBundle(
             self.incdf['SectorRateScalersCounts'])
         bundle.slice(1, [2, 3, 5])
-        with warnings.catch_warnings(record=True) as cm:
+        with spacepy_testing.assertDoesntWarn(
+                self, 'always',
+                'Using a non-tuple sequence for multidimensional indexing',
+                FutureWarning, r'spacepy\.pycdf\.istp$'):
             bundle.output(self.outcdf)
-        for w in cm:
-            if w.category is FutureWarning\
-               and str(w.message).startswith(
-                   'Using a non-tuple sequence for multidimensional indexing'):
-                self.fail('Raised FutureWarning for non-tuple sequence index.')
-            else:
-                warnings.showwarning(
-                    w.message, w.category, w.filename, w.lineno)
         numpy.testing.assert_array_equal(
             self.outcdf['SectorRateScalersCounts'][...],
             self.incdf['SectorRateScalersCounts'][...][:, [2, 3, 5], ...])

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -8,6 +8,7 @@ Copyright 2010-2012 Los Alamos National Security, LLC.
 """
 import unittest
 
+import spacepy_testing
 import spacepy.rst as rst
 
 __all__ = ['RSTTests', ]

--- a/tests/test_seapy.py
+++ b/tests/test_seapy.py
@@ -32,7 +32,7 @@ class SEATestsUniform(unittest.TestCase):
         self.unidata = [self.testval]*200
         time = list(range(200))
         self.epochs = [20,40,60,80,100,120,140,160,180]
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.filterwarnings('always', 'Window size changed .*',
                                     UserWarning, '^spacepy\\.seapy$')
             self.obj = seapy.Sea(self.unidata, time, self.epochs, verbose=False)

--- a/tests/test_seapy.py
+++ b/tests/test_seapy.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 import numpy.testing as ntest
 
+import spacepy_testing
 try:
     import seapy
 except ImportError:

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -13,6 +13,7 @@ import numpy as np
 import datetime
 import matplotlib.dates as mdates
 
+import spacepy_testing
 import spacepy.datamodel as dm
 import spacepy.toolbox as tb
 
@@ -54,21 +55,12 @@ class spectrogramTests(unittest.TestCase):
 
     def test_deprecation(self):
         """Deprecation warning on old name"""
-        with warnings.catch_warnings(record=True) as cm:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'Use spacepy\.plot\.Spectrogram \(capitalized\)\.',
+                DeprecationWarning, r'spacepy.plot$'):
             a = spacepy.plot.spectrogram(
                 self.data, variables=self.kwargs['variables'])
-        n_match = 0
-        for w in cm:
-            if w.category is DeprecationWarning\
-               and str(w.message) \
-               == 'Use spacepy.plot.Spectrogram (capitalized).':
-                n_match += 1 # We're expecting this warning
-            else:
-                # Anything else, show as normal
-                warnings.showwarning(
-                    w.message, w.category, w.filename, w.lineno)
-        self.assertEqual(1, n_match) # Did we get the one we wanted?
 
     def test_defaults(self):
         """run it and check that defaults were set correctly"""

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -11,8 +11,73 @@ import warnings
 import spacepy_testing
 
 
+class SPTestWarning(Warning):
+    """Used to have a unique type of warning"""
+    pass
+
 class SpacepyTestingTests(unittest.TestCase):
     """Simple tests for the testing support"""
+
+    def testassertWarnsSimple(self):
+        """Simple test of assertWarns"""
+        # This is most similar to how it would normally be used
+        with spacepy_testing.assertWarns(
+                self, 'always', r'f.*', SPTestWarning):
+            warnings.warn('foo', SPTestWarning)
+
+    def testassertWarnsfilter(self):
+        """assertWarns only acts on desired warnings"""
+        with warnings.catch_warnings(record=True) as cm:
+            with spacepy_testing.assertWarns(
+                    self, 'always', r'f.*', SPTestWarning):
+                warnings.warn('foo', SPTestWarning)
+                warnings.warn('foo')
+                warnings.warn('bar', SPTestWarning)
+        # Verify that the other two warnings were issued as expected
+        self.assertEqual(2, len(cm))
+        for w in cm:
+            self.assertIn(w.category, (UserWarning, SPTestWarning))
+            if w.category is UserWarning:
+                self.assertEqual('foo', str(w.message))
+            else:
+                self.assertEqual('bar', str(w.message))
+
+    def testassertWarnsTwice(self):
+        """Issue warning twice, test fails"""
+        with self.assertRaises(AssertionError):
+            with spacepy_testing.assertWarns(
+                self, 'always', r'f.*', SPTestWarning):
+                warnings.warn('foo', SPTestWarning)
+                warnings.warn('foo2', SPTestWarning)
+
+    def testassertDoesntWarnSimple(self):
+        """Simple test of doesn't warn"""
+        with spacepy_testing.assertDoesntWarn(
+                self, 'always', r'f.*', SPTestWarning):
+            pass
+
+    def testassertDoesntWarnIssued(self):
+        """Issue warning, test fails"""
+        with self.assertRaises(AssertionError):
+            with spacepy_testing.assertDoesntWarn(
+                self, 'always', r'f.*', SPTestWarning):
+                warnings.warn('foo', SPTestWarning)
+
+    def testassertDoesntWarnfilter(self):
+        """assertDoesntWarn only acts on desired warnings"""
+        with warnings.catch_warnings(record=True) as cm:
+            with spacepy_testing.assertDoesntWarn(
+                    self, 'always', r'f.*', SPTestWarning):
+                warnings.warn('foo')
+                warnings.warn('bar', SPTestWarning)
+        # Verify that the other two warnings were issued as expected
+        self.assertEqual(2, len(cm))
+        for w in cm:
+            self.assertIn(w.category, (UserWarning, SPTestWarning))
+            if w.category is UserWarning:
+                self.assertEqual('foo', str(w.message))
+            else:
+                self.assertEqual('bar', str(w.message))
 
 
 if __name__ == '__main__':

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+"""Test of test-suite helper functions
+
+Tests to ensure that the more involved support in spacepy_testing works.
+"""
+
+import unittest
+import warnings
+
+import spacepy_testing
+
+
+class SpacepyTestingTests(unittest.TestCase):
+    """Simple tests for the testing support"""
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -133,7 +133,7 @@ class TimeFunctionTests(unittest.TestCase):
                     [0, 59, 59])
         with spacepy_testing.assertWarns(
                 self, 'always',
-                'Number of seconds > seconds in day\. Try days keyword\.$',
+                r'Number of seconds > seconds in day\. Try days keyword\.$',
                 UserWarning, r'spacepy\.time$'):
             for i, val in enumerate(inval):
                 ans = t.sec2hms(*val)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -30,6 +30,7 @@ except: # Don't bring down whole test suite
     HAVE_ASTROPY = False
 import numpy
 
+import spacepy_testing
 import spacepy
 import spacepy.pycdf
 import spacepy.time as t
@@ -130,17 +131,13 @@ class TimeFunctionTests(unittest.TestCase):
                     [0, 0, 1],
                     [0, 0, 30],
                     [0, 59, 59])
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings(
-                'always', 'Number of seconds > seconds in day.*',
-                UserWarning, '^spacepy\\.time')
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                'Number of seconds > seconds in day\. Try days keyword\.$',
+                UserWarning, r'spacepy\.time$'):
             for i, val in enumerate(inval):
                 ans = t.sec2hms(*val)
                 self.assertEqual(real_ans[i], ans)
-        self.assertEqual(1, len(w))
-        self.assertEqual(
-            'Number of seconds > seconds in day. Try days keyword.',
-            str(w[0].message))
         self.assertEqual(t.sec2hms(12, False, False, True), datetime.timedelta(seconds=12))
 
     def test_no_tzinfo(self):
@@ -1038,14 +1035,11 @@ class TimeClassTests(unittest.TestCase):
         t0 = 1663236947
         range_ex = list(numpy.linspace(t0, t0 + 4000, 4))
         # make a TAI that is a leapsecond time
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'now\(\) returns UTC time as of 0\.2\.2\.$',
+                DeprecationWarning, r'spacepy\.time$'):
             tt2 = t.Ticktock.now()
-        self.assertEqual(1, len(w))
-        self.assertEqual(w[0].category, DeprecationWarning)
-        self.assertEqual(
-            'now() returns UTC time as of 0.2.2.',
-            str(w[0].message))
         tt2tai = tt2.TAI
         taileaps = tt2.TAIleaps
         range_ex.append(taileaps[39] - 1)
@@ -1383,29 +1377,26 @@ class TimeClassTests(unittest.TestCase):
 
     def test_now(self):
         """now() is at least deterministic"""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'now\(\) returns UTC time as of 0\.2\.2\.$',
+                DeprecationWarning, r'spacepy\.time$'):
             v1 = t.Ticktock.now()
-            time.sleep(0.1)
+        time.sleep(0.1)
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'now\(\) returns UTC time as of 0\.2\.2\.$',
+                DeprecationWarning, r'spacepy\.time$'):
             v2 = t.Ticktock.now()
-        self.assertEqual(2, len(w))
-        for i in (0, 1):
-            self.assertEqual(w[i].category, DeprecationWarning)
-            self.assertEqual(
-                'now() returns UTC time as of 0.2.2.',
-                str(w[i].message))
         self.assertTrue(v1 < v2)
 
     def test_today(self):
         """today() has 0 time"""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'today\(\) returns UTC day as of 0\.2\.2\.$',
+                DeprecationWarning, r'spacepy\.time$'):
             v1 = t.Ticktock.today()
-        self.assertEqual(1, len(w))
-        self.assertEqual(w[0].category, DeprecationWarning)
-        self.assertEqual(
-            'today() returns UTC day as of 0.2.2.',
-            str(w[0].message))
         self.assertEqual(v1.UTC[0].hour, 0)
         self.assertEqual(v1.UTC[0].minute, 0)
         self.assertEqual(v1.UTC[0].second, 0)
@@ -1657,14 +1648,12 @@ class TimeClassTests(unittest.TestCase):
             datetime.datetime(2001, 1, 1),
             tt.UTC[0])
         tt.data[0] = '2002-01-01'
-        with warnings.catch_warnings(record=True) as w:
+        with spacepy_testing.assertWarns(
+                self, 'always',
+                r'cls argument of update_items was deprecated in 0\.2\.2'
+                r' and will be ignored\.$',
+                DeprecationWarning, r'spacepy\.time$'):
             tt.update_items(type(tt), 'data')
-        self.assertEqual(1, len(w))
-        self.assertEqual(w[0].category, DeprecationWarning)
-        self.assertEqual(
-            'cls argument of update_items was deprecated in 0.2.2'
-            ' and will be ignored.',
-            str(w[0].message))
         self.assertEqual(
             datetime.datetime(2002, 1, 1),
             tt.UTC[0])

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -529,8 +529,10 @@ class SimpleFunctionTests(unittest.TestCase):
 
     def test_pmm_object(self):
         """Test pmm handling of object arrays"""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', 'pmm: Unable to exclude non-finite',
+                RuntimeWarning, 'spacepy.toolbox$')
             data = [array([5,9,23,24,6]).astype(object),
                     [datetime.datetime(2000, 3, 1, 0, 1), datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1)],
                     numpy.array(['foo', 'bar', 'baz'], dtype=object),
@@ -982,7 +984,7 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean_outputTimes(self):
         '''windowMean should return a known set of output times for a given set of input times and windows'''
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(hours=1)
             olap = datetime.timedelta(0)
@@ -1009,7 +1011,7 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean1(self):
         """windowMean should give known results 1(regression)"""
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
@@ -1032,7 +1034,7 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean2(self):
         """windowMean should give known results 2(regression)"""
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
@@ -1054,7 +1056,7 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean3(self):
         """windowMean should give known results 3(regression)"""
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
@@ -1082,7 +1084,7 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean4(self):
         """windowMean should give known results 4(regression)"""
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
@@ -1098,8 +1100,9 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean5(self):
         """windowMean should give known results 5(regression)"""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', r'windowmean\:', UserWarning, 'spacepy.toolbox$')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
             data = [10, 20]*50
@@ -1118,11 +1121,10 @@ class TBTimeFunctionTests(unittest.TestCase):
             od_ans, ot_ans = tb.windowMean(data, winsize=1.0, overlap=0)
             numpy.testing.assert_almost_equal(ot_ans, outtime)
             numpy.testing.assert_almost_equal(od_ans, outdata)
-            self.assertEqual(8, len(w))
 
     def test_windowMean_op(self):
         """windowMean should give known results (regression)"""
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
@@ -1144,7 +1146,7 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_windowMean_op2(self):
         """windowMean should give expected sums with len as passed function"""
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings():
             warnings.simplefilter('always')
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(0)

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -30,6 +30,7 @@ from numpy import array
 from scipy import inf
 from scipy.stats import poisson
 
+import spacepy_testing
 import spacepy
 import spacepy.toolbox as tb
 import spacepy.lib
@@ -204,7 +205,7 @@ class SimpleFunctionTests(unittest.TestCase):
 
     def test_getNamedPath(self):
         """getNamedPath should have known result"""
-        curloc = os.path.dirname(os.path.abspath(__file__))
+        curloc = spacepy_testing.testsdir
         tmpdir = os.path.join(curloc, 'tmp', 'test1', 'test2')
         os.makedirs(tmpdir)
         ans = ['tests', 'tmp', 'test1']
@@ -819,9 +820,7 @@ class SimpleFunctionTests(unittest.TestCase):
 
     def test_assemble_qindenton_daily(self):
         """Assemble OMNI data structure from Qin-Denton daily files"""
-        dailydir = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            'data', 'qindenton_daily')
+        dailydir = os.path.join(spacepy_testing.datadir, 'qindenton_daily')
         omnidata = tb._assemble_qindenton_daily(dailydir)
         self.assertEqual(
             ['ByIMF', 'Bz1', 'Bz2', 'Bz3', 'Bz4', 'Bz5', 'Bz6', 'BzIMF',

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -138,48 +138,32 @@ class SimpleFunctionTests(unittest.TestCase):
 
     def test_quaternionDeprecation(self):
         """Make sure deprecated quaternion functions work"""
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always', r'moved to spacepy\.coordinates',
+                DeprecationWarning, r'spacepy'):
             tst = tb.quaternionNormalize([0.707, 0, 0.707, 0.2])
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual(
-            'moved to spacepy.coordinates',
-            str(w[0].message))
         numpy.testing.assert_array_almost_equal(
             [0.693,  0.,  0.693,  0.196], tst, decimal=2)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always', r'moved to spacepy\.coordinates',
+                DeprecationWarning, r'spacepy'):
             tst = tb.quaternionRotateVector([0.7071, 0, 0, 0.7071],
                                             [0, 1, 0])
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual(
-            'moved to spacepy.coordinates',
-            str(w[0].message))
         numpy.testing.assert_array_almost_equal(
             [0, 0, 1], tst, decimal=5)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always', r'moved to spacepy\.coordinates',
+                DeprecationWarning, r'spacepy'):
             tst = tb.quaternionMultiply([1., 0, 0, 0],
                                         [0., 0, 0, 1], scalarPos='first')
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual(
-            'moved to spacepy.coordinates',
-            str(w[0].message))
         numpy.testing.assert_array_equal([0, 0, 0, 1], tst)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(
+                self, 'always', r'moved to spacepy\.coordinates',
+                DeprecationWarning, r'spacepy'):
             tst = tb.quaternionConjugate([.707, 0, .707, 0.2])
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual(
-            'moved to spacepy.coordinates',
-            str(w[0].message))
         numpy.testing.assert_array_equal([-.707, 0, -.707, 0.2], tst)
 
     def test_indsFromXrange(self):
@@ -374,31 +358,28 @@ class SimpleFunctionTests(unittest.TestCase):
         """feq should return true when they are equal"""
         val1 = 1.1234
         val2 = 1.1235
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(self, 'always', r'use numpy\.isclose',
+                                         DeprecationWarning, r'spacepy'):
             self.assertTrue(tb.feq(val1, val2, 0.0001))
+        with spacepy_testing.assertWarns(self, 'always', r'use numpy\.isclose',
+                                         DeprecationWarning, r'spacepy'):
             numpy.testing.assert_array_equal(
                 [False, True, False, False],
                 tb.feq([1., 2., 3., 4.],
                        [1.25, 2.05, 2.2, 500.1],
                        0.1)
             )
-        self.assertEqual(2, len(w))
-        for this_w in w:
-            self.assertEqual(DeprecationWarning, this_w.category)
-            self.assertEqual(DeprecationWarning, this_w.category)
-            self.assertEqual('use numpy.isclose', str(this_w.message))
 
     def testfeq_notequal(self):
         """feq should return false when they are not equal"""
         val1 = 1.1234
         val2 = 1.1235
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+        with spacepy_testing.assertWarns(self, 'always', r'use numpy\.isclose',
+                                         DeprecationWarning, r'spacepy'):
+            self.assertTrue(tb.feq(val1, val2, 0.0001))
+        with spacepy_testing.assertWarns(self, 'always', r'use numpy\.isclose',
+                                         DeprecationWarning, r'spacepy'):
             self.assertFalse(tb.feq(val1, val2, 0.000005))
-        self.assertEqual(1, len(w))
-        self.assertEqual(DeprecationWarning, w[0].category)
-        self.assertEqual('use numpy.isclose', str(w[0].message))
 
     def test_medAbsDev(self):
         """medAbsDev should return a known range for given random input"""


### PR DESCRIPTION
This PR combines a number of quality-of-life improvements for the unit test suite and docs:

- Adds a new test support module, `spacepy_testing`.
- Adds `assertWarns`/`assertDoesntWarn` context managers to make testing of warnings easier per conversation in #505.
- Uses these new context managers to clean up existing warning tests
- Does some further warnings cleanup where we had tests that were enabling all warnings with `simplefilter always` and then eating them with `catch_warnings` and doing nothing with the output.
- Changes the unit tests to run against the _built_ SpacePy instead of the _installed_ SpacePy, so you can test without installing. This will make it much easier for us to cache dependencies in the future, although that is left out here.
- Similarly changes the documentation to run against the built SpacePy instead of the source. This allows the removal of some workarounds in the code where compiled code wasn't available to the documentation builder, and should make cleaning up docs warnings easier in the future.

## Open questions

1. This uses `assertWarns` and `assertDoesntWarn` as two different classes (`DoesntWarn` is an almost trivial subclass). I think this is easier from the user perspective, although it probably could be an argument to `__init__` instead. Also I'm not thrilled with `assertDoesntWarn` as a name.
2. `assertX` reproduces the warnings filter syntax exactly. I don't think `lineno` is very useful, but it's in the warnings filter so I left it in. Also the `action` should almost always be `always`; I made the default be to add no filter, but maybe this should be the default. Or maybe `action` should be left out and just forced to `always`.
3. Do we want the ability to specify the number of times a warning should be issued instead of just lock to one-or-none? For warnings that are raised on successive lines, I just used the context manager twice. This would complicate the argument list but would also be a way to back away from having two different classes (just specify 0 if the warning shouldn't be raised.)

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
