### PR TITLE
Support VarBundle input from SpaceData objects

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -27,7 +27,7 @@ temporary removal of support for this module in SpacePy 0.3.0 has therefore
 been lifted. The new implementation provides a slight performance increase
 with no change in results or accuracy.
 
-:class:`~spacepy.pycdf.istp.VarBundle` now supports output to
+:class:`~spacepy.pycdf.istp.VarBundle` now supports output to and input from
 :class:`~spacepy.datamodel.SpaceData` objects as well as
 :class:`~spacepy.pycdf.CDF`.
 

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1175,13 +1175,23 @@ class VarBundle(object):
     chaining operations, or to load just the relevant data from a CDF
     into a :class:`~spacepy.datamodel.SpaceData`.
 
+    ``VarBundle`` operates on a single variable within a file and
+    its various dependencies, uncertainties, labels, etc. That variable
+    can be specified one of two ways. A :class:`~spacepy.pycdf.Var`
+    can be passed as the only parameter, which implicitly defines
+    the input file (the CDF containing that variable). Or, the file
+    can be passed as the first parameter, and the name of a variable
+    within it as the second variable.
+
     Unusual or indecipherable error messages may indicate an ISTP
     compliance issue; see :class:`VariableChecks` for some checks.
 
     Parameters
     ----------
-    var : :class:`~spacepy.pycdf.Var`
-        Variable to process
+    source : :class:`~spacepy.pycdf.CDF` or :class:`~spacepy.pycdf.Var`
+        CDF containing the variable to process, or the variable itself.
+    name : :class:`str`
+        Name of the variable within ``source`` to process ("main variable").
 
     See Also
     --------
@@ -1207,6 +1217,7 @@ class VarBundle(object):
     ...
     >
     >>> b = spacepy.pycdf.istp.VarBundle(infile['FPDU'])
+    >>> b = spacepy.pycdf.istp.VarBundle(infile, 'FPDU')  # Equivalent
     >>> outfile = spacepy.pycdf.CDF('output.cdf', create=True)
     >>> b.slice(1, 2, single=True).output(outfile)
     <VarBundle:
@@ -1253,17 +1264,19 @@ class VarBundle(object):
 
     """
 
-    def __init__(self, var):
+    def __init__(self, source, name=None):
         """Initialize variable bundle
 
         Parameters
         ----------
-        var : :class:`~spacepy.pycdf.Var`
-            Variable to process
+        source : :class:`~spacepy.pycdf.CDF` or :class:`~spacepy.pycdf.Var`
+            CDF containing the variable to process, or the variable itself.
+        name : :class:`str`
+            Name of the variable within ``source`` to process ("main variable").
         """
-        self.mainvar = var
+        self.mainvar = source if name is None else source[name]
         """The variable to operate on."""
-        self.cdf = self.mainvar.cdf_file
+        self.cdf = self.mainvar.cdf_file if name is None else source
         """Input CDF file containing the main variable."""
         self._varinfo = {}
         """Keyed by variable name. Values are also dicts, keys are

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -2,7 +2,7 @@
 
 """Support for ISTP-compliant CDFs
 
-The `ISTP metadata standard  <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+The `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
 specifies the interpretation of the attributes in a CDF to describe
 relationships between the variables and their physical interpretation.
 
@@ -1197,6 +1197,19 @@ class VarBundle(object):
     --------
     .datamodel.fromCDF
     .pycdf.CDF.copy
+
+    Notes
+    -----
+    If using :class:`~.datamodel.SpaceData` input, the contents are
+    assumed to be `ISTP compliant
+    <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_. In particular,
+    the following attributes of the enclosed
+    :class:`~.datamodel.dmarray` are used (*italics* denotes required):
+
+        * *DEPEND_0*, *DEPEND_1*, etc.
+        * LABL_PTR_0, LABL_PTR_1, etc.
+        * DELTA_PLUS_VAR, DELTA_MINUS_VAR
+        * VALIDMIN, VALIDMAX, *FILLVAL*
 
     Examples
     --------

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -372,17 +372,10 @@ class VariableChecks(object):
         timetype = v.type() in spacepy.pycdf.lib.timetypes
         actual = (v.cdf_file.raw_var(v.name()) if timetype else v)\
                  .attrs['FILLVAL']
-        # isclose added in numpy 1.7, so fix this when go to 0.3.0
-        if hasattr(numpy, 'isclose'):
-            match = numpy.isclose(
-                actual, expected, atol=0, rtol=1e-7)\
-                if numpy.issubdtype(v.dtype, numpy.floating)\
-                else numpy.all(actual == expected)
-        else:
-            if numpy.issubdtype(v.dtype, numpy.floating):
-                match = (abs(actual - expected) / expected < 1e-7)
-            else:
-                match = numpy.all(actual == expected)
+        match = numpy.isclose(
+            actual, expected, atol=0, rtol=1e-7)\
+            if numpy.issubdtype(v.dtype, numpy.floating)\
+            else numpy.all(actual == expected)
         if not match:
             if timetype:
                 converted_expected = {

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -1170,11 +1170,11 @@ class VarBundle(object):
 
     ``VarBundle`` operates on a single variable within a file or SpaceData
     and its various dependencies, uncertainties, labels, etc. That variable
-    can be specified one of two ways. A :class:`~spacepy.pycdf.Var`
-    can be passed as the only parameter, which implicitly defines
-    the input file (the CDF containing that variable). Or, the file or
+    can be specified one of two ways. An open CDF file or
     SpaceData can be passed as the first parameter, and the name of a
-    variable within it as the second parameter.
+    variable within it as the second parameter. Or, for CDF files, a
+    :class:`~.pycdf.Var` can be passed as the only parameter, implicitly
+    defining the input file (the CDF containing that variable).
 
     Unusual or indecipherable error messages may indicate an ISTP
     compliance issue; see :class:`VariableChecks` for some checks.
@@ -1182,7 +1182,7 @@ class VarBundle(object):
     Parameters
     ----------
     source : :class:`~.pycdf.CDF`, :class:`~.datamodel.SpaceData`, or :class:`~.pycdf.Var`
-        SpaceData or open CDF containing the variable to process, or the variable itself.
+        SpaceData or open CDF containing the variable to process, or the CDF variable itself.
     name : :class:`str`
         Name of the variable within ``source`` to process ("main variable").
 
@@ -1280,6 +1280,9 @@ class VarBundle(object):
         name : :class:`str`
             Name of the variable within ``source`` to process ("main variable").
         """
+        if name is None and not hasattr(source, 'cdf_file'):
+            raise TypeError('Single-argument form must be a variable'
+                ' in an open CDF, not {}.'.format(type(source).__name__))
         self.mainvar = source if name is None else source[name]
         """The variable to operate on."""
         self.cdf = self.mainvar.cdf_file if name is None else source

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -915,6 +915,28 @@ class VarBundleChecks(VarBundleChecksBase):
                 dimension, bundle._varinfo[varname].get('thisdim', None),
                 varname)
 
+    def testNameSeparate(self):
+        """Specify source and variable name separately"""
+        bundle = spacepy.pycdf.istp.VarBundle(
+            self.indata, 'SectorRateScalersCounts')
+        self.assertEqual(
+            [
+                'ATC',
+                'SectorNumbers',
+                'SectorRateScalerNames',
+                'SectorRateScalersCounts',
+                'SectorRateScalersCountsSigma',
+                'SpinNumbers',
+            ],
+            sorted(bundle._varinfo.keys()))
+        self.assertEqual(bundle.mainvar.name(),
+                         self.indata['SectorRateScalersCounts'].name())
+        self.assertIs(bundle.cdf, self.indata)
+        self.assertEqual(
+            [0], bundle._varinfo['ATC']['dims'])
+        self.assertEqual(
+            [slice(None)], bundle._varinfo['ATC']['slice'])
+
     def testSliceRecordStr(self):
         """Slice away record dimension and get str"""
         bundle = spacepy.pycdf.istp.VarBundle(

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -865,7 +865,7 @@ class VarBundleChecks(VarBundleChecksBase):
     def testGetVarInfo(self):
         """Get dependencies, dims, etc. for a variable"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         self.assertEqual(
             [
                 'ATC',
@@ -915,10 +915,10 @@ class VarBundleChecks(VarBundleChecksBase):
                 dimension, bundle._varinfo[varname].get('thisdim', None),
                 varname)
 
-    def testNameSeparate(self):
-        """Specify source and variable name separately"""
+    def testVar(self):
+        """Specify source as a Var object"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata, 'SectorRateScalersCounts')
+            self.indata['SectorRateScalersCounts'])
         self.assertEqual(
             [
                 'ATC',
@@ -940,7 +940,7 @@ class VarBundleChecks(VarBundleChecksBase):
     def testSliceRecordStr(self):
         """Slice away record dimension and get str"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(0, 2, 20).mean(0)
         expected = """
         SectorRateScalersCounts: CDF_FLOAT [18, 32, 9] NRV
@@ -956,7 +956,7 @@ class VarBundleChecks(VarBundleChecksBase):
     def testCAMMICESortOrder(self):
         """More tests of sort order"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         for varname, sortorder in {
                 'SectorRateScalersCounts': 0,
                 'SectorRateScalersCountsSigma': 2,
@@ -973,7 +973,7 @@ class VarBundleChecks(VarBundleChecksBase):
         """Test name mapping"""
         #Essentially a subtest of testSumRename
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.sum(2)
         namemap = bundle._namemap(suffix="_Summed")
         expected = { n: n + '_Summed' for n in [
@@ -990,7 +990,7 @@ class VarBundleChecks(VarBundleChecksBase):
     def testToSpaceData(self):
         """Output to new SpaceData"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         data = bundle.toSpaceData()
         numpy.testing.assert_array_equal(
             data['SectorRateScalersCounts'][...],
@@ -1007,7 +1007,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testOutputSimple(self):
         """Copy single var and deps with no slicing to output"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.output(self.output)
         numpy.testing.assert_array_equal(
             self.output['SectorRateScalersCounts'][...],
@@ -1025,11 +1025,11 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testNonconflictingMultiple(self):
         """Output multiple variables without conflict"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.sum(1) #Sum over spin
         bundle.output(self.output)
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SpinRateScalersCounts'])
+            self.indata, 'SpinRateScalersCounts')
         #This has some overlapping deps, but they're all the same
         bundle.output(self.output)
         self.assertTrue('SpinNumbers' in self.output)
@@ -1053,11 +1053,11 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testConflictingMultiple(self):
         """Output multiple variables with conflict"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(1, 0, 3)
         bundle.output(self.output)
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SpinRateScalersCounts'])
+            self.indata, 'SpinRateScalersCounts')
         bundle.slice(1, 2, 5)
         #This is a different slice on same dim, should fail
         msg = 'Incompatible SpinNumbers already exists in output.'
@@ -1071,7 +1071,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSimpleSlice(self):
         """Slice single element on single dimension"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(1, 2, single=True)
         bundle.output(self.output)
         numpy.testing.assert_array_equal(
@@ -1096,7 +1096,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSimpleRange(self):
         """Slice a range on single dimension"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(1, 2, single=False)
         bundle.output(self.output)
         numpy.testing.assert_array_equal(
@@ -1117,7 +1117,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSliceUndo(self):
         """Slice single element on single dimension, then undo"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(1, 2, single=True).slice(1)
         bundle.output(self.output)
         numpy.testing.assert_array_equal(
@@ -1138,7 +1138,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSliceRecord(self):
         """Slice on the record dimension"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(0, 2, 20)
         bundle.output(self.output)
         numpy.testing.assert_array_equal(
@@ -1159,7 +1159,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSliceMultiIDX(self):
         """Slice multiple indices"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(1, [2, 3, 5])
         with spacepy_testing.assertDoesntWarn(
                 self, 'always',
@@ -1184,7 +1184,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSliceMultiIDXrecord(self):
         """Slice on the record dimension, multiple index"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(0, [2, 3, 5])
         bundle.output(self.output)
         numpy.testing.assert_array_equal(
@@ -1205,7 +1205,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSum(self):
         """Sum over a dimension"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.sum(2)
         self.assertEqual([False, False, True, False], bundle._summed)
         bundle.output(self.output)
@@ -1240,7 +1240,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSliceSum(self):
         """Slice and sum over a dimension"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(1, 0, 16).sum(1)
         self.assertEqual([False, True, False, False], bundle._summed)
         bundle.output(self.output)
@@ -1272,7 +1272,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testMean(self):
         """Average over a dimension"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.mean(2)
         self.assertEqual([False, False, False, False], bundle._summed)
         self.assertEqual([False, False, True, False], bundle._mean)
@@ -1314,7 +1314,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSumRename(self):
         """Sum over a dimension, rename output"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.sum(2)
         bundle.output(self.output, suffix='_Summed')
         counts = self.indata['SectorRateScalersCounts'][...]
@@ -1348,7 +1348,7 @@ class VarBundleOutputCDF(VarBundleChecksBase):
     def testSumRenameConflict(self):
         """Sum over a dimension, rename output, with a potential conflict"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['SectorRateScalersCounts'])
+            self.indata, 'SectorRateScalersCounts')
         bundle.slice(2, 0, 2)
         bundle.output(self.output, suffix='_0-1')
         bundle.slice(2, 2, 4)
@@ -1407,7 +1407,7 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
     def testSortOrder(self):
         """Check sort order of variables"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['Counts_P'])
+            self.indata, 'Counts_P')
         for varname, sortorder in {
                 'Counts_P': 0,
                 'Epoch_Ion': 1,
@@ -1424,7 +1424,7 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
 
     def testOperations(self):
         """Get operations of a bundle"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['Counts_P'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'Counts_P')
         bundle.slice(1, 1, single=True).slice(2, 0, 10).mean(2)
         ops = bundle.operations()
         self.assertEqual(
@@ -1433,14 +1433,14 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
              ('mean', (2,), {})],
             ops)
         #Check fancy index
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['Counts_P'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'Counts_P')
         bundle.slice(1, [5, 6])
         ops = bundle.operations()
         self.assertEqual([('slice', (1, [5, 6]), {})], ops)
 
     def testVars(self):
         """Get variables of a bundle"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['FPDU'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'FPDU')
         bundle.slice(1, 1, single=True).slice(2, 0, 10)
         variables = bundle.variables()
         self.assertEqual([
@@ -1453,7 +1453,7 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
 
     def testStrRepr(self):
         """Get string representation of bundle"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['FPDU'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'FPDU')
         bundle.slice(1, 1, single=True).slice(2, 0, 10)
         expected = """
         FPDU: CDF_FLOAT [100, 10]
@@ -1473,7 +1473,7 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
 
     def testOutshape(self):
         """Get the output shape of variables"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['FPDU'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'FPDU')
         bundle.slice(1, 1, single=True).slice(2, 0, 10)
         expected = {
             'FPDU': (100, 10),
@@ -1511,7 +1511,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
     def testDepWithDelta(self):
         """Properly handle a dependency with a delta"""
         bundle = spacepy.pycdf.istp.VarBundle(
-            self.indata['Counts_P'])
+            self.indata, 'Counts_P')
         self.assertEqual('M', bundle._varinfo['Counts_P']['vartype'])
         self.assertEqual('D', bundle._varinfo['ENERGY_Ion_DELTA']['vartype'])
         bundle.slice(2, 0, 10).mean(2).output(self.output)
@@ -1524,7 +1524,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
 
     def testSumRecord(self):
         """Sum on the record dimension"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['Counts_P'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'Counts_P')
         bundle.sum(0).output(self.output)
         expected = numpy.sum(self.indata['Counts_P'][...], axis=0)
         numpy.testing.assert_array_equal(
@@ -1537,7 +1537,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
 
     def testAvgRecord(self):
         """Average on the record dimension"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['Counts_P'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'Counts_P')
         bundle.mean(0).output(self.output)
         expected = numpy.mean(self.indata['Counts_P'][...], axis=0)
         numpy.testing.assert_array_equal(
@@ -1550,7 +1550,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
 
     def testSliceSingleRecord(self):
         """Slice single element on the record dimension"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['Counts_P'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'Counts_P')
         bundle.slice(0, 0, single=True).output(self.output)
         expected = self.indata['Counts_P'][0, ...]
         numpy.testing.assert_array_equal(
@@ -1577,7 +1577,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
             newdelta.rename('Epoch_Ion_DELTA')
         self.incdf = spacepy.pycdf.CDF(newtest)
         self.indata = self.incdf
-        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['FPDU'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf, 'FPDU')
         bundle.slice(0, 0, 10).output(self.output)
         numpy.testing.assert_array_equal(
             self.output['FPDU'][...], self.incdf['FPDU'][0:10, ...])
@@ -1597,7 +1597,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
             del cdf['FPDU'][...] #Delete data not variable
         self.incdf = spacepy.pycdf.CDF(newtest)
         self.indata = self.incdf
-        bundle = spacepy.pycdf.istp.VarBundle(self.incdf['FPDU'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.incdf, 'FPDU')
         bundle.sum(1).slice(2, 0, 6).output(self.output)
         self.assertEqual(
             (0, 6), self.output['FPDU'].shape)
@@ -1633,12 +1633,11 @@ class VarBundleChecksEPILoCDF(VarBundleChecksBase):
 
     def testDoubleDep(self):
         """Handle a variable with a 2D depend"""
-        countrate = self.indata['H_CountRate_ChanT']
-        bundle = spacepy.pycdf.istp.VarBundle(countrate)
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'H_CountRate_ChanT')
         bundle.sum(1).slice(2, 0, 10).output(self.output)
         numpy.testing.assert_array_equal(
             self.output['H_CountRate_ChanT'],
-            countrate[:, :, 0:10].sum(axis=1))
+            self.indata['H_CountRate_ChanT'][:, :, 0:10].sum(axis=1))
         #Look direction should go away
         for v in ('Look_80_LABL', 'Look_Direction_80',
                   'Look_Direction_80_DELTAMINUS',
@@ -1647,12 +1646,12 @@ class VarBundleChecksEPILoCDF(VarBundleChecksBase):
 
     def testDoubleDepSummed(self):
         """Handle a variable with a 2D depend, sum all dims"""
-        countrate = self.indata['H_CountRate_ChanT']
-        bundle = spacepy.pycdf.istp.VarBundle(countrate)
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'H_CountRate_ChanT')
         bundle.sum(1).slice(2, 0, 10).sum(2).output(self.output, '_TS')
         numpy.testing.assert_array_equal(
             self.output['H_CountRate_ChanT_TS'],
-            countrate[:, :, 0:10].sum(axis=2).sum(axis=1))
+            self.indata['H_CountRate_ChanT'][:, :, 0:10].sum(axis=2)\
+            .sum(axis=1))
         #Look direction and energy should go away
         for v in ('Look_80_LABL', 'Look_Direction_80',
                   'Look_Direction_80_DELTAMINUS',
@@ -1664,7 +1663,7 @@ class VarBundleChecksEPILoCDF(VarBundleChecksBase):
 
     def testConflictingEpoch(self):
         """Regression test for complicated name conflict"""
-        bundle = spacepy.pycdf.istp.VarBundle(self.indata['H_CountRate_ChanT'])
+        bundle = spacepy.pycdf.istp.VarBundle(self.indata, 'H_CountRate_ChanT')
         bundle.sum(1).slice(2, 1).output(self.output, suffix='_SP')
         #Still summed on 1!
         bundle.slice(2, 18, 32).sum(2).output(self.output, suffix='_TS')

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -858,7 +858,7 @@ class VarBundleChecksBase(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
 
-class VarBundleChecks(VarBundleChecksBase):
+class VarBundleChecksCDFIn(VarBundleChecksBase):
     """Checks for VarBundle class, CAMMICE sample file"""
     testfile = 'po_l1_cam_test.cdf'
 
@@ -1005,19 +1005,19 @@ class VarBundleChecks(VarBundleChecksBase):
             self.indata['SectorRateScalersCounts'][...])
 
 
-class VarBundleChecksInputSD(VarBundleChecks):
+class VarBundleChecksSDIn(VarBundleChecksCDFIn):
     """Checks for VarBundle, SpaceData input"""
 
     def setUp(self):
-        super(VarBundleChecksInputSD, self).setUp()
+        super(VarBundleChecksSDIn, self).setUp()
         self.indata = self.incdf.copy()
 
 
-class VarBundleOutputCDF(VarBundleChecksBase):
+class VarBundleCDFInCDFOut(VarBundleChecksBase):
     """Checks for VarBundle class, output to CDF"""
 
     def setUp(self):
-        super(VarBundleOutputCDF, self).setUp()
+        super(VarBundleCDFInCDFOut, self).setUp()
         self.output = self.outcdf
 
     def testOutputSimple(self):
@@ -1407,31 +1407,31 @@ class VarBundleOutputCDF(VarBundleChecksBase):
             self.output['SectorNumbers_2-3'].attrs['FIELDNAM'])
 
 
-class VarBundleInputSDOutputCDF(VarBundleOutputCDF):
+class VarBundleSDInCDFOut(VarBundleCDFInCDFOut):
     """Checks for VarBundle class, in from SpaceData, output to CDF"""
 
     def setUp(self):
-        super(VarBundleInputSDOutputCDF, self).setUp()
+        super(VarBundleSDInCDFOut, self).setUp()
         self.indata = self.incdf
 
 
-class VarBundleOutputSpaceData(VarBundleOutputCDF):
+class VarBundleCDFInSDOut(VarBundleCDFInCDFOut):
     """Checks for VarBundle, output to SpaceData"""
 
     def setUp(self):
-        super(VarBundleOutputSpaceData, self).setUp()
+        super(VarBundleCDFInSDOut, self).setUp()
         self.output = spacepy.SpaceData()
 
 
-class VarBundleInputSDOutputSD(VarBundleOutputSpaceData):
+class VarBundleSDInSDOut(VarBundleCDFInSDOut):
     """Checks for VarBundle class, in/out SpaceData"""
 
     def setUp(self):
-        super(VarBundleInputSDOutputSD, self).setUp()
+        super(VarBundleSDInSDOut, self).setUp()
         self.indata = self.incdf
 
 
-class VarBundleChecksHOPE(VarBundleChecksBase):
+class VarBundleHOPECDFIn(VarBundleChecksBase):
     """Checks for VarBundle class, HOPE sample file"""
     testfile = os.path.join('data',
                             'rbspa_rel04_ect-hope-PA-L3_20121201_v0.0.0.cdf')
@@ -1527,21 +1527,21 @@ class VarBundleChecksHOPE(VarBundleChecksBase):
                 shape, bundle._outshape(vname), vname)
 
 
-class VarBundleChecksHOPEInputSD(VarBundleChecksHOPE):
+class VarBundleHOPESDIn(VarBundleHOPECDFIn):
     """Checks for VarBundle class, in from HOPE SpaceData, no output"""
 
     def setUp(self):
-        super(VarBundleChecksHOPEInputSD, self).setUp()
+        super(VarBundleHOPESDIn, self).setUp()
         self.indata = self.incdf.copy()
 
 
-class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
+class VarBundleHOPECDFInCDFOut(VarBundleChecksBase):
     """Checks for VarBundle class, HOPE sample file, out to CDF"""
     testfile = os.path.join('data',
                             'rbspa_rel04_ect-hope-PA-L3_20121201_v0.0.0.cdf')
 
     def setUp(self):
-        super(VarBundleChecksHOPECDFOutput, self).setUp()
+        super(VarBundleHOPECDFInCDFOut, self).setUp()
         self.output = self.outcdf
 
     def tearDown(self):
@@ -1551,7 +1551,7 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
             category=spacepy.pycdf.CDFWarning,
             module='^spacepy.pycdf')
         try:
-            super(VarBundleChecksHOPECDFOutput, self).tearDown()
+            super(VarBundleHOPECDFInCDFOut, self).tearDown()
         finally:
             del warnings.filters[0]
 
@@ -1653,37 +1653,37 @@ class VarBundleChecksHOPECDFOutput(VarBundleChecksBase):
             (0, 6), self.output['FPDU'].shape)
 
 
-class VarBundleChecksHOPEInputSDOutputCDF(VarBundleChecksHOPECDFOutput):
+class VarBundleHOPESDInCDFOut(VarBundleHOPECDFInCDFOut):
     """Checks for VarBundle class, in from HOPE SpaceData, output to CDF"""
 
     def setUp(self):
-        super(VarBundleChecksHOPEInputSDOutputCDF, self).setUp()
+        super(VarBundleHOPESDInCDFOut, self).setUp()
         self.indata = self.incdf.copy()
 
 
-class VarBundleChecksHOPESpaceDataOutput(VarBundleChecksHOPECDFOutput):
+class VarBundleHOPECDFInSDOut(VarBundleHOPECDFInCDFOut):
     """Checks for VarBundle class, HOPE sample file, out to SpaceData"""
 
     def setUp(self):
-        super(VarBundleChecksHOPESpaceDataOutput, self).setUp()
+        super(VarBundleHOPECDFInSDOut, self).setUp()
         self.output = spacepy.SpaceData()
 
 
-class VarBundleChecksHOPEInputSDOutputSD(VarBundleChecksHOPESpaceDataOutput):
+class VarBundleHOPESDInSDOut(VarBundleHOPECDFInSDOut):
     """Checks for VarBundle class, HOPE sample file, in/out SpaceData"""
 
     def setUp(self):
-        super(VarBundleChecksHOPEInputSDOutputSD, self).setUp()
+        super(VarBundleHOPESDInSDOut, self).setUp()
         self.indata = self.incdf.copy()
 
 
-class VarBundleChecksEPILoCDF(VarBundleChecksBase):
+class VarBundleEPILoCDFInCDFOut(VarBundleChecksBase):
     """Checks for VarBundle class, EPILo sample file, CDF output"""
     testfile = os.path.join('data',
                             'psp_isois-epilo_l2-ic_20190401_v0.0.0.cdf')
 
     def setUp(self):
-        super(VarBundleChecksEPILoCDF, self).setUp()
+        super(VarBundleEPILoCDFInCDFOut, self).setUp()
         self.output = self.outcdf
 
     def tearDown(self):
@@ -1693,7 +1693,7 @@ class VarBundleChecksEPILoCDF(VarBundleChecksBase):
             category=spacepy.pycdf.CDFWarning,
             module='^spacepy.pycdf')
         try:
-            super(VarBundleChecksEPILoCDF, self).tearDown()
+            super(VarBundleEPILoCDFInCDFOut, self).tearDown()
         finally:
             del warnings.filters[0]
 
@@ -1737,27 +1737,27 @@ class VarBundleChecksEPILoCDF(VarBundleChecksBase):
         self.assertIn('H_CountRate_ChanT_TS', self.output)
 
 
-class VarBundleEPILoSpaceData(VarBundleChecksEPILoCDF):
+class VarBundleEPILoCDFInSDOut(VarBundleEPILoCDFInCDFOut):
     """Checks for VarBundle class, EPI-Lo sample file, out to SpaceData"""
 
     def setUp(self):
-        super(VarBundleEPILoSpaceData, self).setUp()
+        super(VarBundleEPILoCDFInSDOut, self).setUp()
         self.output = spacepy.SpaceData()
 
 
-class VarBundleEPILoInputSDOutputCDF(VarBundleChecksEPILoCDF):
+class VarBundleEPILoSDInCDFOut(VarBundleEPILoCDFInCDFOut):
     """Checks for VarBundle class, EPI-Lo sample file, in from SpaceData"""
 
     def setUp(self):
-        super(VarBundleEPILoInputSDOutputCDF, self).setUp()
+        super(VarBundleEPILoSDInCDFOut, self).setUp()
         self.indata = self.incdf.copy()
 
 
-class VarBundleEPILoInputSDOutputSD(VarBundleEPILoSpaceData):
+class VarBundleEPILoSDInSDOut(VarBundleEPILoCDFInSDOut):
     """Checks for VarBundle class, EPI-Lo sample file, in/out SpaceData"""
 
     def setUp(self):
-        super(VarBundleEPILoInputSDOutputSD, self).setUp()
+        super(VarBundleEPILoSDInSDOut, self).setUp()
         self.indata = self.incdf.copy()
 
 


### PR DESCRIPTION
This PR supports VarBundle operations on SpaceData objects (it's the complement of #624). There's still a bit of CDF-specific sugar where using CDF inputs or outputs, but from the user's perspective a CDF with ISTP metadata and a SpaceData with ISTP metadata will be treated basically the same. Over time I expect to move the ISTP stuff into datamodel and make this all a lot smoother...this is a baby step.

I also pulled out some numpy 1.6 code while I was at it.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
