### PR TITLE
Deprecate colourmaps; fix plot on matplotlib 3.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
 - Installs numpy before build on newer versions of pip (thanks Michael Hirsch)
+plot
+ - Deprecate colourmaps; they were in matplotlib 1.5.
 tests
  - Add spacepy_testing module to provide helper functions for testing.
  - Add assertWarns and assertDoesntWarn context managers.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -22,6 +22,14 @@ New features
 enabling/disabling sparse records (:meth:`~spacepy.pycdf.Var.sparse`) and
 setting the pad value (:meth:`~spacepy.pycdf.Var.pad`). Thanks Antoine Brunet.
 
+Deprecations and removals
+*************************
+The colourmaps provided in the :mod:`~spacepy.plot` module have been
+deprecated. The same colourmaps have been available in matplotlib since
+at least 1.5, and users who do not directly import the colourmaps should
+see no impact.
+
+
 Major bugfixes
 **************
 The passing of keyword arguments from :func:`~spacepy.toolbox.bootHisto`

--- a/spacepy/plot/__init__.py
+++ b/spacepy/plot/__init__.py
@@ -26,10 +26,6 @@ of color, it may be better to use one of the alternatives::
     splot.style('polar') # designed for filled polar plots
     splot.revert_style() # put the style back to matplotlib defaults
 
-For those constrained by institutional computing, we also provide the
-new colormaps developed for matplotlib v2. These colormaps are designed 
-to be perceptually uniform, and hence colorblind-friendly.
-
 Authors: Brian Larsen and Steve Morley
 Institution: Los Alamos National Laboratory
 Contact: balarsen@lanl.gov
@@ -67,7 +63,6 @@ several submodules listed below
     :template: clean_module.rst
 
     carrington
-    colourmaps
     spectrogram
     utils
 
@@ -90,15 +85,6 @@ from .. import config
 from .spectrogram import *
 from .utils import *
 from .carrington import *
-from .colourmaps import plasma as _plasma
-from .colourmaps import plasma_r as _plasma_r
-from .colourmaps import viridis as _viridis
-from .colourmaps import viridis_r as _viridis_r
-
-plt.register_cmap(name='plasma', cmap=_plasma)
-plt.register_cmap(name='plasma_r', cmap=_plasma_r)
-plt.register_cmap(name='viridis', cmap=_viridis)
-plt.register_cmap(name='viridis_r', cmap=_viridis_r)
 
 def plot(*args, **kwargs):
     '''Convenience wrapper for matplotlib's plot function

--- a/spacepy/plot/colourmaps.py
+++ b/spacepy/plot/colourmaps.py
@@ -5,11 +5,16 @@
 # public domain dedication.
 #
 # These, and additional, colourmaps can be found in the mpl-colormaps
-# package on github and will be available in matplotlib v2 when it is
-# released. This file provides these colourmaps for SpacePy users.
+# package on github and are available in matplotlib v1.5+
+# This file provided these colourmaps for SpacePy users under earlier versions.
 
 # The CC0 license can be found at
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+import warnings
+
+warnings.warn('colourmaps deprecated in 0.2.3; use Matplotlib built-ins.',
+              DeprecationWarning)
 
 __all__ = ['plasma', 'viridis']
 


### PR DESCRIPTION
The colormaps provided by SpacePy have been in matplotlib since at least 1.5 and attempting to register them breaks on matplotlib 3.4 (#525), so this PR deprecates them and does not register them with matplotlib. Closes #525.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
