### PR TITLE
datamodel to/fromHDF5 improvements (gzip scalars, unicode strings)

### DIFF
--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -697,6 +697,15 @@ class converterTests(unittest.TestCase):
         np.testing.assert_almost_equal(self.SDobj['var'], newobj['var'])
         self.assertEqual(self.SDobj['var'].attrs['a'], newobj['var'].attrs['a'])
 
+    def test_toHDF5gzipScalar(self):
+        """Convert to HDF5 with a scalar value, gzipped"""
+        a = dm.SpaceData({'dat': dm.dmarray(1),
+                          'str': dm.dmarray(b'foo')})
+        a.toHDF5(self.testfile, mode='a', compression='gzip')
+        newobj = dm.fromHDF5(self.testfile)
+        np.testing.assert_array_equal(1, newobj['dat'])
+        np.testing.assert_array_equal(b'foo', newobj['str'])
+
     def test_HDF5Exceptions(self):
         """HDF5 has warnings and exceptions"""
         dm.toHDF5(self.testfile, self.SDobj)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -706,6 +706,19 @@ class converterTests(unittest.TestCase):
         np.testing.assert_array_equal(1, newobj['dat'])
         np.testing.assert_array_equal(b'foo', newobj['str'])
 
+    def test_toHDF5String(self):
+        """Convert to HDF5 with (unicode) strings"""
+        # Can change to just strings when drop python 2
+        a = dm.SpaceData({'scalar': dm.dmarray(b'foo'.decode()),
+                          'dat': dm.dmarray([b'foo'.decode(), b'bar'.decode()])
+        })
+        a.toHDF5(self.testfile, mode='a')
+        newobj = dm.fromHDF5(self.testfile)
+        self.assertEqual('U', newobj['dat'].dtype.kind)
+        self.assertEqual('U', newobj['scalar'].dtype.kind)
+        np.testing.assert_array_equal(a['dat'], newobj['dat'])
+        np.testing.assert_array_equal(a['scalar'], newobj['scalar'])
+
     def test_HDF5Exceptions(self):
         """HDF5 has warnings and exceptions"""
         dm.toHDF5(self.testfile, self.SDobj)


### PR DESCRIPTION
This PR makes three changes to the `toHDF5` and `fronHDF5` functions in `datamodel`:

1. Does not attempt to compress scalar variables if compression is requested. Previously, the entire toHDF5 function would fail if a single element of the `SpaceData` were scalar.
2. Supports writing Unicode arrays, i.e. Python 3 strings, and also reading them as such.
3. Some light refactoring/cleanup. Mostly this is consolidating lines but I also changed the `import h5py as hdf` to just `import h5py`...it doesn't look like the renaming is a convention anywhere else, and it confused the heck out of me.

The Unicode writing is a bit messy, but it maintains the fallback to "just try it as a 35-element array of bytes" and passes all the tests...this code is somewhat messy anyhow, alas. Another wrinkle is that Unicode variables are inherently variable-length in HDF5, whereas numpy has fixed-length Unicode string arrays (U) or can permit variable-length by using object arrays. This code will, on read, always convert to a fixed-length Unicode string array (which will be as long as the longest string).

All this conversion isn't great from a performance perspective, but it's a function of Python, and thus numpy, using UCS-2 or USC-4, whereas HDF5 uses UTF-8.

The new tests demonstrate what failed before.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

I didn't add anything to the release notes, because this felt like very inside baseball. I did note the change to the compress argument. I didn't see an obvious place to note the Unicode array writing; maybe that one does belong in release notes?