### PR TITLE
Include build deps file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@
 #top-level docs
 include INSTALL
 include CHANGELOG
+# Defining build requirements (numpy)
+include pyproject.toml
 #Sphinx docs and source
 graft Doc/build/html
 include Doc/Makefile


### PR DESCRIPTION
We need numpy to build, and this is indicated from the `pyproject.toml` file (PEP517/518). This let wheels build from a checkout. However, this file wasn't included in the source distribution (an oversight in #517), so building a wheel from a zip fails. This is what `pip` does by default if there's no binary wheel, so it would complain about falling back to `setup.py`.

This PR just makes sure that file is in the source dist. I verified that building the source dist with this PR applied does include `pyproject.toml`, and then I can `pip install` right off the resulting zip without complaint.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to CHANGELOG if fixing a major bug or providing a major new feature
- [X] (see below) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

This is our usual "CI isn't set up to test installer issues" problem, so tested by hand, as described above.