### PR TITLE
Rename default branch to main (Closes #476)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Thank you so much for your PR!  The SpacePy community appreciates your
 help and feedback.  To help us review your contribution, please
 consider the following points:
 
-- Do not create the PR out of master, but out of a separate branch.
+- Do not create the PR out of main, but out of a separate branch.
 
 - The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
   Avoid non-descriptive titles such as "Bug fix" or "Updates".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   schedule:
     - cron: '37 7 * * *'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [ opened, synchronize, reopened, ready_for_review ]
   # Required for manual triggering
   workflow_dispatch:

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -136,7 +136,7 @@ pins its build system to the oldest numpy it wishes to support".
 ABI is in numpy/core/setup_common.py and there's no history, so going
 through the git tags for each numpy release gives:
 
-1.4 through current master : 0x01000009
+1.4 through current main : 0x01000009
 
 It looks like ABI version is a complete break: if it changes, old
 modules will no longer work. However, the API version is backward
@@ -230,7 +230,7 @@ https://help.github.com/en/articles/creating-releases
 
 On the code tab, click on "n releases" (on the right column, below
 "about"). Click "Draft a new release." Make the tag
-"release-x.y.z" and hopefully the target will be master if it's up to
+"release-x.y.z" and hopefully the target will be main if it's up to
 date. The most consistent with what we've done so far (which is not
 necessarily the best) is to use just "x.y.z" as the title with nothing
 the "describe."

--- a/Doc/source/ci.rst
+++ b/Doc/source/ci.rst
@@ -5,9 +5,9 @@ Continuous Integration
 SpacePy uses `GitHub Actions <https://docs.github.com/en/actions>`_
 for continuous integration. Most of the relevant information is
 checked into the repository: the configuration file `CI.yml
-<https://github.com/spacepy/spacepy/blob/master/.github/workflows/ci.yml>`_
+<https://github.com/spacepy/spacepy/blob/main/.github/workflows/ci.yml>`_
 manages the CI process, which ultimately runs `the unit tests
-<https://github.com/spacepy/spacepy/blob/master/tests/test_all.py>`_. However
+<https://github.com/spacepy/spacepy/blob/main/tests/test_all.py>`_. However
 a few elements of the setup are not in the repository and are
 documented here. This may be useful if this ever has to be set up in
 the future, or if you want to run SpacePy CI tests on your fork before
@@ -21,7 +21,7 @@ Initial run
 
 A workflow cannot be run `until it has been run once against the
 default branch <https://github.community/t/
-workflow-dispatch-event-not-working/128856/2>`_ (``master``). This makes
+workflow-dispatch-event-not-working/128856/2>`_ (``main``). This makes
 it somewhat hard to test the workflow before merging; in SpacePy this was
 handled by merging a tiny workflow first (PR `496 <https://github.com/
 spacepy/spacepy/pull/496>`_).

--- a/Doc/source/install_windows.rst
+++ b/Doc/source/install_windows.rst
@@ -40,7 +40,7 @@ by ``m2w64-gcc-fortran``.
 
 If you have difficulties, it may be useful to reference the `build
 scripts
-<https://github.com/spacepy/spacepy/tree/master/developer/scripts>`_
+<https://github.com/spacepy/spacepy/tree/main/developer/scripts>`_
 the SpacePy developers use.
 
 .. _windows_CDF:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3252523.svg)](https://doi.org/10.5281/zenodo.3252523)
-[![Build Status](https://github.com/spacepy/spacepy/workflows/CI/badge.svg?branch=master)](https://github.com/spacepy/spacepy/actions?query=workflow%3ACI)
+[![Build Status](https://github.com/spacepy/spacepy/workflows/CI/badge.svg?branch=main)](https://github.com/spacepy/spacepy/actions?query=workflow%3ACI)
 
 # SpacePy
 
@@ -15,7 +15,7 @@ SpacePy is a package for Python, targeted at the space sciences, that aims to ma
 
 The SpacePy project seeks to promote accurate and open research standards by providing an open environment for code development. In the space physics community there has long been a significant reliance on proprietary languages that restrict free transfer of data and reproducibility of results. By providing a comprehensive, open-source library of widely-used analysis and visualization tools in a free, modern and intuitive language, we hope that this reliance will be diminished.
 
-To help foster an open and welcoming environment, we have adopted a [code of conduct](https://github.com/spacepy/spacepy/blob/master/code-of-conduct.md) that we encourage members of the SpacePy community to read and follow.
+To help foster an open and welcoming environment, we have adopted a [code of conduct](https://github.com/spacepy/spacepy/blob/main/code-of-conduct.md) that we encourage members of the SpacePy community to read and follow.
 
 ## Getting SpacePy
 
@@ -75,4 +75,4 @@ Certain modules may provide additional citations in the ```__citation__``` attri
 For acknowledging SpacePy, please provide the URL to our github repository. [github.com/spacepy/spacepy](https://github.com/spacepy/spacepy)
 
 ## Changes
-Changes in the released version of SpacePy are provided in the [release notes](https://spacepy.github.io/release_notes.html). For changes since the latest release, see the [repository version](https://github.com/spacepy/spacepy/blob/master/Doc/source/release_notes.rst).
+Changes in the released version of SpacePy are provided in the [release notes](https://spacepy.github.io/release_notes.html). For changes since the latest release, see the [repository version](https://github.com/spacepy/spacepy/blob/main/Doc/source/release_notes.rst).


### PR DESCRIPTION
This PR supports [renaming the default branch](https://github.com/github/renaming/) from ``master`` to ``main``. The actual rename is a configuration change that will be done as soon as this is merged. Closes #476.

GitHub automatically deals with most of this, including repointing PRs. Local clones of a repo and forks in GitHub will need to make small changes. Popups appear on the SpacePy repo in GitHub and on any forks noting the change. The [GitHub documentation](https://github.com/github/renaming/) on this is very good.

Mostly this is documentation changes and one CI change.

This does not remove all references to ``master`` in the codebase, just renames the default branch--some of the rest should be easily eliminated in future work; some may need to stay for consistency with other projects. But those are matters for another day.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
