### PR TITLE
Add cache-expiration to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,19 +125,23 @@ jobs:
       shell: bash
     - name: Cache pip
       uses: actions/cache@v2
+      env: # Need to tickle this to get it to unlock secrets at all
+        CACHE_VERSION: ${{ secrets.CACHE_VERSION }}
       with:
         path: ~/.cache/pip
         # Force-expire the pip cache weekly
-        key: pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-strategy }}
+        key: pip-v${{ env.pip-cache-version}}-${{ secrets.CACHE_VERSION }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-strategy }}
         restore-keys: |
-          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
-          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
+          pip-v${{ env.pip-cache-version}}-${{ secrets.CACHE_VERSION }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
+          pip-v${{ env.pip-cache-version}}-${{ secrets.CACHE_VERSION }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
     - name: Cache cdf
       uses: actions/cache@v2
+      env: # Need to tickle this to get it to unlock secrets at all
+        CACHE_VERSION: ${{ secrets.CACHE_VERSION }}
       with:
         path: ~/cdf
         # Force-expire the CDF cache weekly
-        key: cdf-v${{ env.cdf-cache-version}}-3.8.0.1-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
+        key: cdf-v${{ env.cdf-cache-version}}-${{ secrets.CACHE_VERSION }}-3.8.0.1-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
     - name: Install dependencies
       env:
         NUMPY_VERSION: ${{ matrix.numpy-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,23 +125,19 @@ jobs:
       shell: bash
     - name: Cache pip
       uses: actions/cache@v2
-      env: # Need to tickle this to get it to unlock secrets at all
-        CACHE_VERSION: ${{ secrets.CACHE_VERSION }}
       with:
         path: ~/.cache/pip
         # Force-expire the pip cache weekly
-        key: pip-v${{ env.pip-cache-version}}-${{ secrets.CACHE_VERSION }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-strategy }}
+        key: pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-strategy }}
         restore-keys: |
-          pip-v${{ env.pip-cache-version}}-${{ secrets.CACHE_VERSION }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
-          pip-v${{ env.pip-cache-version}}-${{ secrets.CACHE_VERSION }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
+          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
+          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
     - name: Cache cdf
       uses: actions/cache@v2
-      env: # Need to tickle this to get it to unlock secrets at all
-        CACHE_VERSION: ${{ secrets.CACHE_VERSION }}
       with:
         path: ~/cdf
         # Force-expire the CDF cache weekly
-        key: cdf-v${{ env.cdf-cache-version}}-${{ secrets.CACHE_VERSION }}-3.8.0.1-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
+        key: cdf-v${{ env.cdf-cache-version}}-3.8.0.1-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
     - name: Install dependencies
       env:
         NUMPY_VERSION: ${{ matrix.numpy-version }}

--- a/Doc/source/ci.rst
+++ b/Doc/source/ci.rst
@@ -71,13 +71,9 @@ dependencies, and one for the NASA CDF library. This minimizes CI time
 use for building dependencies.
 
 Caches expire weekly (the week begins at 00 Monday, UTC). Caches can
-also be force-expired by incrementing the ``CACHE_VERSION``
-`repository secret
-<https://docs.github.com/en/actions/security-guides/encrypted-secrets>`_. This
-applies to all caches in the SpacePy repository CI; there are also
-separate versions in ``ci.yml`` for the pip and CDF cache. The current
-version of this secret is not visible, but the important thing is only
-that it change.
+also be force-expired by incrementing the versions in ``ci.yml`` for
+the pip and/or CDF cache. Unfortunately this does require pushing a
+commit.
 
 Usage
 =====

--- a/Doc/source/ci.rst
+++ b/Doc/source/ci.rst
@@ -64,6 +64,21 @@ Note that a PR will not trigger the CI `if there is a merge conflict
 <https://github.community/t/run-actions-on-pull-requests-with-merge-conflicts/
 17104>`_.
 
+Cacheing
+========
+Dependencies for CI are stored in two caches: one for all pip
+dependencies, and one for the NASA CDF library. This minimizes CI time
+use for building dependencies.
+
+Caches expire weekly (the week begins at 00 Monday, UTC). Caches can
+also be force-expired by incrementing the ``CACHE_VERSION``
+`repository secret
+<https://docs.github.com/en/actions/security-guides/encrypted-secrets>`_. This
+applies to all caches in the SpacePy repository CI; there are also
+separate versions in ``ci.yml`` for the pip and CDF cache. The current
+version of this secret is not visible, but the important thing is only
+that it change.
+
 Usage
 =====
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -1,4 +1,5 @@
 
+import spacepy_testing
 import unittest
 import spacepy.coordinates as spc
 import glob
@@ -6,7 +7,6 @@ import os
 import datetime
 from numpy import array
 import numpy as np
-import spacepy_testing
 from spacepy.time import Ticktock
 try:
     import spacepy.irbempy as ib


### PR DESCRIPTION
CI is currently failing due to AstroPy and I think it's because there was a glitch at exactly the time our dependencies were rebuilt for the week. There's no way to force-expire the dependency cache to check that. This PR modifies the cache keys to include a reference to a repository-wide secret. We can change that secret to force-expire all dependency caches.

While I was diagnosing this I also found that `test_coordinates` imports `spacepy_testing` (which sets up the pathing) after `spacepy.coordinates`. This meant the `coordinates` import would not come from the build directory. This wasn't showing up in CI because `test_all` fixes the path immediately, but I fixed that for testing `coordinates` on its own.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A)Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A)Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A)New features and bug fixes should have unit tests
- [X] (N/A)Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
