### PR TITLE
Add SPH as a synonym of GEO in SpacePy Coords

### DIFF
--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -118,7 +118,7 @@ SYSAXES_TYPES = {'GDZ': {'sph': 0, 'car': None},
                  'ECITOD': {'sph': None, 'car': 12}, 'J2000': {'sph': None, 'car': 13},
                  'ECI2000': {'sph': None, 'car': 13}, 'ECIMOD': {'sph': None, 'car': 14}}
 
-SYS_EQUIV = {'GEI': 'ECITOD', 'TOD': 'ECITOD', 'J2000': 'ECI2000', 'MAG': 'CDMAG'}
+SYS_EQUIV = {'SPH': 'GEO', 'GEI': 'ECITOD', 'TOD': 'ECITOD', 'J2000': 'ECI2000', 'MAG': 'CDMAG'}
 
 IRBEM_RE = 6371.2  # kilometers
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -194,6 +194,24 @@ class coordsTest(unittest.TestCase):
         """len of Coords should return number of 3-vectors"""
         self.assertEqual(len(self.cvals), 2)
 
+    def test_SPH_output_noconvert(self):
+        """SPH is a synonym of GEO in spherical"""
+        self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')
+        expected = spc.Coords([[2, 45, 90], [3.0, 31, 31]], 'GEO', 'sph', use_irbem=False)
+        got = expected.convert('SPH', 'sph')
+        np.testing.assert_allclose(got.data, expected.data)
+        np.testing.assert_equal(got.dtype, 'GEO')
+
+    def test_SPH_output_convert(self):
+        """SPH is a synonym of GEO in spherical"""
+        self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')
+        expected = spc.Coords([[2, 45, 90], [3.0, 31, 31]], 'GEO', 'sph', use_irbem=False)
+        expected.ticks = self.cvals.ticks
+        stage1 = expected.convert('GSE', 'car')
+        got = stage1.convert('SPH', 'sph')
+        np.testing.assert_allclose(got.data, expected.data)
+        np.testing.assert_equal(got.dtype, 'GEO')
+
     def test_roundtrip_GEO_ECIMOD(self):
         """Roundtrip [GEO->MOD->GEO] should yield input as answer"""
         self.cvals.ticks = Ticktock(['2002-02-02T12:00:00', '2002-02-02T12:00:00'], 'ISO')


### PR DESCRIPTION
SpacePy's coordinates backend in `ctrans` works exclusively in Cartesian (with special-case carveouts for geodetic). However, IRBEM includes spherical `GEO` as a separate system (`SPH`).

While `Coords` has long trapped incoming `SPH` and just set the dtype to `GEO`, conversion to `SPH` has not explicitly overidden the type.

This PR adds `SPH` to the dictionary of coordinate system synonyms as a synonym of GEO. It also adds tests to make sure that the SpacePy backend is treating SPH as a synonym and will not fail when converting to `SPH`.

Issue reported by @rebeccaringuette.

Example of failure:
```
In [11]: test1 = spc.Coords([2, 45, 90], 'SPH', 'sph', use_irbem=False)

In [12]: test1.ticks = spt.Ticktock.now()
/home/smorley/miniconda3/envs/default/lib/python3.8/site-packages/spacepy/time.py:1790: DeprecationWarning: now() returns UTC time as of 0.2.2.
  warnings.warn('now() returns UTC time as of 0.2.2.',

In [13]: test1.convert('GEO', 'car')
Out[13]: Coords( [[8.659560562354932e-17, 1.414213562373095, 1.4142135623730951]] , 'GEO', 'car')

In [14]: _.convert('SPH', 'sph')
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
~/miniconda3/envs/default/lib/python3.8/site-packages/spacepy/ctrans/__init__.py in convert(self, vec, sys_in, sys_out, defaults)
    757                     assert trans1 in self['Transform']
--> 758                     assert trans2 in self['Transform']
    759                     tmatr = self['Transform'][trans2].dot(self['Transform'][trans1])

AssertionError:

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-14-24ba97375d08> in <module>
----> 1 _.convert('SPH', 'sph')

~/miniconda3/envs/default/lib/python3.8/site-packages/spacepy/coordinates.py in convert(self, returntype, returncarsph)
    507                     # ellipsoid referenced system, input must be in km
    508                     data *= self.Re  # geodetic is defined in [km, deg, deg]
--> 509                 NewCoords.data = np.atleast_2d(ctrans.convert_multitime(data, self.ticks,
    510                                                                         self.dtype, returnname,
    511                                                                         DEFAULTS.values))

~/miniconda3/envs/default/lib/python3.8/site-packages/spacepy/ctrans/__init__.py in convert_multitime(coords, ticks, sys_in, sys_out, defaults, itol)
   1185     loopover = np.atleast_2d(coords)
   1186     if len(ctdict) == 1:
-> 1187         newcoords = ctdict[tais[0]].convert(loopover, sys_in, sys_out, defaults=defaults)
   1188     else:
   1189         newcoords = np.empty_like(loopover)

~/miniconda3/envs/default/lib/python3.8/site-packages/spacepy/ctrans/__init__.py in convert(self, vec, sys_in, sys_out, defaults)
    761                 except (KeyError, AssertionError):
    762                     # Can't construct the transform requested
--> 763                     self._raiseErr(ValueError, 'transform')
    764             else:
    765                 # Required transform stored already, just use it

~/miniconda3/envs/default/lib/python3.8/site-packages/spacepy/ctrans/__init__.py in _raiseErr(self, errtype, code)
    890             err = 'Operation not defined'
    891
--> 892         raise errtype('CTrans: {0}'.format(err))
    893
    894     def _kepler(self, mean_anom, ecc, tol=1e-8, maxiter=100):

ValueError: CTrans: Requested coordinate transform not defined.
```

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [N/A] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] New features and bug fixes should have unit tests
- [N/A] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)