### PR TITLE
PEP 517/518 support for install numpy before build

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
+- Installs numpy before build on newer versions of pip (thanks Michael Hirsch)
 tests
  - Add spacepy_testing module to provide helper functions for testing.
  - Add assertWarns and assertDoesntWarn context managers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,19 @@ Los Alamos National Laboratory
 Copyright 2010 - 2014 Los Alamos National Security, LLC.
 """
 
-#pip force-imports setuptools, on INSTALL, so then need to use its versions
-#but on reading the egg info, it DOESN'T force-import, assumes you are using
 import sys
-if any([a in sys.argv for a in ('pip-egg-info', 'bdist_wheel')]):
+# Calling egg info, so a lot of stuff doesn't have to work
+egginfo_only = any([a in sys.argv for a in (
+    'pip-egg-info', 'egg_info', 'dist_info')])
+if egginfo_only:
+    # pip force-imports setuptools, on INSTALL, so then need to use its versions
+    # but on reading egg info, it DOESN'T force-import, assumes you are using
     import setuptools
 if 'bdist_wheel' in sys.argv:
+    # Similarly, self-inject setuptools if making wheel
+    import setuptools
     import wheel
 use_setuptools = "setuptools" in globals()
-#Calling egg info, so a lot of stuff doesn't have to work
-egginfo_only = ('pip-egg-info' in sys.argv)
 
 import copy
 import os, shutil, getopt, glob, re


### PR DESCRIPTION
Newer versions of pip support installing build dependencies before trying the build, so for instance people don't need to install numpy before installing SpacePy from source via pip. This is a re-open/extension of #440, which got erroneously closed by GitHub being overzealous about the definition of "merged." See discussion there for details.

EDIT: Closes #173

