### PR TITLE
sort_unstructured_data keyword added to pybats IdlFile method

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -65,7 +65,7 @@ and `~.pybats.bats.Bats2d.calc_upar` methods.
 
 `~.pybats.IdlFile` supports reading binary files without sorting
 unstructured data (and adds support for sorting in reading ASCII
-files).
+files). Unsorted is now the default for all except `~.pybats.bats.Bats2d`.
 
 Deprecations and removals
 *************************

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -63,6 +63,10 @@ with temperature and density naming.
 perpendicular velocities with new `~.pybats.bats.Bats2d.calc_uperp`
 and `~.pybats.bats.Bats2d.calc_upar` methods.
 
+`~.pybats.IdlFile` supports reading binary files without sorting
+unstructured data (and adds support for sorting in reading ASCII
+files).
+
 Deprecations and removals
 *************************
 Since plot styles are no longer applied on import, importing

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -66,6 +66,7 @@ and `~.pybats.bats.Bats2d.calc_upar` methods.
 `~.pybats.IdlFile` supports reading binary files without sorting
 unstructured data (and adds support for sorting in reading ASCII
 files). Unsorted is now the default for all except `~.pybats.bats.Bats2d`.
+Thanks Lutz Rastaetter.
 
 Deprecations and removals
 *************************

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1183,15 +1183,23 @@ class IdlFile(PbData):
         Determine how to interpret the additional header information.
         Defaults to 'units'.
 
-    keep_case : boolean
+    keep_case : bool
         If set to True, the case of variable names will be preserved.  If
         set to False, variable names will be set to all lower case.
-    sort_unstructured_data : boolean 9default: None
-        If not set, the behavior of the _read_idl_bin() and _read-idl-ascii() readers reamin, as described below:
-        If set to True, the positions and data are sorted so nearby positions are arranged as close as possible to each other in the data arrays. 
-          True is the default in the _read_idl_bin() reader.
-        If set to False the positions in the unstructured grid data are not rearranged. When reading 3D magnetosphere files, the 3D block structure is preserved and can then be used by the BATSRUS interpolator developed for the Kamodo Heliohysics model readers package (https://github.com/nasa/kamodo) that relies on these Spacepy.pybats readers.
-          False is the default for the _read_idl_ascii() reader where the feature was not implemented before this keyword was added.
+
+    sort_unstructured_data : bool, default: ``None``
+
+        .. versionadded:: 0.5.0
+
+        If ``True``, the positions and data are sorted so nearby
+        positions are arranged as close as possible to each other in
+        the data arrays (default in the ``_read_idl_bin()`` reader).
+        If ``False`` the positions in the unstructured grid data are
+        not rearranged. (default for ``_read_idl_ascii()``
+        reader). When reading 3D magnetosphere files, the 3D block
+        structure is preserved. Needed for the BATSRUS interpolator
+        in the `Kamodo Heliophysics model readers package
+        <https://github.com/nasa/kamodo>`_.
     '''
 
     def __init__(self, filename, iframe=0, header='units',
@@ -1350,13 +1358,16 @@ class IdlFile(PbData):
     def __repr__(self):
         return 'SWMF IDL-Binary file "%s"' % (self.attrs['file'])
 
-    def read(self, iframe=0,sort_unstructured_data=None):
+    def read(self, iframe=0, sort_unstructured_data=None):
         '''
         This method reads an IDL-formatted BATS-R-US output file and places
         the data into the object.  The file read is self.filename which is
         set when the object is instantiated.
-        The new sort_unstructured_data keyword can turn off the data sorting run by default in the binary file reader.
-        The idl_ascii reader now has the option to perform the same sorting as the idl_bin reader when teh keyword is set to True.
+
+        The new sort_unstructured_data keyword can turn off the data sorting
+        run by default in the binary file reader; the idl_ascii reader now
+        has the option to perform the same sorting as the idl_bin reader when
+        the keyword is set to True.
         '''
 
         # Get location of frame that we wish to read:

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -400,7 +400,7 @@ def add_body(ax, rad=2.5, facecolor='lightgrey', show_planet=True,
     ax.add_artist(body)
 
 
-def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True, sort_unstructured_data=False):
+def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True, sort_unstructured=False):
     '''
     Load a SWMF IDL ascii output file and load into a pre-existing PbData
     object.  This should only be called by :class:`IdlFile`.
@@ -548,7 +548,7 @@ def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True, sort_uns
                                               order='F'), attrs=pbdat[v].attrs)
 
     # Unstructured data can be in any order, so let's sort it.
-    if gtyp == 'Unstructured' and sort_unstructured_data:
+    if gtyp == 'Unstructured' and sort_unstructured:
         gridtotal = np.zeros(npts)
         offset = 0.0  # The offset ensures no repeating vals while sorting.
         for key in pbdat['grid'].attrs['dims']:
@@ -839,7 +839,7 @@ def _probe_idlfile(filename):
 
 
 def _read_idl_bin(pbdat, header='units', start_loc=0, keep_case=True,
-                  headeronly=False, sort_unstructured_data=False):
+                  headeronly=False, sort_unstructured=False):
     '''
     Load a SWMF IDL binary output file and load into a pre-existing PbData
     object.  This should only be called by :class:`IdlFile`, which will
@@ -875,7 +875,7 @@ def _read_idl_bin(pbdat, header='units', start_loc=0, keep_case=True,
         If set to True, the case of variable names will be preserved.  If
         set to False, variable names will be set to all lower case.
 
-    sort_unstructured_data : bool, default False
+    sort_unstructured : bool, default False
 
       .. versionadded:: 0.5.0
 
@@ -1014,7 +1014,7 @@ def _read_idl_bin(pbdat, header='units', start_loc=0, keep_case=True,
                     pbdat['grid'], order='F')
 
         # Unstructured data can be in any order, so let's sort it.
-        if gtyp == 'Unstructured' and sort_unstructured_data:
+        if gtyp == 'Unstructured' and sort_unstructured:
             gridtotal = np.zeros(npts)
             offset = 0.0  # The offset ensures no repeating vals while sorting.
             for key in pbdat['grid'].attrs['dims']:
@@ -1197,7 +1197,7 @@ class IdlFile(PbData):
         If set to True, the case of variable names will be preserved.  If
         set to False, variable names will be set to all lower case.
 
-    sort_unstructured_data : bool, default: ``False``
+    sort_unstructured : bool, default: ``False``
 
         .. versionadded:: 0.5.0
 
@@ -1212,7 +1212,7 @@ class IdlFile(PbData):
     '''
 
     def __init__(self, filename, iframe=0, header='units',
-                 keep_case=True, sort_unstructured_data=False, *args, **kwargs):
+                 keep_case=True, sort_unstructured=False, *args, **kwargs):
         super(IdlFile, self).__init__(*args, **kwargs)  # Init as PbData.
 
         # Gather information about the file: format, endianess (if necessary),
@@ -1242,7 +1242,7 @@ class IdlFile(PbData):
             self._scan_asc_frames()
 
         # Read one entry of the file (defaults to first frame):
-        self.read(iframe=iframe, sort_unstructured_data=sort_unstructured_data)
+        self.read(iframe=iframe, sort_unstructured=sort_unstructured)
 
         # Update information about the currently loaded frame.
         self.attrs['iframe'] = iframe
@@ -1360,7 +1360,7 @@ class IdlFile(PbData):
     def __repr__(self):
         return 'SWMF IDL-Binary file "%s"' % (self.attrs['file'])
 
-    def read(self, iframe=0, sort_unstructured_data=False):
+    def read(self, iframe=0, sort_unstructured=False):
         '''
         This method reads an IDL-formatted BATS-R-US output file and places
         the data into the object.  The file read is self.filename which is
@@ -1368,7 +1368,7 @@ class IdlFile(PbData):
 
         .. versionchanged:: 0.5.0
 
-        The new sort_unstructured_data keyword can enable data sorting
+        The new sort_unstructured keyword can enable data sorting
         (formerly default in the binary file reader).
         '''
 
@@ -1378,11 +1378,11 @@ class IdlFile(PbData):
         if self.attrs['format'] == 'asc':
             _read_idl_ascii(self, header=self._header, start_loc=loc,
                             keep_case=self._keep_case,
-                            sort_unstructured_data=sort_unstructured_data)
+                            sort_unstructured=sort_unstructured)
         elif self.attrs['format'] == 'bin':
             _read_idl_bin(self, header=self._header, start_loc=loc,
                           keep_case=self._keep_case,
-                          sort_unstructured_data=sort_unstructured_data)
+                          sort_unstructured=sort_unstructured)
         else:
             raise ValueError('Unrecognized file format: {}'.format(
                 self._format))

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -755,14 +755,14 @@ class Bats2d(IdlFile):
 
     '''
     # Init by calling IdlFile init and then building qotree, etc.
-    def __init__(self, filename, *args, sort_unstructured_data=True, **kwargs):
+    def __init__(self, filename, *args, sort_unstructured=True, **kwargs):
 
         # Create quad tree object attribute:
         self._qtree = None
 
         # Read file.
         IdlFile.__init__(self, filename, keep_case=False, *args,
-                         sort_unstructured_data=sort_unstructured_data,
+                         sort_unstructured=sort_unstructured,
                          **kwargs)
 
         # Behavior of output files changed Jan. 2017:

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -755,13 +755,15 @@ class Bats2d(IdlFile):
 
     '''
     # Init by calling IdlFile init and then building qotree, etc.
-    def __init__(self, filename, *args, **kwargs):
+    def __init__(self, filename, *args, sort_unstructured_data=True, **kwargs):
 
         # Create quad tree object attribute:
         self._qtree = None
 
         # Read file.
-        IdlFile.__init__(self, filename, keep_case=False, *args, **kwargs)
+        IdlFile.__init__(self, filename, keep_case=False, *args,
+                         sort_unstructured_data=sort_unstructured_data,
+                         **kwargs)
 
         # Behavior of output files changed Jan. 2017:
         # Check for 'r' instead of 'rbody' in attrs.

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -284,6 +284,12 @@ class TestIdlFile(unittest.TestCase):
         self.assertEqual(self.knownMhdXmin, mhd['x'].min())
         self.assertEqual(self.knownMhdZlim, mhd['z'].max())
         self.assertEqual(self.knownMhdZlim*-1, mhd['z'].min())
+        for v in range(len(self.knownMhdX_unsorted)):
+            self.assertEqual(self.knownMhdX_unsorted[v], (mhd['x'])[v])
+        mhd = pb.IdlFile(os.path.join(spacepy_testing.datadir,
+                                      'pybats_test',
+                                      'y=0_mhd_1_e20140410-000050.out'),
+                         sort_unstructured_data=True)
         for v in range(len(self.knownMhdX_sorted)):
             self.assertEqual(self.knownMhdX_sorted[v], (mhd['x'])[v])
 

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -243,6 +243,8 @@ class TestIdlFile(unittest.TestCase):
     knownMhdXmin = -220.0
     knownMhdZlim = 124.0
     knownMhdTime = dt.datetime(2014, 4, 10, 0, 0, 50)
+    knownMhdX_unsorted = [-220., -212., -204., -196., -188., -180., -172., -164.] # first 8 X positions in the y0_ascii.out file
+    knownMhdX_sorted = [-220., -212., -220., -204., -220., -212., -212., -204.] # first 8 X positions in the binary y=0_mhd_1_e20140410-000050.out file after sorting of positions
 
     # Known values for multi-frame *.outs files:
     # Time/iteration range covered by files:
@@ -282,6 +284,8 @@ class TestIdlFile(unittest.TestCase):
         self.assertEqual(self.knownMhdXmin, mhd['x'].min())
         self.assertEqual(self.knownMhdZlim, mhd['z'].max())
         self.assertEqual(self.knownMhdZlim*-1, mhd['z'].min())
+        for v in range(len(self.knownMhdX_sorted)):
+            self.assertEqual(self.knownMhdX_sorted[v], (mhd['x'])[v])
 
     def testAscii(self):
         # Open file:
@@ -298,7 +302,9 @@ class TestIdlFile(unittest.TestCase):
         self.assertEqual(self.knownMhdXmin, mhd['x'].min())
         self.assertEqual(self.knownMhdZlim, mhd['z'].max())
         self.assertEqual(self.knownMhdZlim*-1, mhd['z'].min())
-
+        for v in range(len(self.knownMhdX_unsorted)):
+            self.assertEqual(self.knownMhdX_unsorted[v], (mhd['x'])[v])
+        
     def testReadOuts(self):
         # Start with y=0 slice MHD outs file:
         mhd = pb.IdlFile(os.path.join(spacepy_testing.datadir, 'pybats_test',

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -289,7 +289,7 @@ class TestIdlFile(unittest.TestCase):
         mhd = pb.IdlFile(os.path.join(spacepy_testing.datadir,
                                       'pybats_test',
                                       'y=0_mhd_1_e20140410-000050.out'),
-                         sort_unstructured_data=True)
+                         sort_unstructured=True)
         for v in range(len(self.knownMhdX_sorted)):
             self.assertEqual(self.knownMhdX_sorted[v], (mhd['x'])[v])
 


### PR DESCRIPTION
This is the revised pull request implementing an optional _sort_unstructured_data_ keyword for pybats.IdlFile.
I established a branch for this feature for this pull request.

The new keyword defaults to _None_ which keeps the old behavior of the IdlFile readers unchanged:
  __read_idl_bin()_ implemented sorting of unstructured data and that remains active by default.
  __read_idl_ascii()_ did not implement sorting of positions before and the newly added method is not activated by default.
The keyword can be set to _True_ to have data sorted to arrange nearly positions as close as possible to each other, regardless of whether the model output file format is binary or ASCII, or to _False_ to keep the original arrangement of positions as provided in the model output file.

Keeping the original arrangement of grid positions intact is used by an interpolater developed as part of the Kamodo data access and analysis package (https://github.com/nasa/Kamodo/) that depends on spacepy.pybats.IdlFile readers for SWMF BATSRUS magnetosphere outputs. The interpolater uses the octree grid structure to efficiently compute interpolated MHD values.

I have added code to test_pybats.py to list the first eight known X positions in the y0_ascii.bin output file to confirm the default behavior of the ASCII reader not to sort.
The binary reader does sort by default and the comparison against the first eight known sorted X positions is performed.


- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] New features and bug fixes should have unit tests
- [N/A] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)