### PR TITLE
Revert to USNO for leapseconds

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -73,6 +73,11 @@ a time variable or attribute without specifying a type (EPOCH or
 EPOCH16 are used if TT2000 isn't available). A warning is issued when
 doing so; this warning will be removed in 0.4.0. (Warning added in 0.2.2.)
 
+The default data source for leapsecond files has been reverted from
+NASA/MODIS to the USNO, as USNO data services are back online. If
+present, entries in the :doc:`configuration file <configuration>` will
+still be used instead of the default.
+
 0.2 Series
 ==========
 

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -322,7 +322,7 @@ def _read_config(rcfile):
                 'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip',
                 'qd_daily_url': 'https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/',
                 'omni2_url': 'https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hourly/',
-                'leapsec_url': 'https://oceandata.sci.gsfc.nasa.gov/Ancillary/LUTs/modis/leapsec.dat',
+                'leapsec_url': 'https://maia.usno.navy.mil/ser7/tai-utc.dat',
                 'psddata_url': 'http://spacepy.lanl.gov/repository/psd_dat.sqlite',
                 'support_notice': str(True),
                 'apply_plot_styles': str(True),


### PR DESCRIPTION
This PR reverts the default leapsecond source to the USNO and documents that change. Closes #341.

Verified running `update()` with this change and tests passed after downloading the new leapsecond file from USNO.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A)  Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
