### PR TITLE
Fix toCDF sparse record handling from CDFCopy

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ toolbox
  - Fix bootHisto passing of kwargs to histogram and bar.
 pycdf
  - Add support for Sparse Records variables.
+ - Fix changing compression when creating variable from existing var/data.
 
 Changes in Version 0.2.2 (2020-12-29)
 =====================================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -2359,8 +2359,9 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             else:
                 if compress is None:
                     compress = c
-                if compress_param is None:
-                    compress_param = cp
+                # Ignore data's compress_param if using compress argument
+                    if compress_param is None:
+                        compress_param = cp
         if hasattr(data, 'sparse') and sparse is None:
             sparse = data.sparse()
         if hasattr(data, 'pad') and pad is None:

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -2427,11 +2427,11 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             raise ValueError('Data requires EPOCH16, INT8, or TIME_TT2000; '
                              'incompatible with backward-compatible CDF')
         new_var = Var(self, name, type, n_elements, dims, recVary, dimVarys)
-        if compress != None:
+        if compress is not None:
             new_var.compress(compress, compress_param)
-        if sparse != None:
+        if sparse is not None:
             new_var.sparse(sparse)
-        if pad != None:
+        if pad is not None:
             new_var.pad(pad)
         if data is not None:
             new_var[...] = data

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3558,8 +3558,8 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
             const.PAD_SPARSERECORDS
         ]
         if sparsetype is not None:
-            if sparsetype not in valid_sr:
-                raise CDFError(const.UNKNOWN_SPARSENESS)
+            if not hasattr(sparsetype, 'value'):
+                comptype = ctypes.c_long(sparsetype)
             self._call(const.PUT_, const.zVAR_SPARSERECORDS_, sparsetype)
         sr = ctypes.c_long(0)
         self._call(const.GET_, const.zVAR_SPARSERECORDS_, ctypes.byref(sr))

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2979,6 +2979,14 @@ class ChangeCDF(ChangeCDFBase):
                          " set/modified for the variable.", str(cm.exception))
         self.assertEqual(const.CANNOT_SPARSERECORDS, cm.exception.status)
 
+    def testSparseNonConst(self):
+        """Set sparseness without using the const module"""
+        v = self.cdf.new('newvar', type=const.CDF_INT1)
+        v.sparse(ctypes.c_long(0))
+        self.assertEqual(0, v.sparse().value)
+        v.sparse(0)
+        self.assertEqual(0, v.sparse().value)
+
     def testChecksum(self):
         """Change checksumming on the CDF"""
         self.cdf.checksum(True)

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2655,6 +2655,15 @@ class ChangeCDF(ChangeCDFBase):
                          comptype.value)
         self.assertEqual(8, compparam)
 
+    def testNewVarFromVarCompress(self):
+        """Create a new variable from a variable, change compression"""
+        zvar = self.cdf.new('newzvar1', compress=const.GZIP_COMPRESSION,
+                            data=self.cdf['SpinRateScalersCounts'])
+        comptype, compparam = zvar.compress()
+        self.assertEqual(const.GZIP_COMPRESSION.value,
+                         comptype.value)
+        self.assertEqual(5, compparam)
+
     def testNewVarFromdmarrayAssign(self):
         """Create a new variable by assigning from dmarray"""
         indata = datamodel.dmarray([1,2,3], dtype=numpy.int8,


### PR DESCRIPTION
datamodel.toCDF makes a _copy_ of the input data and tries to write that:
```python
foo = outdata.new(key, SDobject[key][...], recVary=False)
```
I don't know _why_ it does this but the result is that it makes a _copy_ also of the sparseness type, rather than using the exact object from `pycdf.const`. That means `sparse`, which is checking for the actual object, doesn't recognize it as a valid type.

This PR updates `sparse` to accept any ctypes long or a just plain number, which fixes the problem. It no longer checks for valid sparseness itself--that's left to the CDF library itself.

Closes #512.

EDIT: Also now uses the default compression parameter, rather than the compression parameter from the input data, if a compression type is passed as an argument to `CDF.new()`. Also discussed in #512 but completely unrelated.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)


