### PR TITLE
Fix various numpy and Python deprecation warnings in tests

### DIFF
--- a/spacepy/datamanager.py
+++ b/spacepy/datamanager.py
@@ -1036,20 +1036,23 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
     also be used to rebin on the time axis, e.g. for transforming time
     base.
     """
+    makefloat = lambda x: x if isinstance(x, numpy.ndarray)\
+                and issubclass(x.dtype.type, numpy.floating)\
+                else numpy.require(x, dtype=numpy.float_)
     bintype = bintype.lower()
     assert bintype in ('mean', 'count', 'unc')
-    data = numpy.require(data, dtype=numpy.floating)
-    bindata = numpy.require(bindata, dtype=numpy.floating)
+    data = makefloat(data)
+    bindata = makefloat(bindata)
     if axis < 0:
         axis = len(data.shape) + axis
     binnedshape = _find_shape(data.shape, bindata.shape)
     if weights is not None:
-        weights = numpy.require(weights, dtype=numpy.floating)
+        weights = makefloat(weights)
         assert weights.shape == bindata.shape
         weights = numpy.reshape(weights, binnedshape)
     if bindatadelta is not None:
         if not numpy.isscalar(bindatadelta):
-            bindatadelta = numpy.require(bindatadelta, dtype=numpy.floating)
+            bindatadelta = makefloat(bindatadelta)
             assert bindata.shape == bindatadelta.shape
             bindatadelta = numpy.reshape(bindatadelta, binnedshape)
             bindatadelta = numpy.rollaxis(
@@ -1076,8 +1079,8 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
         select = numpy.require(
             numpy.expand_dims(whichbin, axis=-2)
             == numpy.reshape(
-                numpy.arange(nbins, dtype=numpy.int), outbin_shape),
-            dtype=numpy.int)
+                numpy.arange(nbins, dtype=int), outbin_shape),
+            dtype=int)
     else:
         bindatamin = bindata - bindatadelta
         bindatamax = bindata + bindatadelta
@@ -1097,8 +1100,7 @@ def rebin(data, bindata, bins, axis=-1, bintype='mean',
         # No overlap if top < bottom
         overlap = numpy.maximum(overlap_top - overlap_bottom , 0)
         # Normalize the overlap to fraction of the input bin
-        select = numpy.require(overlap, dtype=numpy.float) \
-                                               / (bindatamax - bindatamin)
+        select = overlap / (bindatamax - bindatamin)
     if weights is not None: # Apply weights to the inputs
         select = select * numpy.expand_dims(weights, axis=-2)
     # Add a degenerate dimension to the end of data, so now

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1158,9 +1158,9 @@ def toHDF5(fname, SDobject, **kwargs):
     except NameError:
         allowed_attrs = [int,       float, bytes, str, numpy.ndarray, list, tuple, numpy.string_]
     for v in numpy.typecodes['AllInteger']:
-        allowed_attrs.append(numpy.typeDict[v])
+        allowed_attrs.append(numpy.sctypeDict[v])
     for v in numpy.typecodes['AllFloat']:
-        allowed_attrs.append(numpy.typeDict[v])
+        allowed_attrs.append(numpy.sctypeDict[v])
 
     allowed_elems = [SpaceData, dmarray]
 

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -246,7 +246,7 @@ class Spectrogram(dm.SpaceData):
         # this is here for in the future when we take a list a SpaceData objects
         sz = (self.specSettings['bins'][1].shape[0]-1, self.specSettings['bins'][0].shape[0]-1)
         overall_sum = dm.dmarray(np.zeros(sz, dtype=np.double))
-        overall_count = dm.dmarray(np.zeros(sz, dtype=np.long))
+        overall_count = dm.dmarray(np.zeros(sz, dtype=np.int_))
 
         # the valid range for the histograms
         _range = [self.specSettings['xlim'], self.specSettings['ylim']]

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4399,20 +4399,30 @@ class _Hyperslice(object):
 
     @staticmethod
     def check_well_formed(data):
-        """Checks if input data is well-formed, regular array"""
-        d = numpy.asanyarray(data)
+        """Checks if input data is well-formed, regular array
+
+        Returns
+        -------
+        :class:`~numpy.ndarray`
+            The input data as a well-formed array; may be the input
+            data exactly.
+        """
+        msg = 'Data must be well-formed, regular array of number, '\
+              'string, or datetime'
+        try:
+            d = numpy.asanyarray(data)
+        except ValueError:
+            raise ValueError(msg)
+        # In a future numpy, the case tested below will raise ValueError,
+        # so can remove entire if block.
         if d.dtype == object: #this is probably going to be bad
             if d.shape != () and not len(d):
                 #Completely empty, so "well-formed" enough
-                return
-            try:
-                len(d.flat[0])
-            except TypeError: #at least it's not a list
-                pass
-            else:
-                raise ValueError(
-                    'Data must be well-formed, regular array of number, '
-                    'string, or datetime')
+                return d
+            if numpy.array(d.flat[0]).shape != ():
+                # Sequence-like, so we know it's ragged
+                raise ValueError(msg)
+        return d
 
     @staticmethod
     def dimensions(data):
@@ -4424,9 +4434,7 @@ class _Hyperslice(object):
         @rtype: list of int
         @raise ValueError: if L{data} has irregular dimensions
         """
-        d = numpy.asanyarray(data)
-        _Hyperslice.check_well_formed(d)
-        return d.shape
+        return _Hyperslice.check_well_formed(data).shape
 
     @staticmethod
     def types(data, backward=False):

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -4475,12 +4475,11 @@ class _Hyperslice(object):
         @rtype: 3-tuple of lists ([int], [ctypes.c_long], [int])
         @raise ValueError: if L{data} has irregular dimensions
         """
-        d = numpy.asanyarray(data)
+        d = _Hyperslice.check_well_formed(data)
         dims = d.shape
         elements = 1
         types = []
 
-        _Hyperslice.check_well_formed(d)
         if d.dtype.kind in ('S', 'U'): #it's a string
             types = [const.CDF_CHAR, const.CDF_UCHAR]
             elements = d.dtype.itemsize

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1146,7 +1146,7 @@ def nanfill(v):
     """
     #If input is a zVar, read all the data; if not, this is a no-copy operation
     indata = v[...]
-    badidx = numpy.zeros(shape=v.shape, dtype=numpy.bool)
+    badidx = numpy.zeros(shape=v.shape, dtype=bool)
     if 'FILLVAL' in v.attrs:
         badidx |= (indata == v.attrs['FILLVAL'][...])
     if 'VALIDMIN' in v.attrs:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1014,7 +1014,7 @@ def _get_cdaweb_omni2(omni2url=None):
     data['Epoch'] = data['Epoch'] + datetime.timedelta(minutes=30)
     #Castings to match ViRBO: everything is an int, and fill turns to NaN
     for k, v in data.items():
-        if v.dtype == np.object: #Skip epoch
+        if v.dtype == object: #Skip epoch
             continue
         if v.dtype == np.int32:
             data[k] = v.astype(np.float32)

--- a/tests/test_datamanager.py
+++ b/tests/test_datamanager.py
@@ -552,7 +552,7 @@ class DataManagerBinningTests(unittest.TestCase):
 
         rebinned = spacepy.datamanager.rebin(indata, bindata, bins,
                                 weights=weights, bintype='count')
-        expected = numpy.empty(dtype=numpy.float, shape=(100, 6, 5))
+        expected = numpy.empty(dtype=float, shape=(100, 6, 5))
         for binno in range(len(bins) - 1):
             idx = (bins[binno] <= bindata) & (bindata < bins[binno + 1])
             for i in range(100):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -149,7 +149,11 @@ class NoCDF(unittest.TestCase):
                     'setting an array element with a sequence.',
                 )
         try:
-            cdf._Hyperslice.dimensions(data)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    'ignore', 'Creating an ndarray from ragged.*',
+                    module='spacepy.pycdf')
+                cdf._Hyperslice.dimensions(data)
         except ValueError:
             (t, v, tb) = sys.exc_info()
             self.assertTrue(str(v) in messages)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1232,10 +1232,10 @@ class TimeClassTests(unittest.TestCase):
         t1 = t.Ticktock(['2002-01-01T01:00:00'])
         expected = t.Ticktock(["2002-01-01T01:00:00", "2002-01-02T00:00:00"], dtype='UTC')
         t1.insert(1, '2002-01-02')
-        numpy.testing.assert_array_equal(t1, expected)
+        numpy.testing.assert_array_equal(t1.ISO, expected.ISO)
         t1 = t.Ticktock(['2002-01-01T01:00:00'])
         t1.insert(1, '2002-01-02', dtype='ISO')
-        numpy.testing.assert_array_equal(t1, expected)
+        numpy.testing.assert_array_equal(t1.ISO, expected.ISO)
 
     def test_MJD(self):
         """conversions to MJD should work"""
@@ -1455,7 +1455,7 @@ class TimeClassTests(unittest.TestCase):
         """testing get UTC from GPS"""
         t1 = t.Ticktock([6.93882013e+08, 6.93964813e+08], 'GPS')
         expected = t.Ticktock(['2002-01-01T01:00:00', '2002-01-02'])
-        numpy.testing.assert_array_equal(t1, expected)
+        numpy.testing.assert_array_equal(t1.ISO, expected.ISO)
 
     def test_GPSinput(self):
         """Regressions on GPS input, correct TAI/UTC conversions"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -776,6 +776,24 @@ class TBTimeFunctionTests(unittest.TestCase):
                      for val in range(-20, 20)]
         self.dt_b2 = [dt1 + datetime.timedelta(hours=val)
                      for val in range(-20, -2)]
+        # random.sample(list(range(100)), 100)
+        self.dt_a_shuf = [
+            dt1 + datetime.timedelta(hours=val)
+            for val in
+            [86, 75, 53, 74, 35, 57, 63, 84, 82, 89, 45, 10, 41, 78, 14, 62, 98,
+             80, 42, 24, 31,  2, 34, 85, 28, 47, 21, 81, 54,  7, 12, 18, 83,  5,
+             9,  3, 15, 40, 69, 38, 97, 36, 70, 25, 66, 23, 59, 94, 99, 60,  1,
+             61, 11, 90, 52, 30, 13, 64, 49, 77, 27,  6, 16,  4, 76, 58, 19, 22,
+             39, 55, 87, 37, 95, 29, 33, 72, 32, 48, 50,  8, 96, 93, 44, 73, 26,
+             71, 88, 51, 79, 17, 20, 92, 68, 65, 91, 46,  0, 67, 56, 43]]
+        # random.sample(list(range(-20, 20)), 40)
+        self.dt_b_shuf = [
+            dt1 + datetime.timedelta(hours=val)
+            for val in
+            [  2,   4,  -4, -11,  15, -20,   9, -15,   1,   3, -19,  -3, -12,
+             -16, -13,  18,  -5,  -9,  -1,  16,  19,  -2,   6,   0,  -8,  11,
+             -14, -10,  13,  14,  17, -17,  12,  -6,  -7,   5,   7,   8, -18,
+             10]]
 
     def tearDown(self):
         super(TBTimeFunctionTests, self).tearDown()
@@ -792,14 +810,11 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_tOverlap_random(self):
         """Shuffle input before calling tOverlap"""
-        real_ans = ([1, 5, 6, 10, 15, 16, 18, 24, 29, 30, 43,
-                     46, 47, 51, 53, 55, 56, 64, 67, 74],
-                    [1, 2, 6, 7, 10, 12, 13, 14, 15, 17, 18,
-                     19, 24, 27, 28, 30, 32, 35, 37, 38])
-        random.seed(0)
-        random.shuffle(self.dt_a, lambda:round(random.random(), 9))
-        random.shuffle(self.dt_b, lambda:round(random.random(), 9))
-        ans = tb.tOverlap(self.dt_a, self.dt_b)
+        real_ans = ([[11, 14, 21, 29, 30, 31, 33, 34, 35, 36, 50, 52,
+                      56, 61, 62, 63, 66, 79, 89, 96],
+                     [ 0,  1,  4,  6,  8,  9, 15, 19, 20, 22, 23, 25,
+                       28, 29, 30, 32, 35, 36, 37, 39]])
+        ans = tb.tOverlap(self.dt_a_shuf, self.dt_b_shuf)
         numpy.testing.assert_array_equal(real_ans, ans)
 
     def test_tOverlapHalf(self):
@@ -811,13 +826,9 @@ class TBTimeFunctionTests(unittest.TestCase):
 
     def test_tOverlapHalf_random(self):
         """Shuffle input before calling tOverlapHalf"""
-        real_ans = [1, 2, 6, 7, 10, 12, 13, 14, 15, 17, 18,
-                     19, 24, 27, 28, 30, 32, 35, 37, 38]
-        random.seed(0)
-        #Cut down the python3 rng to the same precision as python2
-        random.shuffle(self.dt_a, lambda:round(random.random(), 9))
-        random.shuffle(self.dt_b, lambda:round(random.random(), 9))
-        ans = tb.tOverlapHalf(self.dt_a, self.dt_b)
+        real_ans = ([0, 1, 4, 6, 8, 9, 15, 19, 20, 22, 23, 25, 28,
+                    29, 30, 32, 35, 36, 37, 39])
+        ans = tb.tOverlapHalf(self.dt_a_shuf, self.dt_b_shuf)
         self.assertEqual(real_ans, ans)
 
     def test_tOverlapSorted(self):


### PR DESCRIPTION
Fixes several deprecation warnings that were showing up in the test suite, from numpy 1.20 and 1.21 and Python 3.9. Most were pretty straightforward.

The pycdf one (#460) is a bit icky because the code is there to work around the original numpy issue, which _warns_ that it will change but hasn't actually been fixed yet. So in that case I just trapped the warning in the test suite; users who trigger that code will get a ValueError along with their deprecation warning.

The other icky one was Python 3.9 deprecating our workaround for the Python 2 and Python 3 RNGs not returning the same values.

Closes #460. Closes #580.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

Verified the `toolbox.update` behaviour of #580 by running manually.
