### PR TITLE
Mac installer and documentation updates

### DIFF
--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -39,6 +39,9 @@ If you need further assistance, you can `open an issue
     install_mac
     install_windows
 
+.. contents::
+   :local:
+
 SpacePy installs with the common Python distutils and pip.
 
 The latest stable release is provided via `PyPI
@@ -82,3 +85,28 @@ To install in custom location, e.g.::
     python setup.py install --home=/n/packages/lib/python
 
 Installs using ``setup.py`` do not require setuptools.
+
+Troubleshooting
+===============
+
+irbempy
+-------
+The most common failures relate to compilation of the IRBEM
+library. Unfortunately ``pip`` will hide these warnings, so they
+manifest when running ``import spacepy.irbempy`` (or some other
+component of SpacePy that uses irbempy).
+
+The error ``ImportError: cannot import name 'irbempylib' from
+partially initialized module 'spacepy.irbempy' (most likely due to a
+circular import)`` means the IRBEM library did not compile at
+all. This is most likely a compiler issue: either there is no Fortran
+compiler, or, when using conda on :doc:`Mac <install_mac>`, the correct
+SDK version has not been installed.
+
+The error ``RuntimeError: module compiled against API version 0x10 but
+this version of numpy is 0xe`` followed by ``ImportError:
+numpy.core.multiarray failed to import`` means that the version of
+numpy used at installation of SpacePy does not match that used at
+runtime. Check that there is only one version of numpy installed. In
+some cases ``pip`` will install another version of number to support
+the build; this was fixed in SpacePy 0.4.0 but may recur.

--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -89,6 +89,20 @@ Installs using ``setup.py`` do not require setuptools.
 Troubleshooting
 ===============
 
+pip failures
+------------
+If ``pip`` completely fails to build, a common issue is a failure in
+the isolated build environment that ``pip`` sets up. Usually this can
+be addressed by installing numpy first and eschewing the separate
+build environment::
+
+  pip install numpy
+  pip install spacepy --no-build-isolation
+
+Manually installing all dependencies (via ``pip``, ``conda``, or other
+means) and then installing the source release via ``setup.py`` is also
+an option.
+
 irbempy
 -------
 The most common failures relate to compilation of the IRBEM
@@ -108,5 +122,6 @@ this version of numpy is 0xe`` followed by ``ImportError:
 numpy.core.multiarray failed to import`` means that the version of
 numpy used at installation of SpacePy does not match that used at
 runtime. Check that there is only one version of numpy installed. In
-some cases ``pip`` will install another version of number to support
-the build; this was fixed in SpacePy 0.4.0 but may recur.
+some cases ``pip`` will install another version of numpy to support
+the build; try installing numpy separately first, and then using the
+``--no-build-isolation`` flag to ``pip``.

--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -17,10 +17,6 @@ This will install a binary build of SpacePy if available (currently
 only on Windows), otherwise it will attempt to compile. It will also
 install most dependencies.
 
-``numpy`` must be installed first as it's required for the SpacePy
-build. See :doc:`install_windows` for important notes regarding numpy
-on Windows.
-
 If you are familiar with installing Python packages, have particular
 preferences for managing an installation, or if the above doesn't
 work, refer to platform-specific instructions and the details
@@ -57,10 +53,13 @@ virtual environment, add the ``--user`` flag when installing with pip.
 Source releases are available from `PyPI
 <https://pypi.org/project/SpacePy/#files>`__ and `our github
 <https://github.com/spacepy/spacepy/releases>`__. Development versions
-are on `github <https://github.com/spacepy/spacepy>`__.
+are on `github <https://github.com/spacepy/spacepy>`__. In addition to
+downloading tarballs, the development version can be directly installed
+with::
 
+  pip install git+https://github.com/spacepy/spacepy
 
-After downloading and
+For source releases, after downloading and
 unpacking, run (a virtual environment, such as a conda environment, is
 recommended)::
 

--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -136,3 +136,18 @@ Or the package manager:
 For Python 3:
 
   sudo apt-get install python3-sphinx python3-numpydoc
+
+Raspberry Pi
+============
+SpacePy works on Raspberry Pi, using Raspberry Pi OS in 32-bit or
+64-bit flavors. A few tips:
+
+   * It is highly recommended to install all dependencies (numpy,
+     etc.)  via the system package manager ``apt-get`` rather than
+     pip, as prebuilt wheels are not generally available and compiling
+     dependencies on the Pi can take a very long time::
+
+      sudo apt-get install gfortran python3-numpy python3-scipy python3-h5py python3-matplotlib
+
+   * Similarly, if installing SpacePy via pip, use the
+     ``--no-build-isolation`` flag to use the system numpy.

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -66,7 +66,7 @@ Finally, install SpacePy::
 If you're installing as a single user (not in a virtual environment) then
 add the ``--user`` flag.
 
-You will also need the :ref:`NASA CDF library <linux_CDF>` to use
+You will also need the :ref:`NASA CDF library <install_mac_cdf>` to use
 :mod:`~spacepy.pycdf`.
 
 .. _install_mac_macports:
@@ -117,13 +117,24 @@ Then you can install SpacePy::
 If you're installing as a single user (not in a virtual environment) then
 add the ``--user`` flag.
 
-You will also need the :ref:`NASA CDF library <linux_CDF>` to use
+You will also need the :ref:`NASA CDF library <install_mac_cdf>` to use
 :mod:`~spacepy.pycdf`.
 
 If you are installing from a source distribution, you can specify the
 compiler at install time instead of using ``port select``::
 
   python3.9 setup.py install --fcompiler=gnu95 --f90exec=/opt/local/bin/gfortran-mp-11
+
+.. _install_mac_cdf:
+
+CDF
+===
+
+NASA provides `Mac binaries
+<https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest-release/macosx/>`_
+of the CDF library. Download the file ending in ``binary_signed.pkg``
+(e.g. ``CDF3_8_1-binary_signed.pkg``), double-click, and install per
+the defaults.
 
 .. _install_mac_xcode:
 

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -35,12 +35,6 @@ add the ``--user`` flag.
 You will also need the :ref:`NASA CDF library <linux_CDF>` to use
 :mod:`~spacepy.pycdf`.
 
-To install the latest code from the repository, rather than
-the latest stable release, use::
-
-   pip install git+https://github.com/spacepy/spacepy
 
 .. contents::
    :local:
-
-

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -114,6 +114,12 @@ Then you can install SpacePy::
 
   pip install spacepy
 
+If you're installing as a single user (not in a virtual environment) then
+add the ``--user`` flag.
+
+You will also need the :ref:`NASA CDF library <linux_CDF>` to use
+:mod:`~spacepy.pycdf`.
+
 If you are installing from a source distribution, you can specify the
 compiler at install time instead of using ``port select``::
 

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -38,16 +38,20 @@ You will now be in an active conda environment. (Note: the
 installation will modify your ``.zprofile`` file.)
 
 Compiling under conda `requires the MacOS 10.9 SDK
-<https://stackoverflow.com/questions/69236331/conda-macos-big-sur-ld-unsupported-tapi-file-type-tapi-tbd-in-yaml-file/>`_. It
-can be downloaded `here
+<https://stackoverflow.com/questions/69236331/
+conda-macos-big-sur-ld-unsupported-tapi-file-type-tapi-tbd-in-yaml-file/>`_
+on Intel (x86_64) Macs and `11.0 on Apple Silicon
+<https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/>`_
+(ARM/M1/M2). It can be downloaded `here
 <https://github.com/phracker/MacOSX-SDKs/releases>`_ (choose
-"MacOSX10.9.sdk.tar.xz"). Uncompress it into ``opt``, e.g.::
+"MacOSX10.9.sdk.tar.xz" or "MacOSX11.0.sdk.tar.xz"). Uncompress it
+into ``opt``, e.g.::
 
   sudo tar xf ~/Downloads/MacOSX10.9.sdk.tar.xz -C /opt
 
 Install the Fortran compiler::
 
-  conda install gfortran_osx-64
+  conda install gfortran
 
 If you do not have Xcode installed, you will be prompted with a
 message like "The xcrun command requires the command line developer
@@ -61,7 +65,8 @@ they will be installed via ``pip``)::
 
 Finally, install SpacePy::
 
-  SDKROOT=/opt/MacOSX10.9.sdk pip install spacepy
+  SDKROOT=/opt/MacOSX10.9.sdk pip install spacepy  # Intel
+  SDKROOT=/opt/MacOSX11.0.sdk pip install spacepy  # ARM
 
 If you're installing as a single user (not in a virtual environment) then
 add the ``--user`` flag.

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -2,39 +2,150 @@
 MacOS Installation
 ******************
 
-The following are performed from the command line on OSX.
+Unless otherwise noted, the commands in these instructions are run
+from the MacOS terminal (command line).
 
-Installation on OSX requires a C compiler::
+Installation requires a working Python environment and compilers. The
+two common ways to achieve this are via :ref:`conda <install_mac_conda>`
+or via :ref:`MacPorts <install_mac_macports>`. As a weak recommendation
+for choosing between them, conda may be better if your main focus is
+running Python and you need conda's easy support for multiple Python
+environments; MacPorts may be better if you want to use many of the other
+open source tools provided in MacPorts.
 
-   xcode-select --install
+Binary installers for SpacePy on Mac are in preparation for a future
+release.
 
-Our recommended (but not required) Python distribution is `Anaconda
-<https://docs.anaconda.com/anaconda/>`_ running 64-bit
-Python 3. Anaconda includes much of the scientific Python
-stack. Another excellent distribution is `Canopy
-<https://www.enthought.com/product/canopy/>`_.
+.. contents::
+   :local:
 
-Once python is installed (Anaconda assumed) install the Fortran compiler::
+.. _install_mac_conda:
 
-   conda install gfortran_osx-64
+Conda installation
+==================
+Our recommendation for `Anaconda
+<https://docs.anaconda.com/anaconda/>`_ is to use Python 3 and 64-bit
+binaries. Follow the directions to install conda and set up an
+environment; a minimal setup can be had by downloading the latest
+`miniconda
+<https://docs.conda.io/en/latest/miniconda.html>`_. Double-click the
+miniconda pkg and run through the installation process, choosing
+"install for me only". Then, at the terminal::
 
+  source ~/opt/miniconda3/bin/activate
 
-Dependencies via conda and pip
-==============================
+You will now be in an active conda environment. (Note: the
+installation will modify your ``.zprofile`` file.)
 
-Installation via ``pip`` will automatically install most Python
-dependencies (but not the :ref:`NASA CDF library <linux_CDF>`). They
-can also be installed from conda::
+Compiling under conda `requires the MacOS 10.9 SDK
+<https://stackoverflow.com/questions/69236331/conda-macos-big-sur-ld-unsupported-tapi-file-type-tapi-tbd-in-yaml-file/>`_. It
+can be downloaded `here
+<https://github.com/phracker/MacOSX-SDKs/releases>`_ (choose
+"MacOSX10.9.sdk.tar.xz"). Uncompress it into ``opt``, e.g.::
+
+  sudo tar xf ~/Downloads/MacOSX10.9.sdk.tar.xz -C /opt
+
+Install the Fortran compiler::
+
+  conda install gfortran_osx-64
+
+If you do not have Xcode installed, you will be prompted with a
+message like "The xcrun command requires the command line developer
+tools." Accept the installation and allow it to finish before
+continuing.
+
+You may optionally install SpacePy dependencies via conda (otherwise
+they will be installed via ``pip``)::
 
    conda install numpy scipy matplotlib h5py
 
-Once this is set up, ``pip install spacepy`` should just work. If
-you're installing as a single user (not in a virtual environment) then
+Finally, install SpacePy::
+
+  SDKROOT=/opt/MacOSX10.9.sdk pip install spacepy
+
+If you're installing as a single user (not in a virtual environment) then
 add the ``--user`` flag.
 
 You will also need the :ref:`NASA CDF library <linux_CDF>` to use
 :mod:`~spacepy.pycdf`.
 
+.. _install_mac_macports:
 
-.. contents::
-   :local:
+MacPorts installation
+=====================
+
+You may install :ref:`the full Xcode suite <install_mac_xcode>` and
+follow the `MacPorts guide <https://guide.macports.org/>`_; however,
+these directions should suffice to install a working Python and
+SpacePy.
+
+Installing the Xcode command line tools is recommended before proceeding::
+
+  xcode-select --install
+
+Download the `MacPorts installer
+<https://www.macports.org/install.php>`_ and double-click the pkg to
+perform the installation. (Note this modifies your ``.zprofile``
+environment file.)
+
+Install Python and the needed compilers. You need to specify a
+version; at this time, Python 3.9 and gcc 11 are reasonable choices::
+
+  sudo port install gcc11  # Includes gfortran
+  sudo port install python39
+  sudo port install py39-pip
+  # Installing the following is optional; pip will automatically install
+  sudo port install py39-numpy py39-scipy py39-h5py py39-matplotlib
+
+If you have not already installed the Xcode command line tools, you
+will be prompted to do so. In that case, it is suggested to accept the
+tools installation, and then quit the port command and restart once
+the tools are installed.
+
+To install via ``pip``, default versions of Python and gcc must be set::
+
+  sudo port select --set python python39
+  rehash #recalculate the pathing to not get system python
+  sudo port select --set python3 python39
+  sudo port select --set pip pip39
+  sudo port select --set gcc mp-gcc11
+
+Then you can install SpacePy::
+
+  pip install spacepy
+
+If you are installing from a source distribution, you can specify the
+compiler at install time instead of using ``port select``::
+
+  python3.9 setup.py install --fcompiler=gnu95 --f90exec=/opt/local/bin/gfortran-mp-11
+
+.. _install_mac_xcode:
+
+Xcode installation
+==================
+Installation of the full Xcode package is not required simply for
+SpacePy; however, if you are interested in regular compiler use, it
+may be useful. If you choose to install the full Xcode package,
+perform these steps before installing conda or macports via the
+directions above.
+
+  * Create and log in to an Apple developer account at
+    https://developer.apple.com/
+  * Check the `Xcode release notes
+    <https://developer.apple.com/documentation/xcode-release-notes/>`_
+    to find the latest version of Xcode supported on your version of
+    MacOS.
+  * From the `more downloads
+    <https://developer.apple.com/download/all/>`_ section of the Apple
+    Developer site, search for and download that version of Xcode.
+  * Double-click on the downloaded .xip file to open with the archive
+    utility and extract the Xcode app.
+  * Drag the resulting Xcode icon into Applications
+  * From the `more downloads
+    <https://developer.apple.com/download/all/>`_ section of the Apple
+    Developer site, search for the Xcode command line tools for the
+    same version of Xcode
+  * Open the dmg file with the command line tools, open the resulting
+    mounted disk image, and double-click the pkg file to install.
+
+Proceed with the installation of conda or MacPorts and SpacePy

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -47,6 +47,10 @@ of the latter functions, :func:`~spacepy.coordinates.sph2car` and
 
 Major bugfixes
 **************
+The installer has been updated to address certain build issues,
+particularly on Mac. The Mac :doc:`installation directions
+<install_mac>` have been completely rewritten.
+
 :mod:`~spacepy.pycdf` has been updated for Apple Silicon (ARM/M1);
 Python 3.8 is required for this support.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,9 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = ["setuptools", "wheel",
+    "numpy ~= 1.10.0 ; python_version == '3.5'",
+    "numpy ~= 1.12.0 ; python_version == '3.6'",
+    "numpy ~= 1.15.0 ; python_version == '3.7'",
+    "numpy ~= 1.17.0 ; python_version == '3.8'",
+    "numpy ~= 1.18.0 ; python_version == '3.9'",
+    "numpy ~= 1.21.0 ; python_version >= '3.10'",
+    ]

--- a/setup.py
+++ b/setup.py
@@ -572,12 +572,11 @@ class build(_build):
             'intel': ['-Bstatic', '-assume', '2underscores', '-O2', '-fPIC'],
             'intelem': ['-Bdynamic', '-O2', '-fPIC'],
             }[fcompiler]
-        if fcompiler == 'gnu':
-            if bit == 64:
+        if fcompiler == 'gnu' and bit == 64:
                 compflags = ['-m64'] + compflags
         if not sys.platform.startswith('win') and fcompiler == 'gnu95' \
-           and not os.uname()[4].startswith('arm'):
-            # Raspberry Pi doesn't have this switch and assumes 32-bit
+           and not os.uname()[4].startswith(('arm', 'aarch64')):
+            # Raspberry Pi doesn't have or need this switch
             compflags = ['-m{0}'.format(bit)] + compflags
         if fcompiler.startswith('intel'):
             if bit == 32:

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,10 @@ def f2py_options(fcompiler, dist=None):
                 fcomp.command_vars._conf_keys[k] = ('exe.{0}'.format(k),) +  \
                                                    oldval[1:]
     fcomp = fcomp()
-    fcomp.customize(dist)
+    try:
+        fcomp.customize(dist)
+    except numpy.distutils.fcompiler.CompilerNotFound:
+        return False
     if 'LDFLAGS' in os.environ:
         env = os.environ.copy()
         currflags = os.environ['LDFLAGS'].split()
@@ -504,7 +507,12 @@ class build(_build):
             os.path.join(builddir, 'source', 'wrappers_{0}.inc'.format(bit)),
             os.path.join(builddir, 'source', 'wrappers.inc'.format(bit)))
 
-        f2py_env, fcompexec = f2py_options(fcompiler, self.distribution)
+        res  = f2py_options(fcompiler, self.distribution)
+        if not res:
+           warnings.warn('Unable to load compiler {}\n'
+                         'IRBEM will not be available.'.format(fcompiler))
+           return
+        f2py_env, fcompexec = res
 
         # compile irbemlib
         olddir = os.getcwd()

--- a/setup.py
+++ b/setup.py
@@ -640,6 +640,18 @@ class build(_build):
             f2py_flags.append('--f77exec={0}'.format(self.f77exec))
         if self.f90exec:
             f2py_flags.append('--f90exec={0}'.format(self.f90exec))
+        if sys.platform == 'darwin':
+            if 'SDKROOT' in os.environ:
+                sdkroot = os.environ['SDKROOT']
+                f2py_env['LDFLAGS'] = '{} -isysroot {}'.format(
+                    f2py_env['LDFLAGS'], sdkroot)
+            else:
+                sdkroot = os.path.join(os.sep, 'Library',
+                    'Developer', 'CommandLineTools', 'SDKs', 'MacOSX.sdk')
+            sdklibs = os.path.join(sdkroot, 'usr', 'lib')
+            # Explicitly include path for -lSystem
+            if os.path.isdir(sdklibs):
+                f2py_flags.append('-L{}'.format(sdklibs))
         try:
             subprocess.check_call(
                 self.f2py + ['-c', 'irbempylib.pyf', 'source/onera_desp_lib.f',

--- a/setup.py
+++ b/setup.py
@@ -648,6 +648,8 @@ class build(_build):
             warnings.warn(
                 'irbemlib module failed. '
                 'Try a different Fortran compiler? (--fcompiler)')
+            os.chdir(olddir)
+            return
 
         #All matching outputs
         created_libfiles = [f for f in libfiles if os.path.exists(f)]

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -531,8 +531,10 @@ class Library(object):
                 os.getenv('SystemDrive', 'c:') + root + extra
                 for root in ['', '\\Program Files', '\\Program Files (x86)']
                 for extra in ['\\CDF Distribution\\', '\\CDF_Distribution\\']],
-            'darwin': ['/Applications/', '/usr/local/',
-                       os.path.expanduser('~')],
+            'darwin': ['/Applications/', os.path.expanduser('~/Applications/'),
+                       '/Applications/cdf/',
+                       os.path.expanduser('~/Applications/cdf/'),
+                       '/usr/local/', os.path.expanduser('~')],
             'linux2': ['/usr/local/', os.path.expanduser('~')],
             'linux': ['/usr/local/', os.path.expanduser('~')],
         }

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -141,13 +141,14 @@ class SpacepyDirTests(unittest.TestCase):
         wd = os.getcwd()
         try:
             os.chdir(self.td)
+            cwd = os.path.abspath('.')  # Mac puts you in a different dir
             os.environ['SPACEPY'] = ''
-            self.assertEqual(os.path.join(self.td, '.spacepy'),
+            self.assertEqual(os.path.join(cwd, '.spacepy'),
                              spacepy._find_spacepy_dir())
             os.environ['SPACEPY'] = 'spacepy'
-            self.assertEqual(os.path.join(self.td, 'spacepy', '.spacepy'),
+            self.assertEqual(os.path.join(cwd, 'spacepy', '.spacepy'),
                              spacepy._find_spacepy_dir())
-            self.assertTrue(os.path.isdir(os.path.join(self.td, 'spacepy')))
+            self.assertTrue(os.path.isdir(os.path.join(cwd, 'spacepy')))
         finally:
             os.chdir(wd)
 


### PR DESCRIPTION
This PR makes some smaller installer changes to make life easier on the Mac, but more importantly it completely rewrites the Mac documentation to reflect the current (onerous) process of getting a working environment on the Mac.

Part of this is changing the build requirement to the minimum version of numpy available, thus closes #638 (which manifested more frequently on Mac.) This also addresses the ``System`` linking, which is related to #583 but I'm not ready to close it based just on this PR.

Other changes made in the course of this (largely coming about from testing install on various ARM platforms):

 * pycdf searches more widely on Mac. In addition to looking in /Applications/cdf-*version*, it will look in /Applications/cdf/cdf-*version*. It will also look in both locations relative to the user's home directory, as this is where the "install only for me" option puts the distribution.
 * The irbem build has always just raised a warning on failure and moved on, which results in a message printed to console. The only case where this didn't happen is if there was no Fortran compiler installed at all. This case is now caught and treated just like any other irbem failure to build. Note that pip eats these warnings, so people with no Fortran compiler installing via pip would silently wind up with a broken irbem. This is, honestly, the situation in so many cases anyhow, that "just giving a working SpacePy without a Fortran compiler" seems better, particularly with coordinates and lanlstar no longer requiring Fortran.

To test pip installs of this branch, use:
```
pip install git+https://github.com/jtniehof/spacepy.git@mac_install
```

Or, on conda with the correct SDK in place:
```
SDKROOT=/opt/MacOSX10.9.sdk pip install git+https://github.com/jtniehof/spacepy.git@mac_install
```

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
