### PR TITLE
Fix priority of pathing when using build directory for tests/docs

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -24,9 +24,10 @@ sys.path.append(os.path.abspath(os.path.join('..', '..', 'tests')))
 # Add build directory to the path, preferring version-specific.
 buildbase = os.path.abspath(os.path.join(
     os.path.dirname(__file__), '..', '..', 'build'))
-for pth in ('lib.{0}-{1}.{2}'.format(sysconfig.get_platform(),
+for pth in ('lib', # Prepending, so add low-priority paths first.
+            'lib.{0}-{1}.{2}'.format(sysconfig.get_platform(),
                                      *sys.version_info[:2]),
-            'lib'):
+            ):
     buildpath = os.path.join(buildbase, pth)
     if os.path.isdir(buildpath):
         if not buildpath in sys.path:

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -31,9 +31,10 @@ def add_build_to_path():
     """
     # Prioritize version-specific path; py2 tends to be version-specific
     # and py3 tends to use just "lib". But only use first-matching.
-    for pth in ('lib.{0}-{1}.{2}'.format(sysconfig.get_platform(),
+    for pth in ('lib',  # Prepending, so add low-priority paths first.
+                'lib.{0}-{1}.{2}'.format(sysconfig.get_platform(),
                                          *sys.version_info[:2]),
-                'lib'):
+                ):
         buildpath = os.path.abspath(os.path.join(testsdir, '..', 'build', pth))
         if os.path.isdir(buildpath):
             if not buildpath in sys.path:


### PR DESCRIPTION
#506 changed the unit tests and documentation to use the `build` directory in preference to normal Python paths. Since versions of Python differ in whether they put the version number in subdirectories of `build`, that code first adds the version-specific directory, and then any non-version-specific directories it finds. However, because this is _prepended_ to the path, adding the version-specific first means it's a _lower_ priority. This PR fixes that: the end result is to have version-specific directories first i the path, and non-version-specific second.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
