### PR TITLE
Fix log-scaled spectrogram plot call for matplotlib >=3.5

### DIFF
--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -461,10 +461,10 @@ class Spectrogram(dm.SpaceData):
 
         if self.plotSettings['zlog']:
             pcm = ax.pcolormesh(self['spectrogram']['xedges'], self['spectrogram']['yedges'], np.asarray(bb),
-                                norm=LogNorm(), cmap=self.plotSettings['cmap'], vmin=self.plotSettings['zlim'][0],
-                                vmax=self.plotSettings['zlim'][1])
+                                norm=LogNorm(vmin=self.plotSettings['zlim'][0], vmax=self.plotSettings['zlim'][1]),
+                                cmap=self.plotSettings['cmap'])
         else:
-            pcm = ax.pcolormesh(self['spectrogram']['xedges'], self['spectrogram']['yedges'], np.asarray(bb), 
+            pcm = ax.pcolormesh(self['spectrogram']['xedges'], self['spectrogram']['yedges'], np.asarray(bb),
                                 cmap=self.plotSettings['cmap'], vmin=self.plotSettings['zlim'][0],
                                 vmax=self.plotSettings['zlim'][1])
 
@@ -580,7 +580,7 @@ def simpleSpectrogram(*args, **kwargs):
     zlog : bool
         Plot the color with a log colorbar (default: True)
     ylog : bool
-        Plot the Y axis with a log scale (default: True) 
+        Plot the Y axis with a log scale (default: True)
     alpha : scalar (0-1)
         The alpha blending value (default: None)
     cmap : string
@@ -595,7 +595,7 @@ def simpleSpectrogram(*args, **kwargs):
         Plot a colorbar (default: True)
     cbtitle : string
         Label to go on the colorbar (default: None)
-    
+
     Returns
     =======
     ax : matplotlib.axes._subplots.AxesSubplot
@@ -628,8 +628,8 @@ def simpleSpectrogram(*args, **kwargs):
                 for ii in range(Y.shape[0]):
                     Y_tmp[ii] = tb.bin_center_to_edges(Y[ii])
                 Y = Y_tmp
-                
-    # deal with all the default keywords 
+
+    # deal with all the default keywords
     zlog    = kwargs.pop('zlog', True)
     ylog    = kwargs.pop('ylog', True)
     alpha   = kwargs.pop('alpha', None)
@@ -639,7 +639,7 @@ def simpleSpectrogram(*args, **kwargs):
     ax      = kwargs.pop('ax', None)
     cb      = kwargs.pop('cb', True)
     cbtitle = kwargs.pop('cbtitle', None)
-    
+
     # the first case is that X, Y are 1d and Z is 2d, just make the plot
     if ax is None:
         fig = plt.figure()
@@ -664,7 +664,7 @@ def simpleSpectrogram(*args, **kwargs):
                            cmap=cmap,
                            alpha=alpha)
     if ylog: ax.set_yscale('log')
-    
+
     if cb: # add a colorbar
         cb_ = fig.colorbar(pc)
         if cbtitle is not None:


### PR DESCRIPTION
The `plot` method in `spacepy.plot.Spectrogram` defaults to log-scaling the colormap. However, it's using syntax that's no longer allowable by passing `vmin` and `vmax` to `pcolormesh` separate from the `LogNorm` normalizer. From matplotlib 3.3 this issued a warning. From matplotlib 3.5 is raises an error.

This fixes the issue by moving the colormap limits inside the `LogNorm` instance (as is already done in, e.g., `simpleSpectrogram`.

Closes #610 

Spectrogram does need some attention paid to the internals, and there's an issue that needs to be filed to ensure that `add_data` works when the times are specified as datetime objects. However, those are bigger efforts that don't hit a breaking change...

## PR Checklist
- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [N/A] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
