### PR TITLE
Adding Sparse Records support to pycdf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ time
  - Fix warning for out-of-date leapseconds.
 toolbox
  - Fix bootHisto passing of kwargs to histogram and bar.
+pycdf
+ - Add support for Sparse Records variables.
 
 Changes in Version 0.2.2 (2020-12-29)
 =====================================

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -16,6 +16,12 @@ contains more detail.
 0.2.3 (2021-xx-xx)
 ------------------
 
+New features
+************
+:mod:`~spacepy.pycdf` now supports variables with sparse records, including
+enabling/disabling sparse records (:meth:`~spacepy.pycdf.Var.sparse`) and
+setting the pad value (:meth:`~spacepy.pycdf.Var.pad`). Thanks Antoine Brunet.
+
 Major bugfixes
 **************
 The passing of keyword arguments from :func:`~spacepy.toolbox.bootHisto`

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3552,10 +3552,12 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
             Current pad value for this variable.
         """
         if value is not None:
-            data = self._prepare([value])
+            data = self._prepare(value)
             self._call(const.PUT_, const.zVAR_PADVALUE_, 
                     data.ctypes.data_as(ctypes.c_void_p))
 
+        # Prepare buffer for return, to get array of correct type
+        # pretend it's [0, 0, 0, 0...] of the variable
         hslice = _Hyperslice(self, (0,)*(self._n_dims() + 1))
         result = hslice.create_array()
         self._call(const.GET_, const.zVAR_PADVALUE_,

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3527,7 +3527,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
     def sparse(self, sparsetype=None):
         """
-        Gets or sets this variable sparse records mode.
+        Gets or sets this variable's sparse records mode.
 
         Sparse records mode may not be changeable on variables with data
         already written; even deleting the data may not permit the change.
@@ -3568,7 +3568,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
     def pad(self, value=None):
         """
-        Gets or sets this variable pad value.
+        Gets or sets this variable's pad value.
 
         See section 2.3.20 of the CDF user's guide for more information on
         pad values.
@@ -3577,7 +3577,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         ================
         value : 
             If specified, should be an appropriate pad value. If not
-            specified, the pad value will not change.
+            specified, the pad value will not be set or changed.
 
         Returns
         =======
@@ -3989,7 +3989,7 @@ class VarCopy(spacepy.datamodel.dmarray):
         return self._cdf_meta['nelems']
 
     def pad(self):
-        """Gets pad value of the variable this was copied from.
+        """Gets pad value of the copied variable.
 
         This copy does *not* preserve which records were written, i.e.
         the entire copy is read, including pad values, and the pad values
@@ -4041,7 +4041,7 @@ class VarCopy(spacepy.datamodel.dmarray):
         self._cdf_meta[key] = value
 
     def sparse(self):
-        """Gets sparse records mode of the variable this was copied from.
+        """Gets sparse records mode of the copied variable.
 
         This copy does *not* preserve which records were written, i.e.
         the entire copy is read, including pad values, and the pad values

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3574,7 +3574,9 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         Returns
         =======
         out : 
-            Current pad value for this variable.
+            Current pad value for this variable. ``None`` if it has never been
+            set. This rarely happens; the pad value is usually set by the CDF
+            library on variable creation.
 
         Notes
         =====
@@ -3589,8 +3591,11 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         # pretend it's [0, 0, 0, 0...] of the variable
         hslice = _Hyperslice(self, (0,)*(self._n_dims() + 1))
         result = hslice.create_array()
-        self._call(const.GET_, const.zVAR_PADVALUE_,
-                     result.ctypes.data_as(ctypes.c_void_p))
+        status = self._call(const.GET_, const.zVAR_PADVALUE_,
+                            result.ctypes.data_as(ctypes.c_void_p),
+                            ignore=(const.NO_PADVALUE_SPECIFIED,))
+        if status == const.NO_PADVALUE_SPECIFIED:
+            return None
         return hslice.convert_input_array(result)
 
     def dv(self, new_dv=None):

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -2283,9 +2283,15 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             Compression parameter if compression used; reasonable default
             is chosen. See :py:meth:`Var.compress`.
         sparse : ctypes.c_long
+
+            .. versionadded:: 0.2.3
+
             Sparse records type for this variable, default None (no sparse
             records). See :meth:`Var.sparse`.
         pad :
+
+            .. versionadded:: 0.2.3
+
             Pad value for this variable, default None (do not set). See
             :meth:`Var.pad`.
 
@@ -2305,7 +2311,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             if no type is provided and data is datetime, warning that
             the default will change in the future.
 
-            .. versionadded:: 0.2.2
+            .. versionadded:: 0.2.3
 
         Notes
         =====
@@ -3533,6 +3539,10 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         =======
         out : ctypes.c_long
             Sparse record mode for this variable.
+
+        Notes
+        =====
+        .. versionadded:: 0.2.3
         """
         valid_sr = [
             const.NO_SPARSERECORDS, 
@@ -3565,6 +3575,10 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         =======
         out : 
             Current pad value for this variable.
+
+        Notes
+        =====
+        .. versionadded:: 0.2.3
         """
         if value is not None:
             data = self._prepare(value)
@@ -3974,6 +3988,10 @@ class VarCopy(spacepy.datamodel.dmarray):
         =======
         various
             Pad value, matching type of the variable.
+
+        Notes
+        =====
+        .. versionadded:: 0.2.3
         """
         return self._cdf_meta['pad']
 
@@ -4022,6 +4040,10 @@ class VarCopy(spacepy.datamodel.dmarray):
         =======
         ctypes.c_long
             Sparse record type
+
+        Notes
+        =====
+        .. versionadded:: 0.2.3
         """
         return self._cdf_meta['sparse']
 

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3007,26 +3007,28 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         ~Var.insert
         ~Var.name
         ~Var.nelems
+        ~Var.pad
         ~Var.rename
         ~Var.rv
         ~Var.shape
+        ~Var.sparse
         ~Var.type
     .. attribute:: Var.attrs
 
        zAttributes for this zVariable in a dict-like format.
        See :class:`zAttrList` for details.
     .. automethod:: compress
-    .. automethod:: sparse
-    .. automethod:: pad
     .. automethod:: copy
     .. autoattribute:: dtype
     .. automethod:: dv
     .. automethod:: insert
     .. automethod:: name
     .. automethod:: nelems
+    .. automethod:: pad
     .. automethod:: rename
     .. automethod:: rv
     .. autoattribute:: shape
+    .. automethod:: sparse
     .. automethod:: type
     """
     def __init__(self, cdf_file, var_name, *args):

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3589,7 +3589,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
         # Prepare buffer for return, to get array of correct type
         # pretend it's [0, 0, 0, 0...] of the variable
-        hslice = _Hyperslice(self, (0,)*(self._n_dims() + 1))
+        hslice = _Hyperslice(self, (0,)*(self._n_dims() + int(self.rv())))
         result = hslice.create_array()
         status = self._call(const.GET_, const.zVAR_PADVALUE_,
                             result.ctypes.data_as(ctypes.c_void_p),

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3464,6 +3464,27 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         self._call(const.GET_, const.zVAR_RECVARY_, ctypes.byref(vary))
         return vary.value != const.NOVARY.value
 
+    def sparse_records(self, new_sr=None):
+        """
+        Gets or sets this variable sparse records mode.
+
+        Other Parameters
+        ================
+        new_sr : int
+            If specified, should be a sparse record mode from
+            :mod:`~spacepy.pycdf.const`.
+
+        Returns
+        =======
+        out : int
+            Sparse record mode for this variable.
+        """
+        if new_sr != None:
+            self._call(const.PUT_, const.zVAR_SPARSERECORDS_, new_sr)
+        sr = ctypes.c_long(0)
+        self._call(const.GET_, const.zVAR_SPARSERECORDS_, ctypes.byref(sr))
+        return sr
+
     def dv(self, new_dv=None):
         """
         Gets or sets dimension variance of each dimension of variable.
@@ -3984,7 +4005,7 @@ class _Hyperslice(object):
                 else: #Single degenerate value
                     if idx < 0:
                         idx += self.dimsizes[i]
-                    if idx != 0 and (idx >= self.dimsizes[i] or idx < 0):
+                    if idx != 0 and ((idx >= self.dimsizes[i] and i > 0) or idx < 0):
                         raise IndexError('list index out of range')
                     self.starts[i] = idx
                     self.degen[i] = True

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4152,10 +4152,14 @@ class _Hyperslice(object):
             for i in range(self.dims):
                 idx = key[i]
                 if hasattr(idx, 'start'): #slice
+                    # Allow read-off-end for record dim if sparse
+                    off_end = not self.no_sr and idx.stop is not None \
+                              and idx.stop > self.dimsizes[i] and i == 0
                     (self.starts[i], self.counts[i],
                      self.intervals[i], self.rev[i]) = \
-                     self.convert_range(idx.start, idx.stop,
-                                              idx.step, self.dimsizes[i])
+                     self.convert_range(
+                         idx.start, idx.stop, idx.step,
+                         idx.stop if off_end else self.dimsizes[i])
                 else: #Single degenerate value
                     if idx < 0:
                         idx += self.dimsizes[i]

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4037,8 +4037,8 @@ class _Hyperslice(object):
         self.counts = numpy.empty((self.dims,), dtype=numpy.int32)
         self.counts.fill(1)
         self.intervals = [1] * self.dims
-        self.degen = numpy.zeros(self.dims, dtype=numpy.bool)
-        self.rev = numpy.zeros(self.dims, dtype=numpy.bool)
+        self.degen = numpy.zeros(self.dims, dtype=bool)
+        self.rev = numpy.zeros(self.dims, dtype=bool)
         #key is:
         #1. a single value (integer or slice object) if called 1D
         #2. a tuple (of integers and/or slice objects) if called nD
@@ -4282,7 +4282,7 @@ class _Hyperslice(object):
     def check_well_formed(data):
         """Checks if input data is well-formed, regular array"""
         d = numpy.asanyarray(data)
-        if d.dtype == numpy.object: #this is probably going to be bad
+        if d.dtype == object: #this is probably going to be bad
             if d.shape != () and not len(d):
                 #Completely empty, so "well-formed" enough
                 return

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3211,12 +3211,20 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
                          ctypes.c_long(recno), ctypes.c_long(recno))
 
     def _prepare(self, data):
-        """Convert data to CDF data formats.
-        
-        @param data: data to store
-        @type data: numpy.array
-        @return prepared data
-        @rtype numpy.array 
+        """Convert data to numpy array for writing to CDF
+
+        Converts input data intended for CDF writing into a numpy array,
+        so the array's buffer can be used directly for the output buffer
+
+        Parameters
+        ==========
+        data : various
+            data to write
+
+        Returns
+        =======
+        numpy.ndarray
+            `data` converted, including time conversions
         """
         cdf_type = self.type()
         if cdf_type == const.CDF_EPOCH16.value:

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -2884,11 +2884,12 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         The C CDF library allows reading records which have not been
         written to a file, returning a pad value. pycdf checks the
         size of a variable and will raise `IndexError` for most
-        attempts to read past the end. If these checks fail, a value
-        is returned with a warning ``VIRTUAL_RECORD_DATA``. Please
-        `open an issue
+        attempts to read past the end, except for variables with sparse
+        records. If these checks fail, a value is returned with a warning
+        ``VIRTUAL_RECORD_DATA``. Please `open an issue
         <https://github.com/spacepy/spacepy/issues/new>`_ if this
-        occurs. See pg. 39 and following of the `CDF User's Guide
+        occurs for variables without sparse records. See pg. 39 and
+        following of the `CDF User's Guide
         <https://cdf.gsfc.nasa.gov/html/cdf_docs.html>`_ for more on
         virtual records.
 

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3490,13 +3490,13 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         See section 2.3.12 of the CDF user's guide for more information on
         sparse records.
 
-
         Other Parameters
         ================
         sparsetype : ctypes.c_long
             If specified, should be a sparse record mode from
-            :mod:`~spacepy.pycdf.const`. If not specified, the sparse record
-            mode for this variable will not change.
+            :mod:`~spacepy.pycdf.const`; see also CDF C reference manual
+            section 4.11.1. If not specified, the sparse record mode for this
+            variable will not change.
 
         Returns
         =======

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1207,6 +1207,7 @@ class OpenCDF(CDFTests):
 
 class ReadCDF(CDFTests):
     """Tests that read an existing CDF, but do not modify it."""
+    longMessage = True
     testbase = 'test_ro.cdf'
     varnames = ['ATC', 'PhysRecNo', 'SpinNumbers', 'SectorNumbers',
                'RateScalerNames', 'SectorRateScalerNames',
@@ -2290,6 +2291,23 @@ class ReadCDF(CDFTests):
         """Read pad value for NRV"""
         # This wasn't explicitly set but that's what it gives
         self.assertEqual(self.cdf['SectorNumbers'].pad(), ' P')
+
+    def testPrepare(self):
+        """Test data conversion to numpy arrays"""
+        # Data here are only prepared, CDF itself does not change
+        # Each test is variable name, input data, expected prepared data,
+        # expected dtype
+        tests = [('ATC',
+                  [datetime.datetime(1, 1, 1)],
+                  numpy.array([[31622400.0, 0]]), numpy.float64),
+                 ('MeanCharge',
+                  [1, 2], numpy.array([1., 2.]), numpy.float32)
+                 ]
+        for vname, inputs, expected, dtype in tests:
+            actual = self.cdf[vname]._prepare(inputs)
+            self.assertIs(type(actual), numpy.ndarray, vname)
+            self.assertEqual(actual.dtype, dtype, vname)
+            numpy.testing.assert_array_equal(actual, expected)
 
 
 class ReadColCDF(ColCDFTests):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2805,6 +2805,21 @@ class ChangeCDF(ChangeCDFBase):
             numpy.testing.assert_array_equal(zVar[...],
                                              [1, 1, 1, 2]);
 
+    def testSparseReadOffEnd(self):
+        """Read past the end of a sparse variable"""
+        zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[...] = [1, 2, 3]
+        hs = cdf._Hyperslice(zVar, slice(None, 4, None))
+        # Make sure the slice sizing is proper before read
+        self.assertEqual([0], hs.starts)
+        self.assertEqual([4], hs.counts)
+        with spacepy_testing.assertWarns(
+                self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                r'spacepy\.pycdf$'):
+            numpy.testing.assert_array_equal(zVar[:4],
+                                             [1, 2, 3, 3]);
+
     def testChangeSparseRecordsPad(self):
         """Change sparse records mode to PAD"""
         zVar = self.cdf.new('newvarSRPad', dims=[], type=const.CDF_INT4)
@@ -2920,7 +2935,7 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual(99, zVar.pad())
         with spacepy_testing.assertWarns(self, 'always', r'VIRTUAL_RECORD_DATA',
                                          cdf.CDFWarning, r'spacepy\.pycdf$'):
-            self.assertEqual(99, zVar[4])
+            numpy.testing.assert_array_equal(zVar[0:5], [1, 2, 3, 4, 99])
 
     def testSparseCopy(self):
         """Make sure sparseness carries through to VarCopy"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2768,6 +2768,20 @@ class ChangeCDF(ChangeCDFBase):
         with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], 1);
     
+    def testSparseRecordsReadAll(self):
+        """Read all records from a sparse variable"""
+        zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        self.assertEqual(4, len(zVar))
+        # Arguments to use for assertWarngs, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                   r'spacepy\.pycdf$')
+        with spacepy_testing.assertWarns(*aw_args):
+            numpy.testing.assert_array_equal(zVar[...],
+                                             [1, 1, 1, 2]);
+
     def testChangeSparseRecordsPad(self):
         """Change sparse records mode to PAD"""
         zVar = self.cdf.new('newvarSRPad', dims=[], type=const.CDF_INT4)
@@ -2788,6 +2802,77 @@ class ChangeCDF(ChangeCDFBase):
             self.assertEqual(zVar[1], pad);
         with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], pad);
+
+    def testSparsePrevInsert(self):
+        """Insert records in sparse records previous mode"""
+        zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        with self.assertRaises(NotImplementedError) as cm:
+            zVar.insert(2, 99)
+        self.assertEqual('Sparse records do not support insertion.',
+                         str(cm.exception))
+        # Following is test for if this did work
+        # Arguments to use for assertWarngs, since used a lot....
+        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+        #           r'spacepy\.pycdf$')
+        #with spacepy_testing.assertWarns(*aw_args):
+        #    numpy.testing.assert_array_equal(zVar[0:5],
+        #                                     [1, 1, 99, 99, 2])
+
+    def testSparsePrevSingle(self):
+        """Delete one record in sparse records previous mode"""
+        zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        zVar[5] = 3;
+        del zVar[3]
+        # Arguments to use for assertWarngs, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                   r'spacepy\.pycdf$')
+        with spacepy_testing.assertWarns(*aw_args):
+            numpy.testing.assert_array_equal(zVar[0:6],
+                                             [1, 1, 1, 1, 1, 3])
+
+    def testSparsePrevDelete(self):
+        """Delete records in sparse records previous mode"""
+        zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        zVar[5] = 3;
+        with self.assertRaises(NotImplementedError) as cm:
+            del zVar[3:5]
+        self.assertEqual('Sparse records do not support multi-record delete.',
+                         str(cm.exception))
+        # Following is test for if this did work
+        # Arguments to use for assertWarngs, since used a lot....
+        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+        #           r'spacepy\.pycdf$')
+        #with spacepy_testing.assertWarns(*aw_args):
+        #    numpy.testing.assert_array_equal(zVar[0:4],
+        #                                     [1, 1, 1, 3])
+
+    def testSparsePrevTruncate(self):
+        """Truncate records in sparse records previous mode"""
+        zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        zVar[4] = 3;
+        with self.assertRaises(NotImplementedError) as cm:
+            zVar[0:] = [100, 101, 102]
+        self.assertEqual('Sparse records do not support truncation on write.',
+                         str(cm.exception))
+        # Following is test for if this did work
+        # Arguments to use for assertWarngs, since used a lot....
+        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+        #           r'spacepy\.pycdf$')
+        #with spacepy_testing.assertWarns(*aw_args):
+        #    numpy.testing.assert_array_equal(zVar[0:4],
+        #                                     [1000, 101, 102, 3])
 
     def testChecksum(self):
         """Change checksumming on the CDF"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -501,7 +501,7 @@ class NoCDF(unittest.TestCase):
                    -1 * 2 ** 31,
                    numpy.array([5, 6, 7], dtype=numpy.uint8),
                    [4611686018427387904],
-                   numpy.array([1], dtype=numpy.object),
+                   numpy.array([1], dtype=object),
                    ]
         type8 = [((4,), [const.CDF_BYTE, const.CDF_INT1, const.CDF_UINT1,
                          const.CDF_INT2, const.CDF_UINT2,
@@ -2846,7 +2846,7 @@ class ChangeCDF(ChangeCDFBase):
         self.cdf['ATC'] = []
         data = self.cdf['ATC'][...]
         self.assertEqual((0,), data.shape)
-        self.assertEqual(numpy.object, data.dtype)
+        self.assertEqual(object, data.dtype)
 
     def testCopyVariable(self):
         """Copy one variable to another"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2903,6 +2903,25 @@ class ChangeCDF(ChangeCDFBase):
         #    numpy.testing.assert_array_equal(zVar[0:4],
         #                                     [1000, 101, 102, 3])
 
+    def testSparseOnCreate(self):
+        """Specify sparseness when creating a variable"""
+        zVar = self.cdf.new('newvar', data=[1, 2, 3, 4],
+                            sparse=const.PAD_SPARSERECORDS, pad=99)
+        self.assertEqual(const.PAD_SPARSERECORDS, zVar.sparse())
+        self.assertEqual(99, zVar.pad())
+        with spacepy_testing.assertWarns(self, 'always', r'VIRTUAL_RECORD_DATA',
+                                         cdf.CDFWarning, r'spacepy\.pycdf$'):
+            self.assertEqual(99, zVar[4])
+
+    def testSparseCopy(self):
+        """Make sure sparseness carries through to VarCopy"""
+        zVar = self.cdf.new('newvar', data=[1, 2, 3, 4],
+                            sparse=const.PAD_SPARSERECORDS, pad=99)
+        cp = zVar.copy()
+        self.assertEqual(const.PAD_SPARSERECORDS, cp.sparse())
+        self.assertEqual(99, cp.pad())
+        numpy.testing.assert_array_equal(zVar[...], [1, 2, 3, 4])
+
     def testChecksum(self):
         """Change checksumming on the CDF"""
         self.cdf.checksum(True)

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2752,6 +2752,32 @@ class ChangeCDF(ChangeCDFBase):
         zVar.rv(True)
         self.assertTrue(zVar.rv())
 
+    def testChangeSparseRecordsPrev(self):
+        """Change sparse records mode to PREV"""
+        zVar = self.cdf.new('newvarSR', dims=[], type=const.CDF_INT4)
+        self.assertEqual(zVar.sparse_records(), const.NO_SPARSERECORDS)
+        zVar.sparse_records(const.PREV_SPARSERECORDS)
+        self.assertEqual(zVar.sparse_records(), const.PREV_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        self.assertEqual(zVar[1], 1);
+        self.assertEqual(zVar[2], 1);
+    
+    def testChangeSparseRecordsPad(self):
+        """Change sparse records mode to PAD"""
+        zVar = self.cdf.new('newvarSRPad', dims=[], type=const.CDF_INT4)
+        zVar.sparse_records(const.PAD_SPARSERECORDS)
+        self.assertEqual(zVar.sparse_records(), const.PAD_SPARSERECORDS)
+        zVar[0] = 1;
+        zVar[3] = 2;
+        pad = zVar.pad_value()
+        self.assertEqual(zVar[1], pad);
+        self.assertEqual(zVar[2], pad);
+        pad = zVar.pad_value(123)
+        self.assertEqual(zVar[1], pad);
+        self.assertEqual(zVar[2], pad);
+
+
     def testChecksum(self):
         """Change checksumming on the CDF"""
         self.cdf.checksum(True)

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2760,13 +2760,13 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual(zVar.sparse(), const.PREV_SPARSERECORDS)
         zVar[0] = 1;
         zVar[3] = 2;
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', 'VIRTUAL_RECORD_DATA',
-                                    cdf.CDFWarning, '^spacepy\\.pycdf')
+        # Arguments to use for assertWarngs, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                   r'spacepy\.pycdf$')
+        with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[1], 1);
+        with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], 1);
-
-        self.assertEqual(len(w), 2)
     
     def testChangeSparseRecordsPad(self):
         """Change sparse records mode to PAD"""
@@ -2776,19 +2776,18 @@ class ChangeCDF(ChangeCDFBase):
         zVar[0] = 1;
         zVar[3] = 2;
         pad = zVar.pad()
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', 'VIRTUAL_RECORD_DATA',
-                                    cdf.CDFWarning, '^spacepy\\.pycdf')
+        # Arguments to use for assertWarngs, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                   r'spacepy\.pycdf$')
+        with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[1], pad);
+        with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], pad);
-        self.assertEqual(len(w), 2)
         pad = zVar.pad(123)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.filterwarnings('always', 'VIRTUAL_RECORD_DATA',
-                                    cdf.CDFWarning, '^spacepy\\.pycdf')
+        with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[1], pad);
+        with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], pad);
-        self.assertEqual(len(w), 2)
 
     def testChecksum(self):
         """Change checksumming on the CDF"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2286,6 +2286,11 @@ class ReadCDF(CDFTests):
         """Test getting pad value on variable where it isn't set."""
         self.assertIs(self.cdf['Epoch'].pad(), None)
 
+    def testPadNRV(self):
+        """Read pad value for NRV"""
+        # This wasn't explicitly set but that's what it gives
+        self.assertEqual(self.cdf['SectorNumbers'].pad(), ' P')
+
 
 class ReadColCDF(ColCDFTests):
     """Tests that read a column-major CDF, but do not modify it."""
@@ -2925,6 +2930,21 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual(const.PAD_SPARSERECORDS, cp.sparse())
         self.assertEqual(99, cp.pad())
         numpy.testing.assert_array_equal(zVar[...], [1, 2, 3, 4])
+
+    def testNRVWritePad(self):
+        """Write pad value for NRV"""
+        v = self.cdf['SectorNumbers']
+        v.pad('Q')
+        self.assertEqual('Q', v.pad())
+
+    def testNRVSparse(self):
+        """Make NRV sparse variable"""
+        v = self.cdf.new('newvar', recVary=False, type=const.CDF_INT1)
+        with self.assertRaises(cdf.CDFError) as cm:
+            v.sparse(const.PAD_SPARSERECORDS)
+        self.assertEqual("CANNOT_SPARSERECORDS: Sparse records can't be"
+                         " set/modified for the variable.", str(cm.exception))
+        self.assertEqual(const.CANNOT_SPARSERECORDS, cm.exception.status)
 
     def testChecksum(self):
         """Change checksumming on the CDF"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2755,28 +2755,40 @@ class ChangeCDF(ChangeCDFBase):
     def testChangeSparseRecordsPrev(self):
         """Change sparse records mode to PREV"""
         zVar = self.cdf.new('newvarSR', dims=[], type=const.CDF_INT4)
-        self.assertEqual(zVar.sparse_records(), const.NO_SPARSERECORDS)
-        zVar.sparse_records(const.PREV_SPARSERECORDS)
-        self.assertEqual(zVar.sparse_records(), const.PREV_SPARSERECORDS)
+        self.assertEqual(zVar.sparse(), const.NO_SPARSERECORDS)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        self.assertEqual(zVar.sparse(), const.PREV_SPARSERECORDS)
         zVar[0] = 1;
         zVar[3] = 2;
-        self.assertEqual(zVar[1], 1);
-        self.assertEqual(zVar[2], 1);
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', 'VIRTUAL_RECORD_DATA',
+                                    cdf.CDFWarning, '^spacepy\\.pycdf')
+            self.assertEqual(zVar[1], 1);
+            self.assertEqual(zVar[2], 1);
+
+        self.assertEqual(len(w), 2)
     
     def testChangeSparseRecordsPad(self):
         """Change sparse records mode to PAD"""
         zVar = self.cdf.new('newvarSRPad', dims=[], type=const.CDF_INT4)
-        zVar.sparse_records(const.PAD_SPARSERECORDS)
-        self.assertEqual(zVar.sparse_records(), const.PAD_SPARSERECORDS)
+        zVar.sparse(const.PAD_SPARSERECORDS)
+        self.assertEqual(zVar.sparse(), const.PAD_SPARSERECORDS)
         zVar[0] = 1;
         zVar[3] = 2;
-        pad = zVar.pad_value()
-        self.assertEqual(zVar[1], pad);
-        self.assertEqual(zVar[2], pad);
-        pad = zVar.pad_value(123)
-        self.assertEqual(zVar[1], pad);
-        self.assertEqual(zVar[2], pad);
-
+        pad = zVar.pad()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', 'VIRTUAL_RECORD_DATA',
+                                    cdf.CDFWarning, '^spacepy\\.pycdf')
+            self.assertEqual(zVar[1], pad);
+            self.assertEqual(zVar[2], pad);
+        self.assertEqual(len(w), 2)
+        pad = zVar.pad(123)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', 'VIRTUAL_RECORD_DATA',
+                                    cdf.CDFWarning, '^spacepy\\.pycdf')
+            self.assertEqual(zVar[1], pad);
+            self.assertEqual(zVar[2], pad);
+        self.assertEqual(len(w), 2)
 
     def testChecksum(self):
         """Change checksumming on the CDF"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2768,6 +2768,20 @@ class ChangeCDF(ChangeCDFBase):
         with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], 1);
     
+    def testSparseMultidimPrev(self):
+        """test multi-dimensional sparse record variables, PREV"""
+        zVar = self.cdf.new('sr', dims=[2], type=const.CDF_INT4)
+        zVar.sparse(const.PREV_SPARSERECORDS)
+        zVar[0] = [1, 2];
+        zVar[3] = [3, 4];
+        # Arguments to use for assertWarngs, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                   r'spacepy\.pycdf$')
+        with spacepy_testing.assertWarns(*aw_args):
+            numpy.testing.assert_array_equal(
+                [[1, 2], [1, 2], [1, 2], [3, 4]],
+                zVar[...])
+
     def testSparseRecordsReadAll(self):
         """Read all records from a sparse variable"""
         zVar = self.cdf.new('newvarSR', type=const.CDF_INT4)
@@ -2802,6 +2816,21 @@ class ChangeCDF(ChangeCDFBase):
             self.assertEqual(zVar[1], pad);
         with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[2], pad);
+
+    def testSparseMultidimPad(self):
+        """test multi-dimensional sparse record variables, PAD"""
+        zVar = self.cdf.new('sr', dims=[2], type=const.CDF_INT4)
+        zVar.sparse(const.PAD_SPARSERECORDS)
+        zVar[0] = [1, 2];
+        zVar[3] = [3, 4];
+        pad = zVar.pad(20)
+        # Arguments to use for assertWarngs, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
+                   r'spacepy\.pycdf$')
+        with spacepy_testing.assertWarns(*aw_args):
+            numpy.testing.assert_array_equal(
+                [[1, 2], [20, 20], [20, 20], [3, 4]],
+                zVar[...])
 
     def testSparsePrevInsert(self):
         """Insert records in sparse records previous mode"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2282,6 +2282,10 @@ class ReadCDF(CDFTests):
         #Repopulated
         self.assertEqual((10, True), self.cdf.attr_num(b'Instrument_type'))
 
+    def testReadUnsetPad(self):
+        """Test getting pad value on variable where it isn't set."""
+        self.assertIs(self.cdf['Epoch'].pad(), None)
+
 
 class ReadColCDF(ColCDFTests):
     """Tests that read a column-major CDF, but do not modify it."""


### PR DESCRIPTION
This PR adds support to the CDF Sparse Records modes in pycdf. It mainly defines the `Var.sparse_records` wrapper to get and set the Sparse Records modes. When a variable is set to any sparse mode, the check for out of range record index is skipped, so it's possible to set data to any record.

This PR also adds a `pad_value` function to get and set the pad value for a given variable, which is important for the PAD_SPARSERECORDS mode.

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)