### PR TITLE
Remove Unicode from IRBEM source and check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,13 +165,26 @@ jobs:
         python setup.py build
         cd tests; . ${HOME}/cdf/bin/definitions.B; xvfb-run python test_all.py -v
 
+  irbem-unicode:
+    name: Check for Unicode in IRBEM source
+    runs-on: ubuntu-20.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Unicode check
+        run: (! file irbem-lib-*/*.f irbem-lib-*/source/*.f | grep -q Unicode )
+        working-directory: ${{ github.workspace }}/spacepy/irbempy/
+
 # See https://github.community/t/status-check-for-a-matrix-jobs/127354/7
   all-tests:
     name: All tests
     if: ${{ always() }}
     runs-on: ubuntu-20.04
-    needs: test
+    needs: [test, irbem-unicode]
     steps:
       - name: Check test matrix status
         if: ${{ needs.test.result != 'success' }}
+        run: exit 1
+      - name: Check IRBEM unicode status
+        if: ${{ needs.irbem-unicode.result != 'success' }}
         run: exit 1

--- a/spacepy/irbempy/irbem-lib-20220829-dfb9d26/source/Tsy_and_Sit07_Jul2017.f
+++ b/spacepy/irbempy/irbem-lib-20220829-dfb9d26/source/Tsy_and_Sit07_Jul2017.f
@@ -21,7 +21,7 @@ C                  high-resolution data-based magneticfield model, J. Geophys. R
 C                  doi:10.1029/2007JA012260.
 C
 C              (2) Sitnov, M. I., N. A. Tsyganenko, A. Y. Ukhorskiy, B. J. Anderson, H. Korth,
-C                  A. T. Y. Lui, and P. C. Brandt (2010),Empirical modeling of a CIR‐driven magnetic
+C                  A. T. Y. Lui, and P. C. Brandt (2010),Empirical modeling of a CIR-driven magnetic
 C                  storm, J. Geophys. Res., 115, A07231, doi:10.1029/2009JA015169.
 C
 C  Inputs:

--- a/spacepy/irbempy/irbem-lib-20220829-dfb9d26/source/onera_desp_lib.f
+++ b/spacepy/irbempy/irbem-lib-20220829-dfb9d26/source/onera_desp_lib.f
@@ -241,7 +241,7 @@ c
             GOTO 99
           endif
 c
-c Compute Bmin assuming 90� PA at S/C
+c Compute Bmin assuming 90deg PA at S/C
          k_l=0
            IPA=1
            CALL calcul_Lstar_opt(t_resol,r_resol,xGEO
@@ -1761,7 +1761,7 @@ c      collect the B components for return in maginput() array
          maginput(16)=baddata
       ENDIF
 c
-c Compute Bmin assuming 90� PA at S/C
+c Compute Bmin assuming 90deg PA at S/C
          k_l=0
            IPA=1
 c             all returned values except Bmin are subsequently overwritten


### PR DESCRIPTION
We keep on trying to keep the Unicode out of the IRBEM source but it keeps creeping back in (#631 this time). This has caused some problems in the past (#190). #214 passes compiler options to make the actual Fortan compiler happy about it.

However, some of the f2py work done before compiling IRBEM is done entirely in numpy Python code, so is unaffected by the fixes in #214. In particular, it will fail if the environment variable ``LANG`` is unset, and probably for certain values of set. (Default in my environment is ``en_US.UTF-8``.

This PR does two things:
- Removes the Unicode characters that were added in the regression of #631.
- Adds a CI check for Unicode in the IRBEM source, so we can catch more easily if this happens in upstream IRBEM again. This was committed, pushed, and tested before the fix (so I could verify it indeed "failed" in the current state.)

Obviously the best thing is for this to remain fixed upstream, but this gets us back running and provides a backstop.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
