### PR TITLE
Set rST default role to Python object

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -100,7 +100,7 @@ release = '0.4.0pre'
 exclude_patterns = ['_templates']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True

--- a/spacepy/igrf.py
+++ b/spacepy/igrf.py
@@ -125,11 +125,11 @@ class IGRF():
 
     .. attribute:: dipole
 
-        Characteristics of dipole (:class:`dict`).
+        Characteristics of dipole (`dict`).
 
     .. attribute:: moment
 
-        Dipole moments (:class:`dict`).
+        Dipole moments (`dict`).
     """
     def __init__(self):
         self.__status = {'coeffs': False,
@@ -144,12 +144,12 @@ class IGRF():
 
         Parameters
         ----------
-        time : :class:`~datetime.datetime`
+        time : `~datetime.datetime`
             Time for which to initialize the model
 
         Other Parameters
         ----------------
-        limits : :class:`str`, optional
+        limits : `str`, optional
             Set to ``warn`` to warn about out-of-range times (default);
             any other value to error.
         """

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -8,11 +8,11 @@ It is targeted at Python 2.6+ and should work without change on either
 Python 2 or Python 3.
 
 The interface is intended to be 'pythonic' rather than reproducing the
-C interface. To open or close a CDF and access its variables, see the :class:`CDF`
-class. Accessing data within the variables is via the :class:`Var`
+C interface. To open or close a CDF and access its variables, see the `CDF`
+class. Accessing data within the variables is via the `Var`
 class. The :data:`lib` object provides access to some routines
 that affect the functionality of the library in general. The
-:mod:`~spacepy.pycdf.const` module contains constants useful for accessing
+`~spacepy.pycdf.const` module contains constants useful for accessing
 the underlying library.
 
 
@@ -105,7 +105,7 @@ class Library(object):
     C reference manual.
 
     Calling the C library directly requires knowledge of
-    :mod:`ctypes`.
+    `ctypes`.
 
     Instantiating this object loads the C library, see :doc:`/pycdf` docs
     for details.
@@ -602,9 +602,9 @@ class Library(object):
 
         Parameters
         ==========
-        args : various, see :mod:`ctypes`
+        args : various, see `ctypes`
             Passed directly to the CDF library interface. Useful
-            constants are defined in the :mod:`~pycdf.const` module.
+            constants are defined in the `~pycdf.const` module.
 
         Other Parameters
         ================
@@ -675,7 +675,7 @@ class Library(object):
 
         Returns
         =======
-        out : :class:`datetime.datetime`
+        out : `datetime.datetime`
             date and time corresponding to epoch. Invalid values are set to
             usual epoch invalid value, i.e. last moment of year 9999.
 
@@ -704,7 +704,7 @@ class Library(object):
 
         Parameters
         ==========
-        dt : :class:`datetime.datetime`
+        dt : `datetime.datetime`
             date and time to convert
 
         Returns
@@ -750,7 +750,7 @@ class Library(object):
 
         Returns
         =======
-        out : :class:`datetime.datetime`
+        out : `datetime.datetime`
             date and time corresponding to epoch. Invalid values are set to
             usual epoch invalid value, i.e. last moment of year 9999.
 
@@ -798,7 +798,7 @@ class Library(object):
 
         Parameters
         ==========
-        dt :  :class:`datetime.datetime`
+        dt :  `datetime.datetime`
             date and time to convert
 
         Returns
@@ -852,7 +852,7 @@ class Library(object):
         """
         Convert CDF EPOCH to matplotlib number.
 
-        Same output as :func:`~matplotlib.dates.date2num` and useful for
+        Same output as `~matplotlib.dates.date2num` and useful for
         plotting large data sets without converting the times through datetime.
 
         Parameters
@@ -926,7 +926,7 @@ class Library(object):
 
         Returns
         =======
-        out : :class:`datetime.datetime`
+        out : `datetime.datetime`
             date and time corresponding to epoch. Invalid values are set to
             usual epoch invalid value, i.e. last moment of year 9999.
 
@@ -977,7 +977,7 @@ class Library(object):
 
         Parameters
         ==========
-        dt :  :class:`datetime.datetime`
+        dt :  `datetime.datetime`
             date and time to convert
 
         Returns
@@ -1010,7 +1010,7 @@ class Library(object):
 
         Parameters
         ==========
-        dt :  :class:`datetime.datetime`
+        dt :  `datetime.datetime`
             date and time to convert
 
         Returns
@@ -1162,7 +1162,7 @@ class Library(object):
         Parameters
         ==========
         cdftype : int
-            CDF type number from :mod:`~spacepy.pycdf.const`
+            CDF type number from `~spacepy.pycdf.const`
 
         Raises
         ======
@@ -1275,8 +1275,8 @@ class CDFException(Exception):
     """
     Base class for errors or warnings in the CDF library.
 
-    Not normally used directly, but in subclasses :class:`CDFError`
-    and :class:`CDFWarning`.
+    Not normally used directly, but in subclasses `CDFError`
+    and `CDFWarning`.
 
     Error messages provided by this class are looked up from the underlying
     C library.
@@ -1338,7 +1338,7 @@ class CDFWarning(CDFException, UserWarning):
         ================
         level : int
             optional (default 3), how far up the stack the warning should
-            be reported. Passed directly to :class:`warnings.warn`.
+            be reported. Passed directly to `warnings.warn`.
         """
         warnings.warn(self, self.__class__, level)
 
@@ -1349,16 +1349,16 @@ class EpochError(Exception):
 
 
 def _compress(obj, comptype=None, param=None):
-    """Set or check the compression of a :py:class:`pycdf.CDF` or :py:class:`pycdf.Var`
+    """Set or check the compression of a `pycdf.CDF` or `pycdf.Var`
 
     @param obj: object on which to set or check compression
-    @type obj: :py:class:`pycdf.CDF` or :py:class:`pycdf.Var`
+    @type obj: `pycdf.CDF` or `pycdf.Var`
     @param comptype: type of compression to change to, see CDF C reference
                      manual section 4.10. Constants for this parameter
-                     are in :py:mod:`pycdf.const`. If not specified, will not change
+                     are in `pycdf.const`. If not specified, will not change
                      compression.
     @type comptype: ctypes.c_long
-    @param param: Compression parameter, see CDF CRM 4.10 and :py:mod:`pycdf.const`.
+    @param param: Compression parameter, see CDF CRM 4.10 and `pycdf.const`.
                   If not specified, will choose reasonable default (5 for
                   gzip; other types have only one possible parameter.)
     @type param: ctypes.c_long
@@ -1489,7 +1489,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     CDF objects behave like a python `dictionary
     <http://docs.python.org/tutorial/datastructures.html#dictionaries>`_,
     where the keys are names of variables in the CDF, and the values,
-    :class:`Var` objects. As a dictionary, they are also `iterable
+    `Var` objects. As a dictionary, they are also `iterable
     <http://docs.python.org/tutorial/classes.html#iterators>`_ and it is easy
     to loop over all of the variables in a file. Some examples:
 
@@ -1499,7 +1499,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
                >>> for k in cdffile: #Alternate
                ...     print(k)
 
-        #. Get a :class:`Var` object for the variable named ``Epoch``:
+        #. Get a `Var` object for the variable named ``Epoch``:
 
                >>> epoch = cdffile['Epoch']
 
@@ -1533,17 +1533,17 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     This last example can be very inefficient as it reads the entire CDF.
     Normally it's better to treat the CDF as a dictionary and access only
     the data needed, which will be pulled transparently from disc. See
-    :class:`Var` for more subtle examples.
+    `Var` for more subtle examples.
 
     Potentially useful dictionary methods and related functions:
 
       - `in <http://docs.python.org/reference/expressions.html#in>`_
       - `keys <http://docs.python.org/tutorial/datastructures.html#dictionaries>`_
-      - :py:func:`len`
+      - `len`
       - `list comprehensions
         <http://docs.python.org/tutorial/datastructures.html#list-comprehensions>`_
-      - :py:func:`sorted`
-      - :py:func:`~spacepy.toolbox.dictree`
+      - `sorted`
+      - `~spacepy.toolbox.dictree`
 
     The CDF user's guide section 2.2 has more background information on CDF
     files.
@@ -1551,7 +1551,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     The :attr:`~CDF.attrs` Python attribute acts as a dictionary
     referencing CDF attributes (do not confuse the two); all the
     dictionary methods above also work on the attribute dictionary.
-    See :class:`gAttrList` for more on the dictionary of global
+    See `gAttrList` for more on the dictionary of global
     attributes.
 
     Creating a new CDF from a master (skeleton) CDF has similar syntax to
@@ -1568,7 +1568,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         >>> cdffile = pycdf.CDF('cdf_filename.cdf', '')
 
     When CDFs are created in this way, they are opened read-write, see
-    :py:meth:`readonly` to change.
+    :meth:`readonly` to change.
 
     By default, new CDFs (without a master) are created in version 3
     format. To create a version 2 (backward-compatible) CDF, use
@@ -1583,7 +1583,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         >>> cdffile['new_variable_name'] = [1, 2, 3, 4]
 
     or, if more control is needed over the type and dimensions, use
-    :py:meth:`new`.
+    :meth:`new`.
 
     Although it is supported to assign Var objects to Python variables
     for convenience, there are some minor pitfalls that can arise when
@@ -1646,7 +1646,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     .. attribute:: CDF.attrs
 
        Global attributes for this CDF in a dict-like format.
-       See :class:`gAttrList` for details.
+       See `gAttrList` for details.
 
     .. attribute:: CDF.backward
 
@@ -1707,7 +1707,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         ========
         Open a CDF by creating a CDF object, e.g.:
             >>> cdffile = pycdf.CDF('cdf_filename.cdf')
-        Be sure to :py:meth:`pycdf.CDF.close` or :py:meth:`pycdf.CDF.save`
+        Be sure to :meth:`pycdf.CDF.close` or :meth:`pycdf.CDF.save`
         when done.
         """
         if masterpath is not None: #Looks like we want to create
@@ -1747,8 +1747,8 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         Close CDF file if there is still a valid handle.
         .. note::
-            To avoid data loss, explicitly call :py:meth:`pycdf.CDF.close` 
-            or :py:meth:`pycdf.CDF.save`.
+            To avoid data loss, explicitly call :meth:`pycdf.CDF.close` 
+            or :meth:`pycdf.CDF.save`.
         """
         if self._opened:
             self.close()
@@ -1789,7 +1789,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         @param name: Name or number of the CDF variable
         @type name: string or int
         @return: CDF variable named or numbered L{name}
-        @rtype: :py:class:`pycdf.Var`
+        @rtype: `pycdf.Var`
         @raise KeyError: for pretty much any problem in lookup
         @note: variable numbers may change if variables are added or removed.
         """
@@ -1807,7 +1807,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         @param name: name or number of the variable to write
         @type name: str or int
-        @param data: data to write, or a :py:class:`pycdf.Var` to copy
+        @param data: data to write, or a `pycdf.Var` to copy
         """
         if isinstance(data, Var):
             self.clone(data, name)
@@ -1876,7 +1876,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         """Returns a string representation of the CDF
 
         This is an 'informal' representation in that it cannot be evaluated
-        directly to create a :py:class:`pycdf.CDF`, just the names, types, and sizes of all
+        directly to create a `pycdf.CDF`, just the names, types, and sizes of all
         variables. (Attributes are not listed.)
 
         @return: description of the variables in the CDF
@@ -1905,7 +1905,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
                      is set to error on warnings.
         .. note:
             Not intended for direct call; pass parameters to
-            :py:class:`pycdf.CDF` constructor.
+            `pycdf.CDF` constructor.
         """
 
         lib.call(const.OPEN_, const.CDF_, self.pathname, ctypes.byref(self._handle))
@@ -1928,7 +1928,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
                      is set to error on warnings.
         .. note:
             Not intended for direct call; pass parameters to
-            :py:class:`pycdf.CDF` constructor.
+            `pycdf.CDF` constructor.
         """
         lib.call(const.CREATE_, const.CDF_, self.pathname, ctypes.c_long(0),
                               (ctypes.c_long * 1)(0), ctypes.byref(self._handle))
@@ -1951,7 +1951,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
                      is set to error on warnings.
         .. note:
             Not intended for direct call; pass parameters to
-            :py:class:`pycdf.CDF` constructor.
+            `pycdf.CDF` constructor.
         """
 
         if os.path.exists(self.pathname):
@@ -1987,8 +1987,8 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             name of the file to create
         sd : spacepy.datamodel.SpaceData
             data to put in the CDF. This structure cannot be nested,
-            i.e., it must contain only :class:`~spacepy.datamodel.dmarray`
-            and no :class:`~spacepy.datamodel.Spacedata` objects.
+            i.e., it must contain only `~spacepy.datamodel.dmarray`
+            and no `~spacepy.datamodel.Spacedata` objects.
         """
         with cls(filename, '') as cdffile:
             for k in sd:
@@ -2004,7 +2004,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         Parameters
         ==========
-        args : various, see :py:mod:`ctypes`.
+        args : various, see `ctypes`.
             Passed directly to the CDF library interface. Useful
             constants are defined in the :doc:`const <pycdf_const>`
             module of this package.
@@ -2031,7 +2031,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         Parameters
         ==========
-        zVar : :py:class:`Var`
+        zVar : `Var`
             variable to clone
 
         Other Parameters
@@ -2044,7 +2044,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         Returns
         =======
-        out : :py:class:`Var`
+        out : `Var`
             The newly-created zVar in this CDF
         """
         if name is None:
@@ -2198,11 +2198,11 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         comptype : ctypes.c_long
             type of compression to change to, see CDF C reference manual
             section 4.10. Constants for this parameter are in
-            :mod:`~spacepy.pycdf.const`. If not specified, will not change
+            `~spacepy.pycdf.const`. If not specified, will not change
             compression.
         param : ctypes.c_long
             Compression parameter, see CDF CRM 4.10 and
-            :mod:`~spacepy.pycdf.const`.
+            `~spacepy.pycdf.const`.
             If not specified, will choose reasonable default (5 for gzip;
             other types have only one possible parameter.)
 
@@ -2248,14 +2248,14 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         data
             data to store in the new variable. If this has a an
             ``attrs`` attribute (e.g.,
-            :class:`~spacepy.datamodel.dmarray`), it will be used to
+            `~spacepy.datamodel.dmarray`), it will be used to
             populate attributes of the new variable. Similarly the CDF
             type, record variance, etc. will, by default, be taken
             from `data` if it is a
-            :class:`~spacepy.pycdf.VarCopy`. This can be overridden by
+            `~spacepy.pycdf.VarCopy`. This can be overridden by
             specifying other keywords.
         type : ctypes.c_long
-            CDF type of the variable, from :mod:`~spacepy.pycdf.const`.
+            CDF type of the variable, from `~spacepy.pycdf.const`.
             See section 2.5 of the CDF user's guide for more information on
             CDF data types.
         recVary : boolean
@@ -2267,16 +2267,16 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
             size of each dimension of this variable, default zero-dimensional.
             Note this is the dimensionality as defined by CDF, i.e., for
             record-varying variables it excludes the leading record dimension.
-            See :py:class:`Var`.
+            See `Var`.
         n_elements : int
             number of elements, should be 1 except for CDF_CHAR,
             for which it's the length of the string.
         compress : ctypes.c_long
             Compression to apply to this variable, default None.
-            See :py:meth:`Var.compress`.
+            See :meth:`Var.compress`.
         compress_param : ctypes.c_long
             Compression parameter if compression used; reasonable default
-            is chosen. See :py:meth:`Var.compress`.
+            is chosen. See :meth:`Var.compress`.
         sparse : ctypes.c_long
 
             .. versionadded:: 0.2.3
@@ -2292,7 +2292,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         Returns
         =======
-        out : :py:class:`Var`
+        out : `Var`
             the newly-created zVariable
 
         Raises
@@ -2427,9 +2427,9 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
     def raw_var(self, name):
         """
-        Get a "raw" :class:`Var` object.
+        Get a "raw" `Var` object.
 
-        Normally a :class:`Var` will perform translation of values for
+        Normally a `Var` will perform translation of values for
         certain types (to/from Unicode for CHAR variables on Py3k,
         and to/from datetime for all time types). A "raw" object
         does not perform this translation, on read or write.
@@ -2476,8 +2476,8 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
         Returns
         =======
-        out : :py:class:`CDFCopy`
-            :class:`~spacepy.datamodel.SpaceData`-like object of all data
+        out : `CDFCopy`
+            `~spacepy.datamodel.SpaceData`-like object of all data
         """
         return CDFCopy(self)
 
@@ -2525,7 +2525,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     attrs = property(
         _get_attrs, _set_attrs, None,
         """Global attributes for this CDF in a dict-like format.
-        See :class:`gAttrList` for details.
+        See `gAttrList` for details.
         """)
 
     def var_num(self, varname):
@@ -2685,14 +2685,14 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
 
 class CDFCopy(spacepy.datamodel.SpaceData):
     """
-    A dictionary-like copy of all data and attributes in a :py:class:`CDF`
+    A dictionary-like copy of all data and attributes in a `CDF`
 
-    Data are :class:`VarCopy` objects, keyed by variable name.
+    Data are `VarCopy` objects, keyed by variable name.
     CDF attributes are in :attr:`attrs`. (I.e.,
-    data are accessed much like from a :class:`CDF`).
+    data are accessed much like from a `CDF`).
 
     Do not instantiate this class directly; use :meth:`~CDF.copy`
-    on an existing :class:`CDF`.
+    on an existing `CDF`.
 
     Examples
     --------
@@ -2709,7 +2709,7 @@ class CDFCopy(spacepy.datamodel.SpaceData):
         """Copies all data and attributes from a CDF
 
         @param cdf: CDF to take data from
-        @type cdf: :py:class:`pycdf.CDF`
+        @type cdf: `pycdf.CDF`
         """
         super(CDFCopy, self).__init__(((key, var.copy())
                                       for (key, var) in cdf.items()),
@@ -2726,7 +2726,7 @@ def concatCDF(cdfs, varnames=None, raw=False):
 
     Parameters
     ----------
-    cdfs : list of :class:`~spacepy.pycdf.Var`
+    cdfs : list of `~spacepy.pycdf.Var`
         Open CDFs, will be read from in order. Must be a list (cannot
         be an iterable, as all files need to be open).
     varnames : list of str
@@ -2737,7 +2737,7 @@ def concatCDF(cdfs, varnames=None, raw=False):
 
     Returns
     -------
-    :class:`~spacepy.datamodel.SpaceData`
+    `~spacepy.datamodel.SpaceData`
         data concatenated from each CDF, with all attributes from first.
         Non-record-varying data is also only from first, and record
         variance is only checked on the first!
@@ -2771,7 +2771,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
     This object does not directly store the data from the CDF; rather,
     it provides access to the data in a format that much like a Python
-    list or numpy :class:`~numpy.ndarray`.
+    list or numpy `~numpy.ndarray`.
     General list information is available in the python docs:
     `1 <http://docs.python.org/tutorial/introduction.html#lists>`_,
     `2 <http://docs.python.org/tutorial/datastructures.html#more-on-lists>`_,
@@ -2780,7 +2780,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
     The CDF user's guide, section 2.3, provides background on variables.
 
     .. note::
-        Not intended to be created directly; use methods of :class:`CDF` to gain access to a variable.
+        Not intended to be created directly; use methods of `CDF` to gain access to a variable.
 
     A record-varying variable's data are viewed as a hypercube of dimensions
     n_dims+1 (the extra dimension is the record number). They are indexed in
@@ -2909,11 +2909,11 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
     All data are, on read, converted to appropriate Python data
     types; EPOCH, EPOCH16, and TIME_TT2000 types are converted to
-    :class:`~datetime.datetime`. Data are returned in numpy arrays.
+    `~datetime.datetime`. Data are returned in numpy arrays.
 
     .. note::
         Although pycdf supports TIME_TT2000 variables, the Python
-        :class:`~datetime.datetime` object does not support leap
+        `~datetime.datetime` object does not support leap
         seconds. Thus, on read, any seconds past 59 are truncated
         to 59.999999 (59 seconds, 999 milliseconds, 999 microseconds).
 
@@ -2939,7 +2939,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
     The :attr:`~Var.attrs` Python attribute acts as a dictionary referencing
     zAttributes (do not confuse the two); all the dictionary methods above
-    also work on the attribute dictionary. See :class:`zAttrList` for more on
+    also work on the attribute dictionary. See `zAttrList` for more on
     the dictionary of attributes.
 
     With writing, as with reading, every attempt has been made to match the
@@ -3037,7 +3037,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
     .. attribute:: Var.attrs
 
        zAttributes for this zVariable in a dict-like format.
-       See :class:`zAttrList` for details.
+       See `zAttrList` for details.
     .. automethod:: compress
     .. automethod:: copy
     .. autoattribute:: dtype
@@ -3057,7 +3057,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
         Parameters
         ==========
-        cdf_file : :py:class:`pycdf.CDF`
+        cdf_file : `pycdf.CDF`
             CDF file containing this variable
         var_name : string
             name of this variable
@@ -3065,7 +3065,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         Other Parameters
         ================
         args
-            additional arguments passed to :py:meth:`_create`. If none,
+            additional arguments passed to :meth:`_create`. If none,
             opens an existing variable. If provided, creates a
             new one.
 
@@ -3093,7 +3093,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         self._attrlistref = weakref.ref(zAttrList(self))
 
     def __getitem__(self, key):
-        """Returns a slice from the data array. Details under :py:class:`pycdf.Var`.
+        """Returns a slice from the data array. Details under `pycdf.Var`.
 
         @return: The data from this variable
         @rtype: list-of-lists of appropriate type.
@@ -3251,7 +3251,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         return data
 
     def __setitem__(self, key, data):
-        """Puts a slice into the data array. Details under :py:class:`pycdf.Var`.
+        """Puts a slice into the data array. Details under `pycdf.Var`.
 
         @param key: index or slice to store
         @type key: int or slice
@@ -3348,7 +3348,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         @param dimVarys: array of VARY or NOVARY, variance for each dimension
         @type dimVarys: sequence of long
         @return: new variable with this name
-        @rtype: :py:class:`pycdf.Var`
+        @rtype: `pycdf.Var`
         @raise CDFError: if CDF library reports an error
         @raise CDFWarning: if CDF library reports a warning and interpreter
                            is set to error on warnings.
@@ -3385,7 +3385,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         @param var_name: name of this variable
         @type var_name: string
         @return: variable with this name
-        @rtype: :py:class:`pycdf.Var`
+        @rtype: `pycdf.Var`
         @raise CDFError: if CDF library reports an error
         @raise CDFWarning: if CDF library reports a warning and interpreter
                            is set to error on warnings.
@@ -3444,7 +3444,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         """Returns a string representation of the variable
 
         This is an 'informal' representation in that it cannot be evaluated
-        directly to create a :py:class:`pycdf.Var`.
+        directly to create a `pycdf.Var`.
 
         @return: info on this zVar, CDFTYPE [dimensions] NRV
                  (if not record-varying)
@@ -3533,7 +3533,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         ================
         sparsetype : ctypes.c_long
             If specified, should be a sparse record mode from
-            :mod:`~spacepy.pycdf.const`; see also CDF C reference manual
+            `~spacepy.pycdf.const`; see also CDF C reference manual
             section 4.11.1. If not specified, the sparse record mode for this
             variable will not change.
 
@@ -3643,8 +3643,8 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         interface. Checks the return value with L{Library.check_status}.
 
         @param args: Passed directly to the CDF library interface. Useful
-                     constants are defined in the :py:mod:`pycdf.const` module of this package.
-        @type args: various, see :py:mod:`ctypes`.
+                     constants are defined in the `pycdf.const` module of this package.
+        @type args: various, see `ctypes`.
         @return: CDF status from the library
         @rtype: ctypes.c_long
         @note: Terminal NULL_ is automatically added to L{args}.
@@ -3687,7 +3687,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         Parameters
         ==========
         new_type : ctypes.c_long
-            the new type from :mod:`~spacepy.pycdf.const`
+            the new type from `~spacepy.pycdf.const`
 
         Returns
         =======
@@ -3752,11 +3752,11 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
         comptype : ctypes.c_long
             type of compression to change to, see CDF C reference
             manual section 4.10. Constants for this parameter
-            are in :mod:`~spacepy.pycdf.const`. If not specified, will not
+            are in `~spacepy.pycdf.const`. If not specified, will not
             change compression.
         param : ctypes.c_long
             Compression parameter, see CDF CRM 4.10 and
-            :mod:`~spacepy.pycdf.const`.
+            `~spacepy.pycdf.const`.
             If not specified, will choose reasonable default (5 for
             gzip; other types have only one possible parameter.)
 
@@ -3773,7 +3773,7 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
 
         Returns
         =======
-        out : :class:`VarCopy`
+        out : `VarCopy`
             list of all data in record order
         """
         return VarCopy(self)
@@ -3863,19 +3863,19 @@ class Var(MutableSequence, spacepy.datamodel.MetaMixin):
     attrs = property(
         _get_attrs, _set_attrs, None,
         """zAttributes for this zVariable in a dict-like format.
-        See :class:`zAttrList` for details.
+        See `zAttrList` for details.
         """)
 
 
 class VarCopy(spacepy.datamodel.dmarray):
-    """A list-like copy of the data and attributes in a :class:`Var`
+    """A list-like copy of the data and attributes in a `Var`
 
     Data are in the list elements. CDF attributes are in a dict,
     accessed through :attr:`attrs`. (I.e.,
-    data and attributes are accessed like in a :class:`Var`.)
+    data and attributes are accessed like in a `Var`.)
 
     Do not instantiate this class directly; use :meth:`~Var.copy`
-    on an existing :class:`Var`.
+    on an existing `Var`.
 
     Several methods provide access to details about how the original
     variable was constructed. This is mostly for making it easier to
@@ -3916,7 +3916,7 @@ class VarCopy(spacepy.datamodel.dmarray):
         """Copies all data and attributes from a zVariable
 
         @param zVar: variable to take data from
-        @type zVar: :py:class:`pycdf.Var`
+        @type zVar: `pycdf.Var`
         """
         obj = super(VarCopy, cls).__new__(cls, zVar[...], zVar.attrs.copy())
         obj._cdf_meta = { k: getattr(zVar, k)() for k in (
@@ -4088,7 +4088,7 @@ class _Hyperslice(object):
     @ivar column: is this slice in column-major mode (if false, row-major)
     @type column: boolean
     @ivar zvar: what CDF variable this object slices on
-    @type zvar: :py:class:`pycdf.Var`
+    @type zvar: `pycdf.Var`
     @ivar expanded_key: fully-expanded version of the key passed to the
                         constructor (all dimensions filled in)
     @type expanded_key: tuple
@@ -4100,7 +4100,7 @@ class _Hyperslice(object):
         """Create a Hyperslice
 
         @param zvar: zVariable that this slices
-        @type zvar: :py:class:`pycdf.Var`
+        @type zvar: `pycdf.Var`
         @param key: Python multi-dimensional slice as passed to
                     __getitem__
         @type key: tuple of slice and/or int
@@ -4373,7 +4373,7 @@ class _Hyperslice(object):
 
         Returns
         -------
-        :class:`~numpy.ndarray`
+        `~numpy.ndarray`
             The input data as a well-formed array; may be the input
             data exactly.
         """
@@ -4636,7 +4636,7 @@ class Attr(MutableSequence):
 
     .. warning::
         This class should not be used directly, but only in its
-        subclasses, :class:`gAttr` and :class:`zAttr`. The methods
+        subclasses, `gAttr` and `zAttr`. The methods
         listed here are safe to use in the subclasses.
 
     Represents a CDF attribute, providing access to the Entries in a format
@@ -4684,7 +4684,7 @@ class Attr(MutableSequence):
         """Initialize this attribute
 
         @param cdf_file: CDF file containing this attribute
-        @type cdf_file: :py:class:`pycdf.CDF`
+        @type cdf_file: `pycdf.CDF`
         @param attr_name: Name of this attribute
         @type attr_name: str
         @param create: True to create attribute, False to look up existing.
@@ -5006,7 +5006,7 @@ class Attr(MutableSequence):
         """Select this CDF and Attr and call the CDF internal interface
 
         @param args: Passed directly to the CDF library interface.
-        @type args: various, see :py:mod:`ctypes`.
+        @type args: various, see `ctypes`.
         @return: CDF status from the library
         @rtype: ctypes.c_long
         @note: Terminal NULL_ is automatically added to L{args}.
@@ -5046,13 +5046,13 @@ class Attr(MutableSequence):
         Other Parameters
         ================
         new_type
-            type to change this Entry to, from :mod:`~spacepy.pycdf.const`.
+            type to change this Entry to, from `~spacepy.pycdf.const`.
             Omit to only check type.
 
         Returns
         =======
         out : int
-            CDF variable type, see :mod:`~spacepy.pycdf.const`
+            CDF variable type, see `~spacepy.pycdf.const`
 
         Notes
         =====
@@ -5120,7 +5120,7 @@ class Attr(MutableSequence):
         Other Parameters
         ================
         type : int
-            type of the new Entry, from :mod:`~spacepy.pycdf.const`
+            type of the new Entry, from `~spacepy.pycdf.const`
             (otherwise guessed from ``data``)
         number : int
             Entry number to write, default is lowest available number.
@@ -5246,7 +5246,7 @@ class Attr(MutableSequence):
         @param number: number of Entry to write
         @type number: int
         @param data: data to write
-        @param cdf_type: the CDF type to write, from :py:mod:`pycdf.const`
+        @param cdf_type: the CDF type to write, from `pycdf.const`
         @param dims: dimensions of L{data}
         @type dims: list
         @param elements: number of elements in L{data}, 1 unless it is a string
@@ -5318,7 +5318,7 @@ class zAttr(Attr):
     .. warning::
         Because zAttributes are shared across all variables in a CDF,
         directly manipulating them may have unexpected consequences.
-        It is safest to operate on zEntries via :class:`zAttrList`.
+        It is safest to operate on zEntries via `zAttrList`.
 
     .. note::
         When accessing a zAttr, pyCDF exposes only the zEntry corresponding
@@ -5326,7 +5326,7 @@ class zAttr(Attr):
 
     See Also
     ========
-    :class:`Attr`
+    Attr
     """
     ENTRY_ = const.zENTRY_
     ENTRY_DATA_ = const.zENTRY_DATA_
@@ -5373,7 +5373,7 @@ class gAttr(Attr):
     `2 <http://docs.python.org/tutorial/datastructures.html#more-on-lists>`_,
     `3 <http://docs.python.org/library/stdtypes.html#typesseq>`_.
 
-    Normally accessed by providing a key to a :class:`gAttrList`:
+    Normally accessed by providing a key to a `gAttrList`:
 
         >>> attribute = cdffile.attrs['attribute_name']
         >>> first_gentry = attribute[0]
@@ -5428,7 +5428,7 @@ class gAttr(Attr):
 
     See Also
     ========
-    :class:`Attr`
+    Attr
     """
     ENTRY_ = const.gENTRY_
     ENTRY_DATA_ = const.gENTRY_DATA_
@@ -5446,7 +5446,7 @@ class AttrList(MutableMapping):
 
     .. warning::
         This class should not be used directly, but only via its
-        subclasses, :class:`gAttrList` and :class:`zAttrList`.
+        subclasses, `gAttrList` and `zAttrList`.
         Methods listed here are safe to use from the subclasses.
 
     .. autosummary::
@@ -5466,7 +5466,7 @@ class AttrList(MutableMapping):
         """Initialize the attribute collection
 
         @param cdf_file: CDF these attributes are in
-        @type cdf_file: :py:class:`pycdf.CDF`
+        @type cdf_file: `pycdf.CDF`
         @param special_entry: callable which returns a "special" entry number,
         used to limit results for zAttrs to those which match the zVar
         (i.e. the var number)
@@ -5652,7 +5652,7 @@ class AttrList(MutableMapping):
         data
             data to put into the first entry in the new Attribute
         type
-            CDF type of the first entry from :mod:`~spacepy.pycdf.const`.
+            CDF type of the first entry from `~spacepy.pycdf.const`.
             Only used if data are specified.
 
         Raises
@@ -5738,19 +5738,19 @@ class gAttrList(AttrList):
     """
     Object representing *all* the gAttributes in a CDF.
 
-    Normally accessed as an attribute of an open :class:`CDF`:
+    Normally accessed as an attribute of an open `CDF`:
 
         >>> global_attribs = cdffile.attrs
 
     Appears as a dictionary: keys are attribute names; each value is an
-    attribute represented by a :class:`gAttr` object. To access the global
+    attribute represented by a `gAttr` object. To access the global
     attribute TEXT:
 
         >>> text_attr = cdffile.attrs['TEXT']
 
     See Also
     ========
-    :class:`AttrList`
+    AttrList
     """
     AttrType = gAttr
     attr_name = 'gAttribute'
@@ -5774,7 +5774,7 @@ class gAttrList(AttrList):
 class zAttrList(AttrList):
     """Object representing *all* the zAttributes in a zVariable.
 
-    Normally accessed as an attribute of a :class:`Var` in an open
+    Normally accessed as an attribute of a `Var` in an open
     CDF:
         
         >>> epoch_attribs = cdffile['Epoch'].attrs
@@ -5809,11 +5809,11 @@ class zAttrList(AttrList):
         #. existing zEntry corresponding to this zVar
         #. other zEntries in this zAttribute
         #. the type of this zVar
-        #. data-matching constraints described in :py:meth:`CDF.new`
+        #. data-matching constraints described in :meth:`CDF.new`
 
     See Also
     ========
-    :class:`AttrList`
+    AttrList
 
     """
     AttrType = zAttr
@@ -5824,7 +5824,7 @@ class zAttrList(AttrList):
         """Initialize the attribute collection
 
         @param zvar: zVariable these attributes are in
-        @param zvar: :py:class:`pycdf.Var`
+        @param zvar: `pycdf.Var`
         """
         super(zAttrList, self).__init__(zvar.cdf_file, zvar._num)
         self._zvar = zvar
@@ -5919,9 +5919,9 @@ class zAttrList(AttrList):
 
         @param name: name of the zAttr to check or change
         @type name: str
-        @param new_type: type to change it to, see :py:mod:`pycdf.const`
+        @param new_type: type to change it to, see `pycdf.const`
         @type new_type: ctypes.c_long
-        @return: CDF variable type, see :py:mod:`pycdf.const`
+        @return: CDF variable type, see `pycdf.const`
         @rtype: int
         @note: If changing types, old and new must be equivalent, see CDF
                User's Guide section 2.5.5 pg. 57

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -58,7 +58,7 @@ class VariableChecks(object):
     performs checks that are not currently performed by the `ISTP
     skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_.  All
     tests return a list, one error string for every noncompliance
-    found (empty list if compliant). :meth:`all` will perform all
+    found (empty list if compliant). `all` will perform all
     tests and concatenate all errors.
 
     .. autosummary::
@@ -98,7 +98,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
         catch : bool
             Catch exceptions in tests (default False). If True, any
@@ -150,7 +150,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -176,7 +176,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -234,7 +234,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -321,7 +321,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -348,7 +348,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -412,7 +412,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -437,7 +437,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         rng : bool
@@ -553,7 +553,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -575,7 +575,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -597,7 +597,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -629,7 +629,7 @@ class VariableChecks(object):
 
         Parameters
         ----------
-        v : :class:`~spacepy.pycdf.Var`
+        v : `~.pycdf.Var`
             Variable to check
 
         Returns
@@ -655,7 +655,7 @@ class FileChecks(object):
     performs checks that are not currently performed by the `ISTP
     skeleton editor <https://spdf.gsfc.nasa.gov/skteditor/>`_.  All
     tests return a list, one error string for every noncompliance
-    found (empty list if compliant). :meth:`all` will perform all
+    found (empty list if compliant). `all` will perform all
     tests and concatenate all errors.
 
     .. autosummary::
@@ -682,11 +682,11 @@ class FileChecks(object):
         """Perform all variable and file-level tests
 
         In addition to calling every test in this class, will also call
-        :meth:`VariableChecks.all` for every variable in the file.
+        `VariableChecks.all` for every variable in the file.
 
         Parameters
         ----------
-        f : :class:`~spacepy.pycdf.CDF`
+        f : `~.pycdf.CDF`
             Open CDF file to check
         catch : bool
             Catch exceptions in tests (default False). If True, any
@@ -740,7 +740,7 @@ class FileChecks(object):
 
         Parameters
         ----------
-        f : :class:`~spacepy.pycdf.CDF`
+        f : `~.pycdf.CDF`
             Open CDF file to check
 
         Returns
@@ -772,7 +772,7 @@ class FileChecks(object):
 
         Parameters
         ----------
-        f : :class:`~spacepy.pycdf.CDF`
+        f : `~.pycdf.CDF`
             Open CDF file to check
 
         Returns
@@ -808,7 +808,7 @@ class FileChecks(object):
 
         Parameters
         ----------
-        f : :class:`~spacepy.pycdf.CDF`
+        f : `~.pycdf.CDF`
             Open CDF file to check
 
         Returns
@@ -841,7 +841,7 @@ class FileChecks(object):
 
         Parameters
         ----------
-        f : :class:`~spacepy.pycdf.CDF`
+        f : `~.pycdf.CDF`
             Open CDF file to check
 
         Returns
@@ -889,7 +889,7 @@ def fillval(v, ret=False):
 
     Parameters
     ----------
-    v : :class:`~spacepy.pycdf.Var`
+    v : `~.pycdf.Var`
         CDF variable to update
 
     Other Parameters
@@ -959,7 +959,7 @@ def format(v, use_scaleminmax=False, dryrun=False):
 
     Parameters
     ----------
-    v : :class:`~spacepy.pycdf.Var`
+    v : `~.pycdf.Var`
         Variable to update
     use_scaleminmax : bool, optional
         Use SCALEMIN/MAX instead of VALIDMIN/MAX (default False).
@@ -1110,8 +1110,8 @@ def nanfill(v):
     restriction.)
 
     Only applicable to floating-point types. Best applied to a
-    :class:`~spacepy.pycdf.VarCopy` or :class:`~spacepy.datamodel.dmarray`
-    rather than :class:`~spacepy.pycdf.Var`. Updating a variable in a CDF
+    `~.pycdf.VarCopy` or `~.datamodel.dmarray`
+    rather than `~.pycdf.Var`. Updating a variable in a CDF
     requires one write per changed value, and also will result in a CDF
     that is no longer ISTP compliant.
 
@@ -1120,7 +1120,7 @@ def nanfill(v):
 
     Parameters
     ----------
-    v : :class:`~spacepy.pycdf.Var` or :class:`~spacepy.datamodel.dmarray`
+    v : `~.pycdf.Var` or `~.datamodel.dmarray`
         CDF variable, data, or copy to update
 
     Examples
@@ -1166,7 +1166,7 @@ class VarBundle(object):
     with its dependencies to enable aggregate operations. Normally
     used to copy a subset of data from one CDF or SpaceData to another by
     chaining operations, or to load just the relevant data from a CDF
-    into a :class:`~spacepy.datamodel.SpaceData`.
+    into a `~.datamodel.SpaceData`.
 
     ``VarBundle`` operates on a single variable within a file or SpaceData
     and its various dependencies, uncertainties, labels, etc. That variable
@@ -1177,13 +1177,13 @@ class VarBundle(object):
     defining the input file (the CDF containing that variable).
 
     Unusual or indecipherable error messages may indicate an ISTP
-    compliance issue; see :class:`VariableChecks` for some checks.
+    compliance issue; see `VariableChecks` for some checks.
 
     Parameters
     ----------
-    source : :class:`~.pycdf.CDF`, :class:`~.datamodel.SpaceData`, or :class:`~.pycdf.Var`
+    source : `~.pycdf.CDF`, `~.datamodel.SpaceData`, or `~.pycdf.Var`
         SpaceData or open CDF containing the variable to process, or the CDF variable itself.
-    name : :class:`str`
+    name : `str`
         Name of the variable within ``source`` to process ("main variable").
 
     See Also
@@ -1275,9 +1275,9 @@ class VarBundle(object):
 
         Parameters
         ----------
-        source : :class:`~spacepy.pycdf.CDF` or :class:`~spacepy.pycdf.Var`
+        source : `~spacepy.pycdf.CDF` or `~spacepy.pycdf.Var`
             CDF containing the variable to process, or the variable itself.
-        name : :class:`str`
+        name : `str`
             Name of the variable within ``source`` to process ("main variable").
         """
         if name is None and not hasattr(source, 'cdf_file'):
@@ -1527,7 +1527,7 @@ class VarBundle(object):
 
         Examples
         --------
-        See the :class:`VarBundle` examples for creating output from
+        See the `VarBundle` examples for creating output from
         the slices.
 
         >>> import spacepy.pycdf
@@ -1599,7 +1599,7 @@ class VarBundle(object):
 
         Examples
         --------
-        See the :class:`VarBundle` examples for creating output.
+        See the `VarBundle` examples for creating output.
 
         >>> import spacepy.pycdf
         >>> import spacepy.pycdf.istp
@@ -1657,7 +1657,7 @@ class VarBundle(object):
 
         Examples
         --------
-        See the :class:`VarBundle` examples for creating output.
+        See the `VarBundle` examples for creating output.
 
         >>> import spacepy.pycdf
         >>> import spacepy.pycdf.istp
@@ -1705,10 +1705,10 @@ class VarBundle(object):
 
         Parameters
         ----------
-        newvar : :class:`~spacepy.pycdf.Var`
+        newvar : `~.pycdf.Var`
             Existing variable to compare to requirements
 
-        invar : : class:`~spacepy.pycdf.Var`
+        invar : : class:`~.pycdf.Var`
             Variable to use as reference for attributes, RV, CDF type,
             number of elements.
 
@@ -1721,7 +1721,7 @@ class VarBundle(object):
         dims : list of int
             Size of each dimension.
 
-        data : :class:`~numpy.ndarray`
+        data : `~numpy.ndarray`
             Data that should be in the variable.
 
         Returns
@@ -1762,7 +1762,7 @@ class VarBundle(object):
     def _namemap(self, suffix=None):
         """Map old variable names to new
 
-        Helper for :meth:`output` that maps the variable name in the
+        Helper for `output` that maps the variable name in the
         input CDF to variable name in the output CDF.
 
         Parameters
@@ -1793,7 +1793,7 @@ class VarBundle(object):
     def _sum_avg(self, data, invar, vinfo, degen, summed, averaged):
         """Sum/average data
 
-        Helper for :meth:`output` that performs summing and averaging
+        Helper for `output` that performs summing and averaging
         of the data for a single variable. Note dimensionality of all
         input is before the removal of degenerate dimensions
         (this function does the translation using ``degen``), and it is
@@ -1802,10 +1802,10 @@ class VarBundle(object):
 
         Parameters
         ----------
-        data : :class:`numpy.ndarray`
+        data : `numpy.ndarray`
             Data as read from input CDF and properly sliced.
 
-        invar : :class:`~spacepy.pycdf.Var`
+        invar : `~.pycdf.Var`
             CDF input variable from which ``data`` was read.
 
         vinfo : dict
@@ -1825,7 +1825,7 @@ class VarBundle(object):
 
         Returns
         -------
-        :class:`numpy.ndarray`
+        `numpy.ndarray`
             Data summed/averaged over dimensions according to ``summed``
             and ``averaged`` inputs.
         """
@@ -1888,10 +1888,10 @@ class VarBundle(object):
 
         Parameters
         ----------
-        invar : :class:`~spacepy.pycdf.Var`
+        invar : `~.pycdf.Var`
             The input variable (opened in raw mode).
 
-        newvar : :class:`~spacepy.pycdf.Var`
+        newvar : `~.pycdf.Var`
             The output variable (opened in raw mode).
 
         preexist : bool
@@ -2049,7 +2049,7 @@ class VarBundle(object):
         list
             Each element is a tuple: first element is a string with
             the name of the operation (i.e. method of
-            :class:`VarBundle`), next is also a tuple of positional
+            `VarBundle`), next is also a tuple of positional
             arguments, and finally a dict of keyword arguments.
 
         Examples
@@ -2091,7 +2091,7 @@ class VarBundle(object):
 
         Parameters
         ----------
-        output : :class:`~spacepy.pycdf.CDF`,  :class:`~spacepy.datamodel.SpaceData`
+        output : `~.pycdf.CDF`,  `~.datamodel.SpaceData`
             Output container to receive the new data, may be an open CDF
             file or a SpaceData.
 
@@ -2217,18 +2217,18 @@ class VarBundle(object):
     def toSpaceData(self, suffix=None):
         """Return variables, as modified.
 
-        Convenience function to call :meth:`output` on a new
-        :class:`~.datamodel.SpaceData` and return it.
+        Convenience function to call `output` on a new
+        `~.datamodel.SpaceData` and return it.
 
         Parameters
         ----------
         suffix : str
             Appended to the name of variables changed on output; see
-            :meth:`output` for details.
+            `output` for details.
 
         Returns
         -------
-        :class:`.datamodel.SpaceData`
+        `.datamodel.SpaceData`
             Data read from input and processed according to the defined
             operations.
 


### PR DESCRIPTION
This PR is nearly cosmetic. The substantial change is setting a default rST role of `obj` in Sphinx `conf.py`. This enables cross-referencing of Python objects with `` `reference` `` instead of ``:meth:`reference` ``, ``:class:`reference` ``, etc.

But this removes a *lot* of cruft from docstrings and seems worthwhile. I did it on igrf (first that came to hand) and pycdf. It didn't seem worth the time to go through the entire codebase at this point--it can be done piecemeal as people want, or on a documentation scrub. It doesn't *hurt* to keep the old ``:class:`reference` `` syntax.

I also cleaned up a few things to relative reference instead of absolute. In case we rename SpacePy to something else, I guess? (But mostly saving some typing.)

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
