### PR TITLE
Do not install docs with SpacePy

### DIFF
--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-SpacePy documentation
-===================================
+SpacePy |version| documentation
+===============================
 
 SpacePy is a package for Python, targeted at the space sciences, that aims to
 make basic data analysis, modeling and visualization easier. It builds on the

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -36,6 +36,16 @@ format is deprecated.
 
 Deprecations and removals
 *************************
+HTML documentation is no longer installed with
+SpacePy. :func:`~spacepy.help` now opens the latest `online
+documentation <https://spacepy.github.io/>`_. Offline documentation
+are available separately (files named like ``spacepy-x.y.z-doc.zip``
+and ``spacepy-x.y.z-doc.pdf``) and as part of the source distribution
+(``spacepy-x.y.z.tar.gz`` or ``spacepy-x.y.z.zip``). These files can
+be downloaded from SpacePy's `releases on GitHub
+<https://github.com/spacepy/spacepy/releases>`_; the source can also
+be found on `PyPI <https://pypi.org/project/spacepy/#files>`_.
+
 ``LANLstar`` requires `ffnet <http://ffnet.sourceforge.net/>`_, which
 does not work on Python 3.7 and later. The SpacePy team is working on
 replacing this dependency, but in the meantime ``LANLstar`` is

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -10,8 +10,7 @@ If running the ipython shell, simply type '?' after any command for help.
 ipython also offers tab completion, so hitting tab after '<module name>.'
 will list all available functions, classes and variables.
 
-Detailed HTML documentation is available locally in the spacepy/doc directory
-and can be launched by typing:
+Detailed HTML documentation is available online by typing:
 
     >>> spacepy.help()
 
@@ -64,20 +63,18 @@ import re
 import shutil
 import sys
 import warnings
+import webbrowser
+
 
 def help():
-    """Launches web browser with local HTML help"""
-    
-    import webbrowser
-    fspec = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         'Doc', 'index.html')
-    if not os.path.exists(fspec):
-        fspec = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..',
-                             'Doc', 'build', 'html', 'index.html')
-    if os.path.exists(fspec):
-        webbrowser.open('file://' + fspec)
-    else:
-        print("Can't find help files in {0}".format(__path__[0]))
+    """Launches web browser with SpacePy documentation
+
+    Online help is always for the latest release of SpacePy.
+    """
+    print('Opening docs for latest release. Installed SpacePy is {}.'.format(
+        __version__))
+    webbrowser.open('https://spacepy.github.io/')
+
 
 # put modules here that you want to be accessible through 'from spacepy import *'
 __all__ = ["seapy", "toolbox", "poppy", "coordinates", "time", "omni", 


### PR DESCRIPTION
This PR removes the documentation which is installed with the library (in the `data` directory), simplifying the installer. `help()` is updated to load the website. Closes #597.

To help with version matching, `help()` prints the user's SpacePy version, and the version is included in the first heading on the main SpacePy docs page.

The release notes go into (probably too much) detail on how to find/download documentation.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
