### PR TITLE
Better DLL search paths (fix irbem on some Windows)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Changes in Version 0.2.3 (2021-xx-xx)
 - Installs numpy before build on newer versions of pip (thanks Michael Hirsch)
 - Fixes install with new versions of setuptools
 - Better handling of unusual status of .spacepy directory
+- More robust handling of Windows library loading on Python 3.8+
 coordinates
  - Added Coords methods to convert to/from Astropy SkyCoord instances
 irbempy

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -29,7 +29,6 @@ deprecated. The same colourmaps have been available in matplotlib since
 at least 1.5, and users who do not directly import the colourmaps should
 see no impact.
 
-
 Major bugfixes
 **************
 The passing of keyword arguments from :func:`~spacepy.toolbox.bootHisto`
@@ -41,6 +40,13 @@ fixed (previously warned even when the file was up to date.)
 Fixed installation on new versions of setuptools, which removed
 ``bdist_wininst`` support (`#530
 <https://github.com/spacepy/spacepy/issues/530>`_).
+
+The handling of library paths on Windows has been updated. This should
+fix situations where :mod:`~spacepy.irbempy` would not import on
+Windows with Python 3.8 or later. This did not seem to be a problem
+with Anaconda, but would sometimes manifest with Python from the app
+store or from `<http://python.org/>`_ (`#507
+<https://github.com/spacepy/spacepy/issues/507>`_)
 
 Other changes
 *************

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -96,6 +96,10 @@ if sys.platform == 'win32':
                 os.environ['PATH'] = minglibs
     else:
         os.environ['PATH'] = minglibs
+    try:
+        os.add_dll_directory(minglibs)
+    except AttributeError:  # Python 3.8+ only
+        pass
 
 #actual deprecation decorator
 def _deprecator(version, message, docstring, func):


### PR DESCRIPTION
This PR uses the new `add_dll_directory` function to add the mingw runtimes to the DLL path. This is the preferred way on Python 3.8+, rather than just using `PATH` (which is what we've done to this point.) Although problems haven't cropped up consistently, failing to do so does cause problems sometimes (e.g. @drsteve found it seemed to be an issue with Python from the app store on Windows 11.)

Because this addresses a possible cause and I haven't seen any followup from the original reporter, I'm going to say this closes #507.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (see below) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

Not unit testable since we don't have Windows in the CI at this point, and the existing tests do often pass on Windows. This one needs to be validated by hand test.