### PR TITLE
Handle leapseconds pre-1972

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ tests
  - Add assertWarns and assertDoesntWarn context managers.
 time
  - Fix warning for out-of-date leapseconds.
+ - Apply post-1972 leapsecond rules to pre-1972.
 toolbox
  - Fix bootHisto passing of kwargs to histogram and bar.
 pycdf

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -30,6 +30,12 @@ to :func:`numpy.histogram` and :func:`matplotlib.pyplot.bar` has been fixed.
 The check for out-of-date leapseconds in :mod:`~spacepy.time` has been
 fixed (previously warned even when the file was up to date.)
 
+Other changes
+*************
+Modern leapsecond rules are applied from 1958-1972 rather than
+rounding fractional leapseconds. See :mod:`~spacepy.time` for full
+discussion of leap seconds and other conversion considerations.
+
 0.2.2 (2020-12-29)
 ------------------
 

--- a/developer/scripts/rubber_seconds.py
+++ b/developer/scripts/rubber_seconds.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+"""Calculate various approaches to UTC - TAI during rubber second era"""
+
+import datetime
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy
+import spacepy.time
+
+# These are values from USNO tai-utc during rubber-second era
+# Piece-wise linear, calculated as a constant plus a rate times
+# days since a particular day (so seconds/day). Days are UTC days
+# The rate can change on 1 Jan and the constant can change any month;
+# the days-since day is relative to the last rate change, not the
+# last record
+# Records are: UTC of start of validity, TAI-UTC at start, reference UTC-MJD,
+# rate in seconds/MJD
+rubbers = numpy.array([
+    (datetime.datetime(1961, 1, 1), 1.422818, 37300.0, 0.001296),
+    (datetime.datetime(1961, 8, 1), 1.372818, 37300.0, 0.001296),
+    (datetime.datetime(1962, 1, 1), 1.845858, 37665.0, 0.0011232),
+    (datetime.datetime(1963, 11, 1), 1.945858, 37665.0, 0.0011232),
+    (datetime.datetime(1964, 1, 1), 3.24013, 38761.0, 0.001296),
+    (datetime.datetime(1964, 4, 1), 3.34013, 38761.0, 0.001296),
+    (datetime.datetime(1964, 9, 1), 3.44013, 38761.0, 0.001296),
+    (datetime.datetime(1965, 1, 1), 3.54013, 38761.0, 0.001296),
+    (datetime.datetime(1965, 3, 1), 3.64013, 38761.0, 0.001296),
+    (datetime.datetime(1965, 7, 1), 3.74013, 38761.0, 0.001296),
+    (datetime.datetime(1965, 9, 1), 3.84013, 38761.0, 0.001296),
+    (datetime.datetime(1966, 1, 1), 4.31317, 39126.0, 0.002592),
+    (datetime.datetime(1968, 2, 1), 4.21317, 39126.0, 0.002592),
+    (datetime.datetime(1972, 1, 1), 10, 41317.0, 0.0),
+    (datetime.datetime(1972, 7, 1), 11, 41317.0, 0.0),
+    (datetime.datetime(1973, 1, 1), 12, 41317.0, 0.0),
+    ],
+    dtype=[('dt', 'O'), ('delta', 'f'), ('mjd', 'f'), ('rate', 'f')])
+
+
+# Observed values of ut1 - tai
+# Annual from 1955 (start of atomic time) through 1961 from
+# https://stjarnhimlen.se/comp/time.html
+# Every 3 mo start 1 Jan 1962, from
+# https://www.iers.org/IERS/EN/Science/EarthRotation/UT1-TAI.html
+ut1tai = numpy.array([
+    1.114,
+    0.834,
+    0.504,
+    0.004,
+    -0.496,
+    -0.966,
+    -1.406,
+    -1.813, -1.936, -2.058, -2.142,
+    -2.289, -2.407, -2.551, -2.659,
+    -2.847, -3.043, -3.217, -3.350,
+    -3.558, -3.761, -3.964, -4.139,
+    -4.360, -4.586, -4.817, -5.006,
+    -5.248, -5.476, -5.700, -5.871,
+    -6.111, -6.344, -6.573, -6.775,
+    -7.021, -7.274, -7.521, -7.734,
+    -7.997, -8.271, -8.526, -8.722,
+    -8.985, -9.237, -9.503, -9.741,
+    -10.045, -10.347, -10.638, -10.888,
+    -11.189
+])
+ut1tai_dt = [datetime.datetime(1955 + i, 1, 1) for i in range(7)] \
+            + [datetime.datetime(1962 + i // 4, (i % 4) * 3 + 1, 1)
+               for i in range(len(ut1tai) - 7)]
+
+
+def fake_taiutc(dt, leaplist):
+    """TAI-UTC based on a list of leap second times"""
+    return numpy.searchsorted(leaplist, dt)
+
+# Calculate a list of leap seconds based on UT1
+# Introduce leap second when leapsecondUTC-UT1 > 0.4
+# NIST adds ls when UTC-UT1 > 0.4 to keep UTC-UT1 < 0.9
+ut1_ls = []
+for i, dt in enumerate(ut1tai_dt):
+    if dt.month in (4, 10):
+        continue # Can't do leapsecond
+    if dt.year >= 1972: # 1972 is end of rubber second
+        continue
+    if -ut1tai[i] - len(ut1_ls) > 0.4:
+        ut1_ls.append(dt)
+# The non-rubber portions
+if len(ut1_ls) < 10:
+    ut1_ls.append(datetime.datetime(1972, 1, 1))
+if len(ut1_ls) < 11:
+    ut1_ls.append(datetime.datetime(1972, 7, 1))
+if len(ut1_ls) < 12:
+    ut1_ls.append(datetime.datetime(1973, 1, 1))
+
+
+def rubber_taiutc(dt):
+    """Calculate TAI-UTC via rubber second for a UTC date dt"""
+    idx = numpy.searchsorted(rubbers['dt'], dt, side='right') - 1
+    if idx < 0:
+        return 0.
+    # assumes input time is start of day...
+    mjd = (dt - datetime.datetime(1858, 11, 17)).days
+    return rubbers[idx]['delta'] \
+        + (mjd - rubbers[idx]['mjd'])  * rubbers[idx]['rate']
+
+
+# Fake leapseconds, introduce leap second when leapsecondUTC - rubberUTC > 0.5
+utc_ls = []
+for dt in [datetime.datetime(1958 + i // 2, 1 + (i % 2) * 6, 1)
+           for i in range(28)]:
+    if rubber_taiutc(dt) - len(utc_ls) > 0.5:
+        utc_ls.append(dt)
+# The non-rubber portions
+if len(utc_ls) < 10:
+    utc_ls.append(datetime.datetime(1972, 1, 1))
+if len(utc_ls) < 11:
+    utc_ls.append(datetime.datetime(1972, 7, 1))
+if len(utc_ls) < 12:
+    utc_ls.append(datetime.datetime(1973, 1, 1))
+
+
+# Fake leapseconds, current SpacePy
+# Obviously will not work if changes to fractional leaps are committed
+def spacepy_taiutc(dt):
+    spacepy_ls = [
+        datetime.datetime(int(y), int(m), 1)
+        for y, m in zip(spacepy.time.year, spacepy.time.mon)]
+    idx = numpy.searchsorted(spacepy_ls, dt, side='right') - 1
+    if idx < 0:
+        return 0
+    return spacepy.time.secs[idx]
+
+
+times = spacepy.time.tickrange('1955-1-1', '1973-1-1', 1).UTC
+
+
+fig = plt.figure(figsize=(11, 8.5))
+ax = fig.add_subplot(111)
+
+ax.plot(times, [rubber_taiutc(t) for t in times],
+        ls='-', marker=None, label='TAI-UTC')
+ax.plot(ut1tai_dt, -ut1tai, ls='', marker='X', ms=5, label='TAI-UT1')
+ax.plot(times, [fake_taiutc(t, ut1_ls) for t in times],
+        ls='--', marker=None, label='Proposed (UT1)')
+ax.plot(times, [fake_taiutc(t, utc_ls) for t in times],
+        ls='-.', marker=None, label='Proposed (UTC)')
+ax.plot(times, [spacepy_taiutc(t) for t in times],
+        ls=':', marker=None, label='Current')
+ax.set_ylabel('seconds')
+ax.set_xlabel('UTC date')
+ax.legend(loc='best')
+plt.savefig('rubber_seconds.pdf', dpi=200)
+plt.savefig('rubber_seconds.png', dpi=200)

--- a/developer/scripts/rubber_seconds.py
+++ b/developer/scripts/rubber_seconds.py
@@ -8,6 +8,7 @@ import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy
+import spacepy.pycdf
 import spacepy.time
 
 # These are values from USNO tai-utc during rubber-second era
@@ -132,6 +133,15 @@ def spacepy_taiutc(dt):
         return 0
     return spacepy.time.secs[idx]
 
+# And CDF
+def cdf_taiutc(dt):
+    # CDF tt2000 when UTC and TAI set equal
+    tt2000_1958 = -1325419167816000000
+    naive_seconds = (dt - datetime.datetime(1958, 1, 1)).total_seconds()
+    actual_seconds = (spacepy.pycdf.lib.datetime_to_tt2000(dt) - tt2000_1958) \
+                     / 1.e9
+    return actual_seconds - naive_seconds
+
 
 times = spacepy.time.tickrange('1955-1-1', '1973-1-1', 1).UTC
 
@@ -152,6 +162,8 @@ ax.plot(times, [spacepy_taiutc(t) for t in times],
 spacepy.time._read_leaps(oldstyle=True)
 ax.plot(times, [spacepy_taiutc(t) for t in times],
         ls=':', marker=None, label='0.2.2')
+ax.plot(times, [cdf_taiutc(t) for t in times],
+        ls='--', marker=None, label='CDF TT2000')
 ax.set_ylabel('seconds')
 ax.set_xlabel('UTC date')
 ax.legend(loc='best')

--- a/developer/scripts/rubber_seconds.py
+++ b/developer/scripts/rubber_seconds.py
@@ -92,6 +92,8 @@ if len(ut1_ls) < 11:
     ut1_ls.append(datetime.datetime(1972, 7, 1))
 if len(ut1_ls) < 12:
     ut1_ls.append(datetime.datetime(1973, 1, 1))
+print('Leapseconds based on UTC - UT1 > 0.4s:')
+print('\n'.join([str(t) for t in ut1_ls]))
 
 
 def rubber_taiutc(dt):
@@ -121,7 +123,6 @@ if len(utc_ls) < 12:
 
 
 # Fake leapseconds, current SpacePy
-# Obviously will not work if changes to fractional leaps are committed
 def spacepy_taiutc(dt):
     spacepy_ls = [
         datetime.datetime(int(y), int(m), 1)
@@ -147,6 +148,10 @@ ax.plot(times, [fake_taiutc(t, utc_ls) for t in times],
         ls='-.', marker=None, label='Proposed (UTC)')
 ax.plot(times, [spacepy_taiutc(t) for t in times],
         ls=':', marker=None, label='Current')
+# Revert to <=0.2.2 leapsecond treatment
+spacepy.time._read_leaps(oldstyle=True)
+ax.plot(times, [spacepy_taiutc(t) for t in times],
+        ls=':', marker=None, label='0.2.2')
 ax.set_ylabel('seconds')
 ax.set_xlabel('UTC date')
 ax.legend(loc='best')

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -30,7 +30,7 @@ on 2009-01-01 is two seconds, but only represents a one-second increment in
 Unix time. Details are also discussed in the individual time representations.
 
 UTC times more than six months in the future are not well-defined, since
-the sechedule of leap second insertion is not known in advance. SpacePy
+the schedule of leap second insertion is not known in advance. SpacePy
 performs conversions assuming there are no leapseconds after those which have
 been announced by IERS.
 

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -65,7 +65,7 @@ calendar and dates including and before 1582-10-04 to be Julian. 10-05 through
 10-14 do not exist. This change is ignored for continuously-running non leap
 second aware timebases: CDF and RDT.
 
-See the ``Ticktock`` documentation and its various ``get`` functions for
+See the :class:`Ticktock` documentation and its various ``get`` functions for
 more details on the exact definitions of time systems used by SpacePy.
 
 Examples:

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1145,7 +1145,7 @@ class Ticktock(MutableSequence):
 
         Notes
         =====
-        This is based on the UTC day, defined as JD(UTC) - 2 400 000.5,
+        This is based on the UTC day, defined as JD(UTC),
         per the recommendation
         of `IAU General Assembly XXIII resolution B1
         <https://www.iers.org/IERS/EN/Science/Recommendations/

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -388,8 +388,11 @@ class TimeFunctionTests(unittest.TestCase):
             -31514400.,# 1957-01-01 06:00:00
             0.,        # 1958-01-01 00:00:00
             43200,     # 1958-01-01 12:00:00
-            126230400, # 1961-12-31 23:59:59
-            126230401, # 1961-12-31 23:59:60
+            94694400,  # 1960-12-31 23:59:59
+            94694401,  # 1960-12-31 23:59:60
+            94694402,  # 1961-01-01 00:00:00
+            126230400, # 1961-12-31 23:59:58
+            126230401, # 1961-12-31 23:59:59
             126230402, # 1962-01-01 00:00:00
             126316802, # 1962-01-02 00:00:00
             1609459232,# 2008-12-31 23:59:59
@@ -402,9 +405,12 @@ class TimeFunctionTests(unittest.TestCase):
             -365.25,
             -0.5,
             0,
-            1460 + 43199. / 86401,
-            1460 + 43200. / 86401,
-            1460 + 43201. / 86401,
+            1095 + 43199. / 86401,
+            1095 + 43200. / 86401,
+            1095 + 43201. / 86401,
+            1460 + 43198. / 86400,
+            1460 + 43199. / 86400,
+            1460.5,
             1461.5,
             18627. + 43199. / 86401,
             18627. + 43200. / 86401,
@@ -418,8 +424,11 @@ class TimeFunctionTests(unittest.TestCase):
             -365.25,
             -0.5,
             0,
+            1095 + 43199. / 86400,
+            1095 + 43199.999999 / 86400,
+            1095.5,
+            1460 + 43198. / 86400,
             1460 + 43199. / 86400,
-            1460 + 43199.999999 / 86400,
             1460.5,
             1461.5,
             18627. + 43199. / 86400,
@@ -434,6 +443,9 @@ class TimeFunctionTests(unittest.TestCase):
             -365.25,
             -0.5,
             0,
+            1095.5,
+            1095.5 + 1. / 86400,
+            1095.5 + 2. / 86400,
             1460.5,
             1460.5 + 1. / 86400,
             1460.5 + 2. / 86400,
@@ -467,8 +479,11 @@ class TimeFunctionTests(unittest.TestCase):
             -31514400.,# 1957-01-01 06:00:00
             0.,        # 1958-01-01 00:00:00
             43200,     # 1958-01-01 12:00:00
-            126230400, # 1961-12-31 23:59:59
-            126230401, # 1961-12-31 23:59:60
+            94694400,  # 1960-12-31 23:59:59
+            94694401,  # 1960-12-31 23:59:60
+            94694402,  # 1961-01-01 00:00:00
+            126230400, # 1961-12-31 23:59:58
+            126230401, # 1961-12-31 23:59:59
             126230402, # 1962-01-01 00:00:00
             126316802, # 1962-01-02 00:00:00
             1609459232,# 2008-12-31 23:59:59
@@ -481,8 +496,11 @@ class TimeFunctionTests(unittest.TestCase):
             -364.75,
             0.,
             0.5,
-            1460 + 86399. / 86401,
-            1460 + 86400. / 86401,
+            1095 + 86399. / 86401,
+            1095 + 86400. / 86401,
+            1095 + 86401. / 86401,
+            1460 + 86398. / 86400,
+            1460 + 86399. / 86400,
             1461,
             1462,
             18627. + 86399. / 86401,
@@ -500,8 +518,11 @@ class TimeFunctionTests(unittest.TestCase):
             -364.75,
             0.,
             0.5,
+            1095 + 86399. / 86400,
+            1095 + 86399.999999 / 86400,
+            1096,
+            1460 + 86398. / 86400,
             1460 + 86399. / 86400,
-            1460 + 86399.999999 / 86400,
             1461,
             1462,
             18627. + 86399. / 86400,
@@ -519,6 +540,9 @@ class TimeFunctionTests(unittest.TestCase):
             -364.75,
             0.,
             0.5,
+            1096,
+            1096 + 1. / 86400,
+            1096 + 2. / 86400,
             1461,
             1461 + 1. / 86400,
             1461 + 2. / 86400,
@@ -541,8 +565,11 @@ class TimeFunctionTests(unittest.TestCase):
             -31514400.,# 1957-01-01 06:00:00
             0.,        # 1958-01-01 00:00:00
             43200,     # 1958-01-01 12:00:00
-            126230400, # 1961-12-31 23:59:59
-            126230401, # 1961-12-31 23:59:60
+            94694400,  # 1960-12-31 23:59:59
+            94694401,  # 1960-12-31 23:59:60
+            94694402,  # 1961-01-01 00:00:00
+            126230400, # 1961-12-31 23:59:58
+            126230401, # 1961-12-31 23:59:59
             126230402, # 1962-01-01 00:00:00
             126316802, # 1962-01-02 00:00:00
             1609459232,# 2008-12-31 23:59:59
@@ -555,9 +582,12 @@ class TimeFunctionTests(unittest.TestCase):
             -365.25,
             -0.5,
             0,
-            1460 + 43199. / 86401,
-            1460 + 43200. / 86401,
-            1460 + 43201. / 86401,
+            1095 + 43199. / 86401,
+            1095 + 43200. / 86401,
+            1095 + 43201. / 86401,
+            1460 + 43198. / 86400,
+            1460 + 43199. / 86400,
+            1460.5,
             1461.5,
             18627. + 43199. / 86401,
             18627. + 43200. / 86401,
@@ -571,8 +601,11 @@ class TimeFunctionTests(unittest.TestCase):
             -365.25,
             -0.5,
             0,
+            1095 + 43199. / 86400,
+            1095 + 43199.999999 / 86400,
+            1095.5,
+            1460 + 43198. / 86400,
             1460 + 43199. / 86400,
-            1460 + 43199.999999 / 86400,
             1460.5,
             1461.5,
             18627. + 43199. / 86400,
@@ -587,6 +620,9 @@ class TimeFunctionTests(unittest.TestCase):
             -365.25,
             -0.5,
             0,
+            1095.5,
+            1095.5 + 1. / 86400,
+            1095.5 + 2. / 86400,
             1460.5,
             1460.5 + 1. / 86400,
             1460.5 + 2. / 86400,
@@ -623,8 +659,11 @@ class TimeFunctionTests(unittest.TestCase):
             -31514400.,# 1957-01-01 06:00:00
             0.,        # 1958-01-01 00:00:00
             43200,     # 1958-01-01 12:00:00
-            126230400, # 1961-12-31 23:59:59
-            126230401, # 1961-12-31 23:59:60
+            94694400,  # 1960-12-31 23:59:59
+            94694401,  # 1960-12-31 23:59:60
+            94694402,  # 1961-01-01 00:00:00
+            126230400, # 1961-12-31 23:59:58
+            126230401, # 1961-12-31 23:59:59
             126230402, # 1962-01-01 00:00:00
             126316802, # 1962-01-02 00:00:00
             1609459232,# 2008-12-31 23:59:59
@@ -634,18 +673,21 @@ class TimeFunctionTests(unittest.TestCase):
             ]
 
         inputs = [
-            -364.75,
+           -364.75,
             0.,
             0.5,
-            1460 + 86399. / 86401,
-            1460 + 86400. / 86401,
+            1095 + 86399. / 86401,
+            1095 + 86400. / 86401,
+            1095 + 86401. / 86401,
+            1460 + 86398. / 86400,
+            1460 + 86399. / 86400,
             1461,
             1462,
             18627. + 86399. / 86401,
             18627. + 86400. / 86401,
             18628.,
             18628. + 1. / 86400,
-            ]
+             ]
         actual = t._days1958totai(inputs, leaps='rubber', midnight=True)
         numpy.testing.assert_almost_equal(expected, actual, decimal=6)
         self.assertEqual(
@@ -656,8 +698,11 @@ class TimeFunctionTests(unittest.TestCase):
             -364.75,
             0.,
             0.5,
+            1095 + 86399. / 86400,
+            1095 + 86399.999999 / 86400,
+            1096,
+            1460 + 86398. / 86400,
             1460 + 86399. / 86400,
-            1460 + 86399.999999 / 86400,
             1461,
             1462,
             18627. + 86399. / 86400,
@@ -675,6 +720,9 @@ class TimeFunctionTests(unittest.TestCase):
             -364.75,
             0.,
             0.5,
+            1096,
+            1096 + 1. / 86400,
+            1096 + 2. / 86400,
             1461,
             1461 + 1. / 86400,
             1461 + 2. / 86400,
@@ -1042,10 +1090,11 @@ class TimeClassTests(unittest.TestCase):
             tt2 = t.Ticktock.now()
         tt2tai = tt2.TAI
         taileaps = tt2.TAIleaps
-        range_ex.append(taileaps[39] - 1)
-        range_ex.append(taileaps[39])
-        range_ex.append(taileaps[39] + 1)
-        range_ex.append(taileaps[38])
+        # Get the TAI at the 2015 and 2012 leap seconds
+        range_ex.append(taileaps[35] - 1)
+        range_ex.append(taileaps[35])
+        range_ex.append(taileaps[35] + 1)
+        range_ex.append(taileaps[34])
         tt = t.Ticktock(range_ex, 'TAI')
         ans = ['2010-09-15T10:15:13', '2010-09-15T10:37:26', '2010-09-15T10:59:39',
                '2010-09-15T11:21:53',
@@ -1197,7 +1246,7 @@ class TimeClassTests(unittest.TestCase):
                                   -320., -100841., -100840.,
                                   37299.5 + 43201. / 86401,
                                   41316.,
-                                  41316.5 + 43201. / 86401])
+                                  41317])
         numpy.testing.assert_almost_equal(t1.MJD, expected)
 
     def test_MJDLeapsecond(self):
@@ -1478,31 +1527,28 @@ class TimeClassTests(unittest.TestCase):
             datetime.datetime(1964, 1, 1),
             datetime.datetime(1965, 3, 1)], dtype='UTC')
         numpy.testing.assert_equal(
-            [0, 0, 1, 3, 4], t1.getleapsecs())
+            [0, 1, 2, 3, 4], t1.getleapsecs())
 
     def test_readleapsecs(self):
         """Test that the leap second file was properly read"""
         numpy.testing.assert_equal(
-            [1, 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 4, 4, 10],
-            spacepy.time.secs[:14])
+            numpy.arange(12) + 1, spacepy.time.secs[:12])
         # The date in the file (the moment after the leapsecond, i.e.
         # the first time where the TAI-UTC changes).
-        expected = [(1961, 1, 1),
-                    (1961, 8, 1),
-                    (1962, 1, 1),
-                    (1963, 11, 1),
-                    (1964, 1, 1),
-                    (1964, 4, 1),
-                    (1964, 9, 1),
+        expected = [(1959, 1, 1),
+                    (1961, 1, 1),
+                    (1963, 7, 1),
                     (1965, 1, 1),
-                    (1965, 3, 1),
-                    (1965, 7, 1),
-                    (1965, 9, 1),
-                    (1966, 1, 1),
-                    (1968, 2, 1),
-                    (1972, 1, 1)]
+                    (1966, 7, 1),
+                    (1967, 7, 1),
+                    (1968, 7, 1),
+                    (1969, 7, 1),
+                    (1970, 7, 1),
+                    (1971, 7, 1),
+                    (1972, 7, 1),
+                    (1973, 1, 1)]
         actual = [(int(y), int(m), int(d))
-                  for y, m, d in zip(t.year, t.mon, t.day)][:14]
+                  for y, m, d in zip(t.year, t.mon, t.day)][:12]
         numpy.testing.assert_equal(expected, actual)
 
     def test_leapsgood(self):
@@ -1525,7 +1571,7 @@ class TimeClassTests(unittest.TestCase):
                 datetime.datetime(*lastleap)), 'Case {}'.format(caseno))
 
     def test_diffAcrossLeaps(self):
-        """Do TAI differences across the first leapsecond"""
+        """Do TAI differences across leapseconds"""
         t1 = t.Ticktock([
             datetime.datetime(1960, 12, 31, 23, 59, 58),
             # 1 normal second in between
@@ -1537,6 +1583,15 @@ class TimeClassTests(unittest.TestCase):
         numpy.testing.assert_equal(
             [1, 2, 1], numpy.diff(t1.TAI))
 
+    def testLeapCount(self):
+        """Check leap-second counts (TAI-UTC) at various times"""
+        t1 = t.Ticktock([datetime.datetime(*dt) for dt in (
+            (1958, 1, 1), (1959, 1, 1), (1961, 1, 1),
+            (1971, 12, 31), (1972, 1, 1), (1982, 7, 1),
+        )], dtype='UTC')
+        numpy.testing.assert_equal(
+            [0, 1, 2, 10, 10, 21], t1.leaps)
+
     def testTAIBase(self):
         """Test the baseline of TAI"""
         t1 = t.Ticktock([
@@ -1544,7 +1599,8 @@ class TimeClassTests(unittest.TestCase):
             datetime.datetime(1961, 1, 1)], dtype='UTC')
         numpy.testing.assert_equal(
             [0, # Start epoch.
-             (3 * 365 + 1) * 86400 + 1, # 1958, 1959, 1960 (leap) + 1 second
+             # 1958, 1959, 1960 (leap year) + leap seconds 1959 and 1961
+             (3 * 365 + 1) * 86400 + 2,
              ],
             t1.TAI)
 


### PR DESCRIPTION
This PR applies the post-1972 leapsecond rules from 1958 to 1972 and thus closes #393. Background discussion of the problem is in that issue. It also gracefully handles a missing leapsecond file and closes #435.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

The fix for #435 isn't easily unit-testable so it was confirmed by hand.