### PR TITLE
Small CDF fixes for 0.4.0

### DIFF
--- a/Doc/source/pycdf.rst
+++ b/Doc/source/pycdf.rst
@@ -281,6 +281,45 @@ All encoding and decoding can also be skipped using the
 however, without encoding, only :class:`bytes` can be written to
 string variables.
 
+Troubleshooting
+===============
+Cannot load CDF C library
+^^^^^^^^^^^^^^^^^^^^^^^^^
+pycdf requires the standard NASA CDF library; it can be installed
+after SpacePy. See specific instructions for :ref:`Linux <linux_CDF>`,
+:ref:`Mac <install_mac_cdf>`, and :ref:`Windows <windows_CDF>`.
+
+The error ``Cannot load CDF C library`` indicates pycdf cannot find
+this library. pycdf searches in locations where the library is
+installed by default; if the library is not found, set the ``CDF_LIB``
+environment variable to the directory containing the library file
+(.dll, .dylib, or .so) before importing pycdf.
+
+ZLIB_ERROR when opening a CDF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The error message ``ZLIB_ERROR: Error during ZLIB decompression`` most
+commonly occurs when opening a CDF which has been compressed with
+whole-file compression. In this case, it must be unzipped into a
+temporary location (details are in the `CDF User's Guide
+<https://cdf.gsfc.nasa.gov/html/cdf_docs.html>`_).
+
+The temporary location is specified by environment variables, most
+commonly ``CDF_TMP``. It appears that, particularly on Windows, some
+installers of the library may set this to a location which is not
+writeable. In that case, the solution is to change the environment
+variable to a writeable location.
+
+On Windows, environment variables are set in the System Properties
+control panel. Click the "Environment Variables" button on the
+Advanced tab. Usually a good value for ``CDF_TMP`` is
+``C:\Users\USERNAME\AppData\Local\Temp``. If ``CDF_TMP`` is not
+set, variables ``TMP`` and ``TEMP`` will be used, so those values are
+worth checking. Values starting with ``C:\WINDOWS\system32\config``
+are unlikely to work.
+
+On Unix, including MacOS, ``CDF_TMP`` is used if set; otherwise
+``TMPDIR``.
+
 Access to CDF constants and the C library
 =========================================
 Constants defined in cdf.h and occasionally useful in accessing CDFs are

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -54,6 +54,12 @@ particularly on Mac. The Mac :doc:`installation directions
 :mod:`~spacepy.pycdf` has been updated for Apple Silicon (ARM/M1);
 Python 3.8 is required for this support.
 
+:mod:`~spacepy.pycdf` contains a time conversion workaround for
+versions of the NASA CDF library before 3.8.0.1. Non-integral epoch
+values close to midnight would erroneously return the following day;
+:meth:`~spacepy.pycdf.Library.epoch_to_datetime` now returns the
+correct value on all CDF library versions.
+
 The IRBEM backend for coordinate transformations has been updated to
 correct the specification of transformations through the J2000 and TOD
 systems, including correctly setting the GEI and TOD systems to be

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -251,6 +251,21 @@ class NoCDF(unittest.TestCase):
         expected = numpy.array(dts)
         numpy.testing.assert_array_equal(expected, result)
 
+    def testEpochToDatetimeRounding(self):
+        """Epoch-to-datetime near end of day, check rounding bug"""
+        epochs = [63570441599999.984,
+                  63570440599999.984,
+                  ]
+        expected = [(2014, 6, 19, 23, 59, 59, 999000),
+                    (2014, 6, 19, 23, 43, 19, 999000),
+                    ]
+        expected = [datetime.datetime(*dt) for dt in expected]
+        for epoch, dt in zip(epochs, expected):
+            self.assertEqual(dt, cdf.lib.epoch_to_datetime(epoch))
+        numpy.testing.assert_array_equal(
+            cdf.lib.v_epoch_to_datetime(epochs),
+            expected)
+
     def testDatetimeToTT2000(self):
         if not cdf.lib.supports_int8:
             self.assertRaises(NotImplementedError, cdf.lib.datetime_to_tt2000,


### PR DESCRIPTION
This PR bundles two small CDF changes from the 0.4.0 project board:

1. Documents the use of `CDF_TMP` and the zlib errors that can result. (Closes #570). This is done with a new "troubleshooting" section of the pycdf docs.
2. Works around a bug in the CDF library when doing epoch conversions near end of day (Closes #285). This was fixed in the latest NASA library, but exists at least as far back as 3.5, so a workaround seems prudent for now. It's a fairly simple fix: Epochs are milliseconds represented as doubles, with millisecond resolution. So the fractional part is always sub-Epoch resolution, and the CDF library always truncates it. The fix is to check for the bug and, if so, truncate Epochs passed in by casting to int. ctypes automatically casts back to a double on the call.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
