### PR TITLE
pycdf docs: reference new() in discussion of default time types

### DIFF
--- a/Doc/source/pycdf.rst
+++ b/Doc/source/pycdf.rst
@@ -56,6 +56,7 @@ CDF_TIME_TT2000 types.
     :meth:`~spacepy.pycdf.Library.set_backward`),
     then :class:`~datetime.datetime` objects are degraded to CDF_EPOCH
     (millisecond resolution), not CDF_EPOCH16 (microsecond resolution).
+    Use :meth:`~spacepy.pycdf.CDF.new` to specify a data type.
 
 Create some random data.
 


### PR DESCRIPTION
Simple documentation one-liner. People were getting confused about the specification of time types when creating a new variable by assignment. I added a reference to the `new` method, which lets the user specify the type, at the point where they were getting confused.

At some point I do want to scrub all the pycdf docs but trying to dispose of some virtual post-it notes here...

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
