### PR TITLE
Small updates to ctrans and time docs: fix GCRF and GPS references

### DIFF
--- a/spacepy/ctrans/__init__.py
+++ b/spacepy/ctrans/__init__.py
@@ -15,14 +15,14 @@ by two categories. The first category is a broad set of Earth-centered
 coordinate systems that are specified by astronomical parameters.
 If we consider the International Celestial Reference Frame to be our
 starting point, then taking the origin as the center of the Earth
-instead of the solar barycenter gives us the International Terrestrial
-Reference Frame (ITRF). All coordinate systems described here are
+instead of the solar barycenter gives us the Geocentric Celestial
+Reference Frame (GCRF). All coordinate systems described here are
 right-handed Cartesian systems, except geodetic.
 
 Systems and their relationships:
 
 - ECI2000: Earth-Centered Inertial, J2000 epoch
-    This system can be considered equivalent to the ITRF, to within 10s
+    This system can be considered equivalent to the GCRF, to within 10s
     of milliarcseconds. The z-axis is aligned with the mean celestial pole
     at the J2000 epoch. The x-axis is aligned with the mean equinox at the
     J2000 epoch. The y-axis completes and lies in the plane of the

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -193,7 +193,7 @@ class Ticktock(MutableSequence):
     Ticktock( data, dtype )
 
     Ticktock class holding various time coordinate systems
-    (TAI, UTC, ISO, JD, MJD, UNX, RDT, CDF, DOY, eDOY, APT)
+    (TAI, UTC, ISO, JD, MJD, GPS, UNX, RDT, CDF, DOY, eDOY, APT)
 
     Possible input data types:
 
@@ -203,6 +203,8 @@ class Ticktock(MutableSequence):
         datetime object with UTC time
     TAI
         Elapsed seconds since 1958-1-1 (includes leap seconds)
+    GPS
+        Elapsed seconds since 1980-1-6 (includes leap seconds)
     UNX
         Elapsed seconds since 1970-1-1 ignoring leapseconds (all days have
         86400 secs).
@@ -260,7 +262,7 @@ class Ticktock(MutableSequence):
     ==========
     data : array_like (int, datetime, float, string)
         time stamp
-    dtype : string {`CDF`, `ISO`, `UTC`, `TAI`, `UNX`, `JD`, `MJD`, `RDT`, `APT`} or function
+    dtype : string {`CDF`, `ISO`, `UTC`, `TAI`, 'GPS', `UNX`, `JD`, `MJD`, `RDT`, `APT`} or function
         data type for data, if a function it must convert input time format to Python datetime
 
     Returns


### PR DESCRIPTION
This PR provides two small documentation updates.

The first replaces the erroneous reference to the ITRF (International Terrestrial Reference Frame) with the intended reference to GCRF (Geocentric Celestial Reference Frame). This closes #626.

The second adds GPS to the docstring for `spacepy.time.Ticktock` as it was previously not included in the list of valid input systems. This closes #625.

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [N/A] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

