### PR TITLE
Installer-related fixes: Windows dll names; document pip cache clearing

### DIFF
--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -89,6 +89,8 @@ Installs using ``setup.py`` do not require setuptools.
 Troubleshooting
 ===============
 
+.. _install_pip_failures:
+
 pip failures
 ------------
 If ``pip`` completely fails to build, a common issue is a failure in
@@ -103,6 +105,13 @@ Manually installing all dependencies (via ``pip``, ``conda``, or other
 means) and then installing the source release via ``setup.py`` is also
 an option.
 
+``pip`` will also cache packages; unfortunately sometimes it will use
+a cached package which is incompatible with the current
+environment. In that case, try clearing the cache first, so all
+locally-compiled packages are rebuilt::
+
+  pip cache purge
+
 irbempy
 -------
 The most common failures relate to compilation of the IRBEM
@@ -115,7 +124,8 @@ partially initialized module 'spacepy.irbempy' (most likely due to a
 circular import)`` means the IRBEM library did not compile at
 all. This is most likely a compiler issue: either there is no Fortran
 compiler, or, when using conda on :doc:`Mac <install_mac>`, the correct
-SDK version has not been installed.
+SDK version has not been installed. This may also result from
+:ref:`pip caching <install_pip_failures>`.
 
 The error ``RuntimeError: module compiled against API version 0x10 but
 this version of numpy is 0xe`` followed by ``ImportError:

--- a/spacepy/lib.py
+++ b/spacepy/lib.py
@@ -99,7 +99,7 @@ def load_lib():
     """
     libdir = os.path.dirname(os.path.abspath(__file__))
     if sys.platform == 'win32':
-        libnames = ['spacepy.dll']
+        libnames = ['spacepy.dll', 'libspacepy.dll.a']
     elif sys.platform == 'darwin':
         libnames = ['libspacepy.dylib', 'libspacepy.so',
                   'spacepy.dylib', 'spacepy.so']


### PR DESCRIPTION
This PR fixes two issues found in testing of 0.4.0rc1.

First, it documents clearing the pip cache. The pip cache is stored at the user level, so it doesn't separate conda and macports builds. This causes problems if mixing them, which is another manifestation of our irbem "circular import" bug.

Second, something in the Windows build chain has changed the name of shared libraries since the 0.3.0 release. Previously libspacepy was `spacepy.dll`. Now, on Python 3.6 it's still `spacepy.dll`; on 3.7+, it's `libspacepy.dll.a`. I don't know what changed; the same version of mingw32 (currently 5.3.0) is used for all current builds, so the difference isn't there. This comes from `compiler.shared_lib_extension` in distutils. The solution is to update `lib.py` to look for the `libspacepy.dll.a` name as well as `spacepy.dll`. Otherwise libspacepy doesn't load.

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
