### PR TITLE
Fix pcolormesh-based plotting methods in pybats.ram

### DIFF
--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -818,7 +818,7 @@ class RamSat(SpaceData):
         # print("Need better energy grid setup for pcolormesh.")
         flx = ax.pcolormesh(time, eboundary,
                             np.asarray(self[nameflux]).transpose(),
-                            norm=LogNorm(), vmin=zlim[0], vmax=zlim[1])
+                            norm=LogNorm(vmin=zlim[0], vmax=zlim[1]))
         ax.set_yscale('log')
         ax.set_ylim([eboundary[0], eboundary[-1]])
         if not timelim:
@@ -1511,8 +1511,9 @@ class BoundaryFluxFile(object):
         egrid = np.array(range(self.nE))
         flux = self.flux.transpose()
         flux[flux<0.01] = 0.01
-        flx = ax.pcolor(self.LT, egrid, flux, norm=LogNorm(), vmin=zlim[0],
-                        vmax=zlim[-1], cmap=plt.get_cmap('inferno'))
+        flx = ax.pcolor(self.LT, egrid, flux,
+                        norm=LogNorm(vmin=zlim[0], vmax=zlim[-1]),
+                        cmap=plt.get_cmap('inferno'))
         cbar = plt.colorbar(flx, pad=0.01, shrink=0.85, ticks=LogLocator(),
                             format=LogFormatterMathtext())
         cbar.set_label('$cm^{-2}s^{-1}ster^{-1}keV^{-1}$')
@@ -2126,8 +2127,8 @@ class GeoMltFile(object):
         lgrid = np.array(range(len(self.lgrid)+1))
         flux = self.flux[epoch,:,:].transpose()
         flux[flux<0.01] = 0.01
-        flx = ax.pcolormesh(lgrid, egrid, flux, norm=LogNorm(),
-                            vmin=0.01, vmax=1e10,
+        flx = ax.pcolormesh(lgrid, egrid, flux,
+                            norm=LogNorm(vmin=0.01, vmax=1e10),
                             cmap=plt.get_cmap('inferno'))
         cbar = plt.colorbar(flx, pad=0.01, shrink=0.85, ticks=LogLocator(),
                             format=LogFormatterMathtext())


### PR DESCRIPTION
Several plot methods in `spacepy.pybats.ram` using syntax that's no longer allowable, passing vmin and vmax to pcolormesh separate from the LogNorm normalizer. From matplotlib 3.3 this issued a warning. From matplotlib 3.5 is raises an error. See also #611.

No explicit testing was added, although I did test that the plot methods now work under matplotlib 3.5.1 by hand. LMK if there are specific tests I should be doing for this (e.g., make a plot w/o showing and just test whether it didn't raise an exception?)

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [N/A] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)