### PR TITLE
Clear up warnings in CDF ISTP tests

### DIFF
--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -172,8 +172,7 @@ class assertWarns(warnings.catch_warnings):
                 fnl = sys.modules[m].__file__
                 if fnl is None:
                     continue
-                fnl = fnl.lower()
-                if fnl.endswith(('.pyc', '.pyo')):
+                if fnl.lower().endswith(('.pyc', '.pyo')):
                     fnl = fnl[:-1]
                 mod_files.append(fnl)
         for w in self._log:

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -287,7 +287,8 @@ class VariablesTests(ISTPTestsBase):
     def testValidRangeFillvalDatetime(self):
         """Validmin/validmax with fillval set, Epoch var"""
         v = self.cdf.new(
-            'var1', data=[datetime.datetime(2010, 1, i) for i in range(1, 6)])
+            'var1', data=[datetime.datetime(2010, 1, i) for i in range(1, 6)],
+            type=spacepy.pycdf.const.CDF_EPOCH)
         v.attrs['VALIDMIN'] = datetime.datetime(2010, 1, 1)
         v.attrs['VALIDMAX'] = datetime.datetime(2010, 1, 31)
         v.attrs['FILLVAL'] = datetime.datetime(9999, 12, 31, 23, 59, 59, 999000)
@@ -728,7 +729,9 @@ class FileTests(ISTPTestsBase):
 
     def testTimesMonoton(self):
         """Test monotonic time"""
-        self.cdf['Epoch'] = [datetime.datetime(1999, 1, 1, i) for i in range(3)]
+        self.cdf.new('Epoch',
+                     data=[datetime.datetime(1999, 1, 1, i) for i in range(3)],
+                     type=spacepy.pycdf.const.CDF_EPOCH)
         self.cdf['Epoch'].append(datetime.datetime(1999, 1, 1, 5))
         self.cdf['Epoch'].append(datetime.datetime(1999, 1, 1, 4))
         errs = spacepy.pycdf.istp.FileChecks.time_monoton(self.cdf)

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -1208,7 +1208,8 @@ class VarBundleChecks(VarBundleChecksBase):
         sigma[sigma < 0] = numpy.nan
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                'ignore', 'invalid value encountered in divide', RuntimeWarning)
+                'ignore', r'invalid value encountered in (?:true_)divide$',
+                RuntimeWarning)
             expected = numpy.sqrt(numpy.nansum(sigma ** 2, axis=2)) \
                         / (~numpy.isnan(sigma)).sum(axis=2)
         expected[numpy.isnan(expected)] = -1e31


### PR DESCRIPTION
This PR clears up three warnings that arise just within the test suite; no changes to the main code.

One is because numpy slightly changed the wording of a warning that was raised when calculating an expected value in a test. The warning was trapped but the new wording wasn't caught, so that was updated.

The other two are from #426; the tests create time variables without specifying a type, so there's a warning the default is going to change. Cleared up by specifying a type.

Closes #515. Closes #516.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
