### PR TITLE
Enhancements to datamodel.toCDF

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -45,6 +45,8 @@ now support reading from gzipped input files; filenames ending with
 :mod:`.pycdf` :meth:`~.pycdf.Library.set_backward` now returns the prior
 state of backward compatibility mode.
 
+:func:`~.datamodel.toCDF` now supports writing backward-compatible CDFs.
+
 Other changes
 *************
 :func:`~.datamodel.toCDF` now only accepts valid keyword arguments.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -42,6 +42,9 @@ New features
 now support reading from gzipped input files; filenames ending with
 ``.gz`` are assumed to be gzipped.
 
+:mod:`.pycdf` :meth:`~.pycdf.Library.set_backward` now returns the prior
+state of backward compatibility mode.
+
 Other changes
 *************
 :func:`~.datamodel.toCDF` now only accepts valid keyword arguments.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -47,6 +47,11 @@ state of backward compatibility mode.
 
 :func:`~.datamodel.toCDF` now supports writing backward-compatible CDFs.
 
+Major bugfixes
+**************
+:func:`~.datamodel.toCDF` handling of time types other than TT2000 has
+been fixed.
+
 Other changes
 *************
 :func:`~.datamodel.toCDF` now only accepts valid keyword arguments.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -42,6 +42,10 @@ New features
 now support reading from gzipped input files; filenames ending with
 ``.gz`` are assumed to be gzipped.
 
+Other changes
+*************
+:func:`~.datamodel.toCDF` now only accepts valid keyword arguments.
+
 0.4 Series
 ==========
 0.4.1 (2022-09-15)

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -243,6 +243,7 @@ class Library(object):
         'CDF_TT2000_to_UTC_EPOCH': [ctypes.c_double, ctypes.c_longlong],
         'CDF_TT2000_to_UTC_EPOCH16': [ctypes.c_double, ctypes.c_longlong,
                                       ctypes.POINTER(ctypes.c_double * 2)],
+        'CDFgetFileBackward': [ctypes.c_int],
         'CDFlib': [ctypes.c_long, ctypes.c_long],
         'CDFsetFileBackward': [None, ctypes.c_long],
         'computeEPOCH': [ctypes.c_double] + [ctypes.c_long] * 7,
@@ -630,11 +631,30 @@ class Library(object):
 
         Parameters
         ==========
-        backward : boolean
-            Set backward compatible mode if True; clear it if False.
+        backward : bool, optional
+            Set backward compatible mode if True; clear it if False. If not
+            specified, will not change current setting.
+
+            .. versionchanged:: 0.5.0
+               Added ability to not change setting (previously defaulted
+               to setting backward compatible).
+
+        Returns
+        =======
+        bool
+            Previous value of backward-compatible mode.
+
+            .. versionadded:: 0.5.0
+
+        Raises
+        ======
+        ValueError : if backward=False and underlying CDF library is V2
         """
-        self._library.CDFsetFileBackward(const.BACKWARDFILEon if backward
-                                         else const.BACKWARDFILEoff)
+        former = bool(self._library.CDFgetFileBackward())
+        if backward is not None:
+            self._library.CDFsetFileBackward(
+                const.BACKWARDFILEon if backward else const.BACKWARDFILEoff)
+        return former
 
     def epoch_to_datetime(self, epoch):
         """

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -799,7 +799,7 @@ class converterTestsCDF(unittest.TestCase):
     def test_toCDF_method(self):
         """Convert to CDF, using the method, catching #404"""
         a = dm.SpaceData({'dat': dm.dmarray([1, 2, 3])})
-        a.toCDF(self.testfile, mode='a')
+        a.toCDF(self.testfile)
         newobj = dm.fromCDF(self.testfile)
         np.testing.assert_array_equal([1, 2, 3], newobj['dat'])
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -28,6 +28,7 @@ import warnings
 
 import spacepy_testing
 import spacepy.datamodel as dm
+import spacepy.pycdf
 import spacepy.time as spt
 import numpy as np
 
@@ -802,6 +803,27 @@ class converterTestsCDF(unittest.TestCase):
         a.toCDF(self.testfile)
         newobj = dm.fromCDF(self.testfile)
         np.testing.assert_array_equal([1, 2, 3], newobj['dat'])
+
+    def test_toCDF_unset_backward(self):
+        """Convert to CDF, default not backward compatible"""
+        dm.toCDF(self.testfile, self.SDobj)
+        with spacepy.pycdf.CDF(self.testfile) as f:
+            self.assertFalse(f.backward)
+
+    def test_toCDF_not_backward(self):
+        """Convert to CDF, force not backward compatible"""
+        dm.toCDF(self.testfile, self.SDobj, backward=False)
+        with spacepy.pycdf.CDF(self.testfile) as f:
+            self.assertFalse(f.backward)
+
+    def test_toCDF_backward(self):
+        """Convert to CDF, force backward compatible"""
+        # Can't use 64-bit int if backward compat
+        self.SDobj['var'] = np.require(self.SDobj['var'], dtype=np.int32)
+        dm.toCDF(self.testfile, self.SDobj, backward=True)
+        with spacepy.pycdf.CDF(self.testfile) as f:
+            self.assertTrue(f.backward)
+
 
 class JSONTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -692,7 +692,8 @@ class MakeCDF(unittest.TestCase):
 
     def testCreateCDFBackward(self):
         """Try a backward-compatible CDF"""
-        cdf.lib.set_backward(True)
+        former = cdf.lib.set_backward(True)
+        self.assertFalse(former)
         newcdf = cdf.CDF(self.testfspec, '')
         (ver, rel, inc) = newcdf.version()
         backward = newcdf.backward
@@ -700,8 +701,10 @@ class MakeCDF(unittest.TestCase):
         os.remove(self.testfspec)
         self.assertEqual(2, ver)
         self.assertTrue(backward)
+        self.assertTrue(cdf.lib.set_backward())
 
-        cdf.lib.set_backward(False)
+        former = cdf.lib.set_backward(False)
+        self.assertTrue(former)
         newcdf = cdf.CDF(self.testfspec, '')
         (ver, rel, inc) = newcdf.version()
         backward = newcdf.backward

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -620,9 +620,9 @@ class VariablesTestsNew(ISTPTestsBase):
 
     def setUp(self):
         """Disable backward-compat before making test CDF"""
-        spacepy.pycdf.lib.set_backward(False)
+        oldback = spacepy.pycdf.lib.set_backward(False)
         super(VariablesTestsNew, self).setUp()
-        spacepy.pycdf.lib.set_backward(True)
+        spacepy.pycdf.lib.set_backward(oldback)
 
     def testFillvalEpoch16(self):
         """Test for fillval being okay with epoch16"""
@@ -828,11 +828,11 @@ class VarBundleChecksBase(unittest.TestCase):
     def setUp(self):
         """Setup: make an empty, open, writeable CDF"""
         self.tempdir = tempfile.mkdtemp()
-        spacepy.pycdf.lib.set_backward(False)
+        oldback = spacepy.pycdf.lib.set_backward(False)
         self.outcdf = spacepy.pycdf.CDF(os.path.join(
             self.tempdir, 'source_descriptor_datatype_19990101_v00.cdf'),
                                      create=True)
-        spacepy.pycdf.lib.set_backward(True)
+        spacepy.pycdf.lib.set_backward(oldback)
         self.incdf = spacepy.pycdf.CDF(os.path.join(
             spacepy_testing.testsdir, self.testfile))
         # Same in this instance, some tests may distinguish


### PR DESCRIPTION
This PR fixes several issues in datamodel.toCDF:

- Converts to normal keyword arguments
- Fixes handling of the ``backward`` kwarg, which was previously ignored (always set not-backward-compatible mode). This also involved improving set_backward in pycdf to return the current state.
- Fixes the specifying of time types, based on discussion in #652. 0.3.0 basically forced TT2000, since that became the new default type. Now if the TT2000 kwarg is False, EPOCH is used. (Not Epoch16, since it's actually very hard to force "Epoch or Epoch16").

Once #652 is merged, this is going to conflict terribly. I'll fix it at that point. I think it makes sense to merge #652 first though.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
