### PR TITLE
Update CI to 20.04 (Closes #550)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,85 +30,73 @@ jobs:
       matrix:
         include:
           - python-version: 2.7
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.10.0,<1.11.0"
             piplist: "scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.0,<1.1 h5py>=2.6,<2.7 ffnet>=0.7.0,<0.8 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
           - python-version: 2.7
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.16.0,<1.17.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.4
-            os: ubuntu-18.04
-            numpy-version: ">=1.10.0,<1.11.0"
-            piplist: "scipy>=0.14.0,<0.15.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
-            cflags: ""
-            dep-strategy: "oldest"
-          - python-version: 3.4
-            os: ubuntu-18.04
-            numpy-version: ">=1.15.0,<1.16.0"
-            piplist: "scipy matplotlib networkx h5py ffnet astropy"
-            cflags: ""
-            dep-strategy: "newest"
           - python-version: 3.5
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.10.0,<1.11.0"
             piplist: "scipy>=0.17.0,<0.18.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
             cflags: ""
             dep-strategy: "oldest"
           - python-version: 3.5
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
           - python-version: 3.6
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.12.0,<1.13.0"
             piplist: "scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
           - python-version: 3.6
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.18.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
           - python-version: 3.7
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.15.1,<1.16.0"
             piplist: "scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
           - python-version: 3.7
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.18.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
           - python-version: 3.8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.17.0,<1.18.0"
             piplist: "scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
           - python-version: 3.8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.18.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
           - python-version: 3.9
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "scipy>=1.5.0,<1.6.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
           - python-version: 3.9
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             numpy-version: ">=1.19.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
@@ -169,7 +157,7 @@ jobs:
   all-tests:
     name: All tests
     if: ${{ always() }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: test
     steps:
       - name: Check test matrix status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
             cflags: ""
             dep-strategy: "newest"
           - python-version: 3.5
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             numpy-version: ">=1.10.0,<1.11.0"
             piplist: "scipy>=0.17.0,<0.18.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
             cflags: ""
             dep-strategy: "oldest"
           - python-version: 3.5
-            os: ubuntu-16.04
+            os: ubuntu-18.04
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
+          - python-version: 3.4
+            os: ubuntu-18.04
+            numpy-version: ">=1.10.0,<1.11.0"
+            piplist: "scipy>=0.14.0,<0.15.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
+            cflags: ""
+            dep-strategy: "oldest"
+          - python-version: 3.4
+            os: ubuntu-18.04
+            numpy-version: ">=1.15.0,<1.16.0"
+            piplist: "scipy matplotlib networkx h5py ffnet astropy"
+            cflags: ""
+            dep-strategy: "newest"
           - python-version: 3.5
             os: ubuntu-18.04
             numpy-version: ">=1.10.0,<1.11.0"


### PR DESCRIPTION
This PR updates all our CI jobs to use Ubuntu 20.04, and closes #550.

The first commit is all that really matters: Python 3.5 was added to the GHA environment on Ubuntu 18.04, and so all that was needed was to move to 18.04 instead of 16.04.

That, however, got me down a deep rabbit hole, much of which has been rebased away. 18.04 also supported Python 3.4 in GHA, so I added that to the CI. Finally, I moved the CI to 20.04, which works fine except it doesn't support 3.4, so that was dropped. I could have kept it on 18.04, I guess, but this seemed like more fun.

A lot of the flailing that was rebased away was trying to use the deadsnakes PPA so we had that in our back pocket for CI on older versions. It's actually really hard to use directly in GHA. There's an action for using it directly, but it only works on 20.04, and the deadsnakes PPA only provides up to 3.5 on 20.04. Despite the name, it's now more oriented towards newer Pythons instead of older.

I should also note...we still have the OS specified for each entry in the matrix, because the cacheing is OS dependent, and it's actually hard to get that information otherwise.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
