### PR TITLE
Only define bdist_wininst if it's being used (Closes #530)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Changes in Version 0.2.3 (2021-xx-xx)
 =====================================
 - Installs numpy before build on newer versions of pip (thanks Michael Hirsch)
+- Fixes install with new versions of setuptools
 coordinates
  - Added Coords methods to convert to/from Astropy SkyCoord instances
 irbempy

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -38,6 +38,10 @@ to :func:`numpy.histogram` and :func:`matplotlib.pyplot.bar` has been fixed.
 The check for out-of-date leapseconds in :mod:`~spacepy.time` has been
 fixed (previously warned even when the file was up to date.)
 
+Fixed installation on new versions of setuptools, which removed
+``bdist_wininst`` support (`#530
+<https://github.com/spacepy/spacepy/issues/530>`_).
+
 Other changes
 *************
 Modern leapsecond rules are applied from 1958-1972 rather than

--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -22,7 +22,7 @@ IF "%1"=="32" (
     set CONDA_FORCE_32_BIT=
 )
 set PYVER="%2"
-CALL %USERPROFILE%\Miniconda3\Scripts\activate py%2_%1
+CALL "%USERPROFILE%\Miniconda3\Scripts\activate" py%2_%1
 pushd %~dp0\..\..\
 rmdir /s /q build
 CALL python setup.py bdist_wheel

--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -13,16 +13,16 @@ GOTO :EOF
 
 :build
 IF "%1"=="32" (
-    set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS32
+    set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS32
     set CONDA_SUBDIR=win-32
     set CONDA_FORCE_32_BIT=1
 ) ELSE (
-    set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS64
+    set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS64
     set CONDA_SUBDIR=win-64
     set CONDA_FORCE_32_BIT=
 )
 set PYVER="%2"
-CALL "%USERPROFILE%\Miniconda3\Scripts\activate" py%2_%1
+CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate" py%2_%1
 pushd %~dp0\..\..\
 rmdir /s /q build
 CALL python setup.py bdist_wheel

--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -13,9 +13,9 @@ set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS64
 set CONDA_SUBDIR=win-64
 set CONDA_FORCE_32_BIT=
 
-start /wait "" %USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%USERPROFILE%\Miniconda3
+start /wait "" "%USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe" /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%USERPROFILE%\Miniconda3
 :: base environment needs to be activated
-CALL %USERPROFILE%\Miniconda3\Scripts\activate
+CALL "%USERPROFILE%\Miniconda3\Scripts\activate"
 CALL conda update -y conda
 CALL conda create -y -n py39_64 python=3.9
 CALL conda create -y -n py38_64 python=3.8
@@ -53,7 +53,7 @@ IF "%1"=="32" (
     set CONDA_SUBDIR=win-64
     set CONDA_FORCE_32_BIT=
 )
-CALL %USERPROFILE%\Miniconda3\Scripts\activate py%2_%1
+CALL "%USERPROFILE%\Miniconda3\Scripts\activate" py%2_%1
 
 :: Are we building SpacePy wheels, or testing?
 IF "%ACTION%"=="BUILD" (

--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -9,13 +9,13 @@ SETLOCAL EnableDelayedExpansion
 set PYTHONPATH=
 set PATH=
 
-set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS64
+set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS64
 set CONDA_SUBDIR=win-64
 set CONDA_FORCE_32_BIT=
 
-start /wait "" "%USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe" /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%USERPROFILE%\Miniconda3
+start /wait "" "%USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe" /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /NoRegistry=1 /S /D=%SYSTEMDRIVE%\Miniconda3
 :: base environment needs to be activated
-CALL "%USERPROFILE%\Miniconda3\Scripts\activate"
+CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate"
 CALL conda update -y conda
 CALL conda create -y -n py39_64 python=3.9
 CALL conda create -y -n py38_64 python=3.8
@@ -23,7 +23,7 @@ CALL conda create -y -n py37_64 python=3.7
 CALL conda create -y -n py36_64 python=3.6
 CALL conda create -y -n py27_64 python=2.7
 
-set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS32
+set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS32
 set CONDA_SUBDIR=win-32
 set CONDA_FORCE_32_BIT=1
 CALL conda create -y -n py39_32 python=3.9
@@ -45,15 +45,15 @@ GOTO :EOF
 
 :installs
 IF "%1"=="32" (
-    set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS32
+    set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS32
     set CONDA_SUBDIR=win-32
     set CONDA_FORCE_32_BIT=1
 ) ELSE (
-    set CONDA_PKGS_DIRS=%USERPROFILE%\Miniconda3\PKGS64
+    set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS64
     set CONDA_SUBDIR=win-64
     set CONDA_FORCE_32_BIT=
 )
-CALL "%USERPROFILE%\Miniconda3\Scripts\activate" py%2_%1
+CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate" py%2_%1
 
 :: Are we building SpacePy wheels, or testing?
 IF "%ACTION%"=="BUILD" (

--- a/developer/scripts/win_build_system_teardown.cmd
+++ b/developer/scripts/win_build_system_teardown.cmd
@@ -1,14 +1,14 @@
 :: Remove the Windows build system
 @ECHO OFF
 
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py27_32
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py27_64
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py36_32
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py36_64
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py37_32
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py37_64
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py38_32
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py38_64
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py39_32
-"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py39_64
-start /wait "" "%USERPROFILE%\Miniconda3\Uninstall-Miniconda3.exe" /S /D=%USERPROFILE%\Miniconda3
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py27_32
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py27_64
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py36_32
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py36_64
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py37_32
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py37_64
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py38_32
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py38_64
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py39_32
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py39_64
+start /wait "" "%SYSTEMDRIVE%\Miniconda3\Uninstall-Miniconda3.exe" /S /D=%SYSTEMDRIVE%\Miniconda3

--- a/developer/scripts/win_build_system_teardown.cmd
+++ b/developer/scripts/win_build_system_teardown.cmd
@@ -1,14 +1,14 @@
 :: Remove the Windows build system
 @ECHO OFF
 
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py27_32
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py27_64
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py36_32
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py36_64
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py37_32
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py37_64
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py38_32
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py38_64
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py39_32
-%USERPROFILE%\Miniconda3\Scripts\conda env remove -y --name py39_64
-start /wait "" %USERPROFILE%\Miniconda3\Uninstall-Miniconda3.exe /S /D=%USERPROFILE%\Miniconda3
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py27_32
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py27_64
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py36_32
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py36_64
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py37_32
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py37_64
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py38_32
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py38_64
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py39_32
+"%USERPROFILE%\Miniconda3\Scripts\conda" env remove -y --name py39_64
+start /wait "" "%USERPROFILE%\Miniconda3\Uninstall-Miniconda3.exe" /S /D=%USERPROFILE%\Miniconda3


### PR DESCRIPTION
This PR does two things:

- Tries to be better about running setup if there are spaces in paths. This comes down to improvements in setup.py to handle pathing better on the one hand, and doing some escaping in the Windows build scripts. Unfortunately this doesn't completely allow for things working properly if the Miniconda path has spaces in it, so this also changes the Windows build scripts to install in the system drive root rather than the user profile directory. As best as I can tell the remaining issues are mostly on f2py/numpy, not SpacePy.
- Doesn't try to define the `bdist_wininst` command unless that was actually passed to `setup.py`. Closes #530. If anybody's unusual enough to explicitly use pip to call `bdist_wininst`, yes, that will probably fail...but that's on them. Basically it keeps that completely out of the way except when we need it, and this will go away entirely in 0.3.0

It does not incorporate a test for this or similar issues, that's #542.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
