### PR TITLE
Change daily CI run to 7:37Z

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
 
 on:
   schedule:
-    - cron: '0 22 * * *'
+    - cron: '37 7 * * *'
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize, reopened, ready_for_review ]


### PR DESCRIPTION
Currently our CI does a daily run at 22:00Z. We also expire the cache of our dependencies at the "beginning of the week", which is at 00:00Z. The first run of the CI after the cache expires takes a long time, as all the dependencies have to be built. It doesn't matter if this first run is the scheduled run or a PR...it is slow, and all subsequent ones for the week are faster. In practice, this means if you open a PR on Monday, the checks take longer to run.

This PR changes the run to 7:37Z. This means the daily run will go (and populate the cache) before most people in Europe or the Americas would be opening a PR. It is off-the-hour to be nice about load balancing, and the 37 is chosen so the minute can clearly not be confused for an hour.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [x] (N/A) New code has inline comments where necessary
- [x] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] (N/A) New features and bug fixes should have unit tests
- [x] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
