### PR TITLE
pybats/ram: Fix fallback pitch angle binning in RamSat

### DIFF
--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -616,14 +616,14 @@ class RamSat(SpaceData):
         omnikeys = [('omni{0}'.format(get_species_label(kk)), kk)
                     for kk in self if get_species_label(kk) is not None]
         # Create delta mu, where mu = cos(pitch angle)
-        dMu = np.zeros(nPa)
         if 'pa_width' in self:
             dMu = 4*np.pi*self['pa_width']
         else:
-            dMu[0] = self['pa_grid'][1]
-            for i in range(1, nPa):
-                # Factor of 4*pi here so we don't need it later
-                dMu[i] = 4*np.pi*self['pa_grid'][i] - self['pa_grid'][i-1]
+            # if "pa_width" absent, calculate...
+            # assume bin width for zeroth bin is same as first,
+            # and that zeroth PA is zero.
+            grdif = np.diff(self['pa_grid'])
+            dMu = 4*np.pi*dmarray(np.r_[grdif[0], grdif])
 
         for omkey, fluxkey in omnikeys:
             self[omkey] = np.zeros((nTime, nEner))

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -616,14 +616,13 @@ class RamSat(SpaceData):
         omnikeys = [('omni{0}'.format(get_species_label(kk)), kk)
                     for kk in self if get_species_label(kk) is not None]
         # Create delta mu, where mu = cos(pitch angle)
-        if 'pa_width' in self:
-            dMu = 4*np.pi*self['pa_width']
-        else:
+        if 'pa_width' not in self:
             # if "pa_width" absent, calculate...
             # assume bin width for zeroth bin is same as first,
             # and that zeroth PA is zero.
             grdif = np.diff(self['pa_grid'])
-            dMu = 4*np.pi*dmarray(np.r_[grdif[0], grdif])
+            self['pa_width'] = dmarray(np.r_[grdif[0], grdif])
+        dMu = 4*np.pi*self['pa_width']
 
         for omkey, fluxkey in omnikeys:
             self[omkey] = np.zeros((nTime, nEner))

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -725,6 +725,24 @@ class RampyTests(unittest.TestCase):
         data.create_omniflux(check=False)
         numpy.testing.assert_array_equal(flux_h, data['FluxH+'])
 
+    def test_RamSat_omni_pabin(self):
+        '''Check that internal PA bin calc is consistent'''
+        data = ram.RamSat(self.testfile)
+        data.create_omniflux(check=False)
+        omni1 = np.asarray(data['omniHe'].copy())
+        origwid = np.asarray(data['pa_width'].copy())
+        del data['pa_width']
+        data.create_omniflux(check=False)
+        omni2 = np.asarray(data['omniHe'])
+        # test that calculated omni is close -- bin widths are
+        # not fully recoverable from grid, so this is approximate
+        numpy.testing.assert_allclose(omni1, omni2, rtol=1e-1)
+        # and test that "pa_width" is consistent with simulation
+        # (again, calculation from pa_grid isn't fully recovering
+        # actual widths - so test is approximate)
+        newwid = np.asarray(data['pa_width'])
+        numpy.testing.assert_array_almost_equal(origwid, newwid, decimal=2)
+
     def test_RamSat_omnicalc_regress(self):
         '''Regression test for omni flux calculation'''
         data = ram.RamSat(self.testfile)


### PR DESCRIPTION
## The Issue
It was pointed out to me that there were missing parentheses in the fallback calculation of `dMu` for calculating omnidirectional flux if the `pa_width` array is not present in the loaded `RamSat` object.
```
dMu[i] = 4*np.pi*self['pa_grid'][i] -self['pa_grid'][i-1]
```
where the _width_ is the subtraction...

This code, because it's a fallback calculation, shouldn't be called by someone using `RamSat` to work with RAM output satellite files. That is, the `pa_width` should always be present. However, if it's there then it should work, so...

## The Updates
- The original fallback calculation didn't actually populate the `pa_width` array, so this now does.
- The original implementation only multiplied indices [1, end] by 4pi (missing
index 0), so would be incorrect even with the parentheses.
- The update removes a loop in the fallback and simplifies the logic check to see whether this needs calling.
- I added comments to document the assumptions of the fallback calculation
- There's now a test to hit the new code:
  - Uses the recalculated `pa_width`, so will error if it's not stored
  - Checks that the new `pa_width` is consistent with that in the test file
  - Check for similarity of derived omni flux using new widths (noting that this won't be the same because the fallback calculation doesn't have enough info to ensure identical bin widths to what should have been in the file)
- I did a sweep of the full `RamSat` class to deal with PEP8 stuff (whitespace, `x not in y` vs. `not x in y`, etc.)

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [x] New features and bug fixes should have unit tests
- [N/A] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)