### PR TITLE
Testing and instruction updates for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,85 +29,85 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: 2.7
+          - python-version: "2.7"
             os: ubuntu-20.04
             numpy-version: ">=1.10.0,<1.11.0"
             piplist: "scipy>=0.11.0,<0.12.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.0,<1.1 h5py>=2.6,<2.7 ffnet>=0.7.0,<0.8 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
-          - python-version: 2.7
+          - python-version: "2.7"
             os: ubuntu-20.04
             numpy-version: ">=1.16.0,<1.17.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.5
+          - python-version: "3.5"
             os: ubuntu-20.04
             numpy-version: ">=1.10.0,<1.11.0"
             piplist: "scipy>=0.17.0,<0.18.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
             cflags: ""
             dep-strategy: "oldest"
-          - python-version: 3.5
+          - python-version: "3.5"
             os: ubuntu-20.04
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.6
+          - python-version: "3.6"
             os: ubuntu-20.04
             numpy-version: ">=1.12.0,<1.13.0"
             piplist: "scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
-          - python-version: 3.6
+          - python-version: "3.6"
             os: ubuntu-20.04
             numpy-version: ">=1.19.0,<1.20.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.7
+          - python-version: "3.7"
             os: ubuntu-20.04
             numpy-version: ">=1.15.1,<1.16.0"
             piplist: "scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
-          - python-version: 3.7
+          - python-version: "3.7"
             os: ubuntu-20.04
             numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.8
+          - python-version: "3.8"
             os: ubuntu-20.04
             numpy-version: ">=1.17.0,<1.18.0"
             piplist: "scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0<0.9 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
-          - python-version: 3.8
+          - python-version: "3.8"
             os: ubuntu-20.04
             numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.9
+          - python-version: "3.9"
             os: ubuntu-20.04
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "scipy>=1.5.0,<1.6.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
-          - python-version: 3.9
+          - python-version: "3.9"
             os: ubuntu-20.04
             numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
-          - python-version: 3.10
+          - python-version: "3.10"
             os: ubuntu-20.04
             numpy-version: ">=1.21.0,<1.22.0"
             piplist: "scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
-          - python-version: 3.10
+          - python-version: "3.10"
             os: ubuntu-20.04
             numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: 3.6
             os: ubuntu-20.04
-            numpy-version: ">=1.18.0"
+            numpy-version: ">=1.19.0,<1.20.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
@@ -73,7 +73,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: 3.7
             os: ubuntu-20.04
-            numpy-version: ">=1.18.0"
+            numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
@@ -85,7 +85,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: 3.8
             os: ubuntu-20.04
-            numpy-version: ">=1.18.0"
+            numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
@@ -97,7 +97,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: 3.9
             os: ubuntu-20.04
-            numpy-version: ">=1.19.0"
+            numpy-version: ">=1.21.0"
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         # Make sure new packages don't override numpy version
         pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
         pip freeze
-        if [ ! -d ${HOME}/cdf ]; then wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; cd cdf38_0-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
+        if [ ! -d ${HOME}/cdf ]; then wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; cd cdf38_0-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
     - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,18 @@ jobs:
             piplist: "scipy matplotlib networkx h5py ffnet astropy"
             cflags: ""
             dep-strategy: "newest"
+          - python-version: 3.10
+            os: ubuntu-20.04
+            numpy-version: ">=1.21.0,<1.22.0"
+            piplist: "scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
+            cflags: "-Wno-error=format-security"
+            dep-strategy: "oldest"
+          - python-version: 3.10
+            os: ubuntu-20.04
+            numpy-version: ">=1.21.0"
+            piplist: "scipy matplotlib networkx h5py ffnet astropy"
+            cflags: ""
+            dep-strategy: "newest"
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           - python-version: "3.10"
             os: ubuntu-20.04
             numpy-version: ">=1.21.0,<1.22.0"
-            piplist: "scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
+            piplist: "scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=3.6,<3.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
             cflags: "-Wno-error=format-security"
             dep-strategy: "oldest"
           - python-version: "3.10"

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -31,7 +31,7 @@ bash ./Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
 
 If CDF library isn't installed, download/install CDF, so that the pycdf
 library will import and the docs build:
-wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; pushd cdf38_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
+wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; pushd cdf38_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
 source ${HOME}/cdf/bin/definitions.B
 
 Make a clean isolated environment just for SpacePy build:

--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -7,7 +7,7 @@ SETLOCAL EnableDelayedExpansion
 set PYTHONPATH=
 set PATH=
 
-FOR %%B in (32 64) DO (FOR %%P in (27 36 37 38 39) DO CALL :build %%B %%P)
+FOR %%B in (32 64) DO (FOR %%P in (27 36 37 38 39 310) DO CALL :build %%B %%P)
 
 GOTO :EOF
 

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -33,7 +33,7 @@ TESTS=(
 # So assuming this is an f2py problem, go for 1.18 minimum.
        "3.9|numpy>=1.18.0,<1.19.0|scipy>=1.5.0,<1.6.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
        "3.9|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
-       "3.10|numpy>=1.21.0,<1.22.0|scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
+       "3.10|numpy>=1.21.0,<1.22.0|scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=3.6,<3.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
        "3.10|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
       )
 for thisTest in "${TESTS[@]}"

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -12,7 +12,7 @@ sudo aptitude install libblas-dev liblapack-dev
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash ./Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
 # download/install CDF
-wget https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; pushd cdf38_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
+wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf38_0/linux/cdf38_0-dist-cdf.tar.gz; tar xzf cdf38_0-dist-cdf.tar.gz; pushd cdf38_0-dist; make OS=linux ENV=gnu all; make INSTALLDIR=$HOME/cdf install; popd
 source ${HOME}/cdf/bin/definitions.B
 
 # For the most part, these versions are: what's the earliest we support,

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -24,15 +24,15 @@ TESTS=(
        "3.5|numpy>=1.10.0,<1.11.0|scipy>=0.17.0,<0.18.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=1.0,<1.1"
        "3.5|numpy>=1.18.0,<1.19.0|scipy matplotlib networkx h5py ffnet astropy"
        "3.6|numpy>=1.12.0,<1.13.0|scipy>=0.19.0,<0.20.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=1.0,<1.1"
-       "3.6|numpy>=1.19.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.6|numpy>=1.19.0,<1.20.0|scipy matplotlib networkx h5py ffnet astropy"
        "3.7|numpy>=1.15.1,<1.16.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
-       "3.7|numpy>=1.19.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.7|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
        "3.8|numpy>=1.17.0,<1.18.0|scipy>=1.0.0,<1.1.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
-       "3.8|numpy>=1.19.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.8|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
 # numpy 1.17 works on 3.9, but doesn't build ffnet, whereas 1.18 does.
 # So assuming this is an f2py problem, go for 1.18 minimum.
        "3.9|numpy>=1.18.0,<1.19.0|scipy>=1.5.0,<1.6.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
-       "3.9|numpy>=1.19.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.9|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
        "3.10|numpy>=1.21.0,<1.22.0|scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
        "3.10|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
       )

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -33,6 +33,8 @@ TESTS=(
 # So assuming this is an f2py problem, go for 1.18 minimum.
        "3.9|numpy>=1.18.0,<1.19.0|scipy>=1.5.0,<1.6.0 matplotlib>=1.5.0,<1.6.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=2.0,<2.1"
        "3.9|numpy>=1.19.0|scipy matplotlib networkx h5py ffnet astropy"
+       "3.10|numpy>=1.21.0,<1.22.0|scipy>=1.7.2,<1.8.0 matplotlib>=2.2.0,<2.3.0 networkx>=1.3,<1.4 h5py>=2.6,<2.7 ffnet>=0.8.0,<0.9 astropy>=4.0,<4.1"
+       "3.10|numpy>=1.21.0|scipy matplotlib networkx h5py ffnet astropy"
       )
 for thisTest in "${TESTS[@]}"
 do

--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -17,6 +17,7 @@ start /wait "" "%USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe" /I
 :: base environment needs to be activated
 CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate"
 CALL conda update -y conda
+CALL conda create -y -n py310_64 python=3.10
 CALL conda create -y -n py39_64 python=3.9
 CALL conda create -y -n py38_64 python=3.8
 CALL conda create -y -n py37_64 python=3.7
@@ -26,6 +27,7 @@ CALL conda create -y -n py27_64 python=2.7
 set CONDA_PKGS_DIRS=%SYSTEMDRIVE%\Miniconda3\PKGS32
 set CONDA_SUBDIR=win-32
 set CONDA_FORCE_32_BIT=1
+CALL conda create -y -n py310_32 python=3.9
 CALL conda create -y -n py39_32 python=3.9
 CALL conda create -y -n py38_32 python=3.8
 CALL conda create -y -n py37_32 python=3.7
@@ -39,7 +41,7 @@ IF "%1"=="build" (
     set ACTION=TEST
 )
 
-FOR %%B in (32 64) DO (FOR %%P in (27 36 37 38 39) DO CALL :installs %%B %%P)
+FOR %%B in (32 64) DO (FOR %%P in (27 36 37 38 39 310) DO CALL :installs %%B %%P)
 
 GOTO :EOF
 
@@ -60,7 +62,10 @@ IF "%ACTION%"=="BUILD" (
     :: Get the compiler
     CALL conda install -y m2w64-gcc-fortran libpython
     set NUMPY="numpy"
-    :: minimum version for each Python version
+    :: Build with the minimum version for each Python version
+    IF "%2"=="310" (
+        set NUMPY="numpy>=1.21.0,<1.22.0"
+    )
     IF "%2"=="39" (
     :: 1.18 works on 3.9, but there's no Windows binary wheel.
     :: 1.19.4 has Win10 2004 bug on 64-bit, but
@@ -86,7 +91,7 @@ IF "%ACTION%"=="BUILD" (
     CALL pip install !NUMPY!
 ) ELSE (
     :: Testing. Get the latest of everything
-    IF "%2"=="39" (
+    IF "%2"=="310" (
         CALL pip install numpy
         CALL pip install numpy scipy matplotlib networkx h5py ffnet astropy
     ) ELSE (

--- a/developer/scripts/win_build_system_teardown.cmd
+++ b/developer/scripts/win_build_system_teardown.cmd
@@ -11,4 +11,6 @@
 "%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py38_64
 "%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py39_32
 "%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py39_64
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py310_32
+"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py310_64
 start /wait "" "%SYSTEMDRIVE%\Miniconda3\Uninstall-Miniconda3.exe" /S /D=%SYSTEMDRIVE%\Miniconda3

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1261,7 +1261,7 @@ def download_library():
         class AppURLopener(u.FancyURLopener):
             version = spacepy.config['user_agent']
         u._urlopener = AppURLopener()
-    baseurl = 'https://spdf.sci.gsfc.nasa.gov/pub/software/cdf/dist/'
+    baseurl = 'https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/'
     url = u.urlopen(baseurl)
     listing = url.read()
     url.close()


### PR DESCRIPTION
This PR updates our CI, developer test scripts, and Windows build instructions (for developers building distributions) to include Python 3.10, now that both Python 3.10 and supporting versions of scipy and numpy are out. This also includes minor tweaks to the minimum/maximum version of numpy in CI.

EDIT: Two more changes were required:

- To get 3.10 to not be interpreted as a number (3.1), all Python version numbers are now quoted in CI.
- h5py has switched to requiring a specific version of numpy that is tied to the specific version of Python. In addition to being a royal pain in the neck, no numpy version was specified for Python 3.10 until h5py 3.6, so h5py 3.6 is now the minimum tested on 3.10.

EDIT: Also updated the URI for the CDF library on SPDF, in several places.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
