### PR TITLE
pycdf enhancements: UTF-8, truthiness, document slow readonly closing

### DIFF
--- a/Doc/source/pycdf.rst
+++ b/Doc/source/pycdf.rst
@@ -1,28 +1,16 @@
-
 ######################################
 pycdf - Python interface to CDF files
 ######################################
 
 .. automodule:: spacepy.pycdf
 
-
 Contents
 --------
 
-- `Quickstart`_
-    - `Create a CDF`_
-    - `Read a CDF`_
-    - `Modify a CDF`_
-    - `Non record-varying`_
-    - `Slicing and indexing`_
-    - `String handling`_
-- `Classes`_
-- `Functions`_
-- `Submodules`_
-- `Data`_
+.. contents::
+   :depth: 2
+   :local:
 
-Quickstart
-----------
 Create a CDF
 ============
 This example presents the entire sequence of creating a CDF and populating
@@ -302,7 +290,7 @@ The underlying C library is represented by the :attr:`~spacepy.pycdf.lib`
 variable.
 
 Classes
--------
+=======
 
 .. autosummary::
     :template: clean_class.rst
@@ -325,7 +313,7 @@ Classes
     EpochError
 
 Functions
----------
+=========
 
 .. autosummary::
     :template: clean_function.rst
@@ -334,7 +322,7 @@ Functions
     concatCDF
 
 Submodules
-----------
+==========
 
 .. autosummary::
     :toctree: autosummary  
@@ -344,7 +332,7 @@ Submodules
     istp
 
 Data
-----
+====
 
 .. attribute:: lib
 

--- a/Doc/source/pycdf.rst
+++ b/Doc/source/pycdf.rst
@@ -15,6 +15,7 @@ Contents
     - `Modify a CDF`_
     - `Non record-varying`_
     - `Slicing and indexing`_
+    - `String handling`_
 - `Classes`_
 - `Functions`_
 - `Submodules`_
@@ -248,6 +249,49 @@ hourly data file created in earlier examples.
 >>> cdf.close()
 
 The :class:`Var` documentation has several additional examples.
+
+.. _pycdf_string_handling:
+
+String handling
+===============
+
+   .. versionchanged:: 0.3.0
+
+   Prior to SpacePy 0.3.0, pycdf treated all strings as ASCII-encoded, and
+   would raise errors when writing or reading strings that were not valid
+   ASCII.
+
+Per the NASA CDF library, variable and attribute names must be in
+ASCII. The contents of ``CDF_CHAR`` and ``CDF_UCHAR`` were redefined
+to be UTF-8 as of CDF 3.8.1. As of SpacePy 0.3.0, pycdf treats all
+``CHAR`` variables with a default encoding of UTF-8. This is true
+regardless of the version of the underlying CDF library.
+
+UTF-8 is a variable-length encoding, so the number of elements in the
+variable may not correspond to the number of characters if data are
+not restricted to the ASCII range.
+
+A different encoding can be specified with the ``encoding`` argument
+to :class:`~spacepy.pycdf.CDF.open` and this encoding will be used on
+all reads and writes to that file. Opening a CDF read-write with
+``encoding`` other than ``utf-8`` or ``ascii`` will issue a warning.
+
+Writing strings which cannot be represented in the desired encoding
+will raise an error. When reading from a CDF, characters which cannot
+be decoded will be replaced with the Unicode "replacement character"
+U+FFFD, which usually displays as a question mark.
+
+It is always possible to write raw bytes data to a variable, if it is
+desired to use a different encoding for one time. For arrays of data,
+this will usually involve :func:`numpy.char.encode`:
+
+   >>> cdf['Variable'] = data.encode('latin-1')
+   >>> cdf['Variable'] = numpy.char.encode(data, encoding='latin-1')
+
+All encoding and decoding can also be skipped using the
+:meth:`~spacepy.pycdf.CDF.raw_var` method to access a variable;
+however, without encoding, only :class:`bytes` can be written to
+string variables.
 
 Access to CDF constants and the C library
 =========================================

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -25,6 +25,11 @@ built at installation time. The default backend remains IRBEM; in
 backend. The new :mod:`~spacepy.igrf` module is part of this support
 but may be of interest on its own.
 
+In accordance with a change from NASA, :mod:`~spacepy.pycdf` now
+assumes strings in CDFs are UTF-8. It will no longer raise errors on
+reading non-ASCII data from a CDF. See :ref:`pycdf_string_handling` in
+the pycdf documentation for details.
+
 Deprecations and removals
 *************************
 Colourmaps have been removed from :class:`~spacepy.plot`. The same

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -1473,8 +1473,8 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     readonly : bool
         Open the CDF read-only. Default True if opening an
         existing CDF; False if creating a new one. A readonly
-        CDF with many variables may be slow to close. See
-        :meth:`readonly`.
+        CDF with many variables may be slow to close on CDF library
+        versions before 3.8.1. See :meth:`readonly`.
     encoding : str, optional
         Text encoding to use when reading and writing strings. Default
         ``'utf-8'``.
@@ -2131,12 +2131,13 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         will have no effect.
 
         .. note::
-            Closing a CDF that has been opened readonly, or setting readonly
+            Before version 3.8.1 of the NASA CDF library,
+            closing a CDF that has been opened readonly, or setting readonly
             False, may take a substantial amount of time if there are many
             variables in the CDF, as a (potentially large) cache needs to
-            be cleared. Consider specifying ``readonly=False`` when opening
-            the file if this is an issue. However, this may make some reading
-            operations slower.
+            be cleared. If upgrading to a newer CDF library is not possible,
+            specifying ``readonly=False`` when opening the file is an option.
+            However, this may make some reading operations slower.
 
         Other Parameters
         ================

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -2902,6 +2902,13 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
     reading an NRV scalar variable with no data will return an empty
     one-dimensional array. This is really not recommended.
 
+    Variables with no records (RV) or no data (NRV) are considered to be
+    "false"; those with records or data written are considered to be
+    "true", allowing for an easy check of data existence:
+
+    >>> if testcdf['variable']:
+    >>>     # do things that require data to exist
+
     As a list type, variables are also `iterable
     <http://docs.python.org/tutorial/classes.html#iterators>`_; iterating
     over a variable returns a single complete record at a time.

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -3263,41 +3263,34 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
             `data` converted, including time conversions
         """
         cdf_type = self.type()
+        np_type = self._np_type()
         if cdf_type == const.CDF_EPOCH16.value:
             if not self._raw:
                 try:
                     data = lib.v_datetime_to_epoch16(data)
                 except AttributeError:
                     pass
-            data = numpy.require(data, requirements=('C', 'A', 'W'),
-                                 dtype=numpy.float64)
+            np_type = numpy.float64
         elif cdf_type == const.CDF_EPOCH.value:
             if not self._raw:
                 try:
                     data = lib.v_datetime_to_epoch(data)
                 except AttributeError:
                     pass
-            data = numpy.require(data, requirements=('C', 'A', 'W'),
-                                 dtype=numpy.float64)
         elif cdf_type == const.CDF_TIME_TT2000.value:
             if not self._raw:
                 try:
                     data = lib.v_datetime_to_tt2000(data)
                 except AttributeError:
                     pass
-            data = numpy.require(data, requirements=('C', 'A', 'W'),
-                                 dtype=numpy.int64)
         elif cdf_type in (const.CDF_UCHAR.value, const.CDF_CHAR.value):
             if not self._raw:
                 data = numpy.asanyarray(data)
                 if data.dtype.kind == 'U':
                     data = numpy.char.encode(
                         data, encoding=self.cdf_file.encoding)
-            data = numpy.require(data, requirements=('C', 'A', 'W'),
-                                 dtype=self._np_type())
-        else:
-            data = numpy.require(data, requirements=('C', 'A', 'W'),
-                                 dtype=self._np_type())
+        data = numpy.require(data, requirements=('C', 'A', 'W'),
+                             dtype=np_type)
         return data
 
     def __setitem__(self, key, data):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -3476,6 +3476,24 @@ class ChangeCDF(ChangeCDFBase):
         else:
             self.fail('Should have raised IndexError on 1')
 
+    def testTruthiness(self):
+        """Variables should be falsey if empty, truthy otherwise"""
+        self.cdf.new('Testvar', dims=[2, 3], type=const.CDF_INT1)
+        self.assertFalse(self.cdf['Testvar'])
+        self.cdf['Testvar'][...] = [[[1, 2, 3], [4, 5, 6]],
+                                    [[7, 8, 9], [10, 11, 12]]]
+        self.assertTrue(self.cdf['Testvar'])
+        del self.cdf['Testvar'][...]
+        self.assertFalse(self.cdf['Testvar'])
+        self.cdf.new('TestNRV', dims=[2, 3], recVary=False, type=const.CDF_INT1)
+        self.assertFalse(self.cdf['TestNRV'])
+        self.cdf['TestNRV'][...] = [[1, 2, 3], [4, 5, 6]]
+        self.assertTrue(self.cdf['TestNRV'])
+        self.cdf.new('TestNRVScalar', recVary=False, type=const.CDF_INT1)
+        self.assertFalse(self.cdf['TestNRVScalar'])
+        self.cdf['TestNRVScalar'][...] = 1
+        self.assertTrue(self.cdf['TestNRVScalar'])
+
 
 class ChangezVar(ChangeCDFBase):
     """Tests that modify a zVar"""

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -1174,6 +1174,24 @@ class MakeCDF(unittest.TestCase):
                    else [u'\ufffd' * len(asbytes[0])] * 2
         numpy.testing.assert_array_equal(expected, numpy.char.rstrip(out))
 
+    def testWarnEncodings(self):
+        """Warn when using nonstandard encoding"""
+        kwargs = {'message': 'Opening CDF for write with nonstandard encoding',
+                  'category': UserWarning}
+        with spacepy_testing.assertWarns(self, **kwargs):
+            with cdf.CDF(self.testfspec, create=True, encoding='latin-1') as f:
+                pass
+        with spacepy_testing.assertDoesntWarn(self, **kwargs):
+            f = cdf.CDF(self.testfspec, encoding='latin-1')
+            f.readonly(True)
+        with spacepy_testing.assertWarns(self, **kwargs):
+            f.readonly(False)
+        f.close()
+        with spacepy_testing.assertDoesntWarn(self, **kwargs):
+            f = cdf.CDF(self.testfspec, encoding='ascii')
+            f.readonly(False)
+        f.close()
+
 
 class CDFTestsBase(unittest.TestCase):
     """Base class for tests involving existing CDF, column or row major"""


### PR DESCRIPTION
This PR lumps together several small pycdf improvements:

- In connection with the new NASA CDF interpretation, support for UTF-8 encoding and documentation of how the encoding works. In addition to switching to utf-8 instead of ascii encoding, this also changes the behavior on decoder fail: silent replacement instead of raising exception. Closes #555. Closes #586.
- Tests truthiness of variables and documents this trick. Closes #560.
- Updates the documentation on slow closing of readonly CDFs, since 3.8.1 fixed this.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
