### PR TITLE
Fix Sphinx warnings; build docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,16 +172,103 @@ jobs:
         run: (! file irbem-lib-*/*.f irbem-lib-*/source/*.f | grep -q Unicode )
         working-directory: ${{ github.workspace }}/spacepy/irbempy/
 
+  docs:
+    name: Build docs
+    runs-on: ${{ matrix.os }}
+    needs: [test]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.6"
+            os: ubuntu-20.04
+            numpy-version: "~=1.15.1"
+            piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 sphinx~=1.8.0 numpydoc"
+            cflags: "-Wno-error=format-security"
+            cdf-version: "3.5.1"
+            cdf-munged-version: "35_1"
+            dep-strategy: "oldest"
+          - python-version: "3.10"
+            os: ubuntu-20.04
+            numpy-version: ">=1.21.0"
+            piplist: "python-dateutil scipy matplotlib h5py astropy sphinx numpydoc"
+            cflags: ""
+            cdf-version: "3.8.1"
+            cdf-munged-version: "38_1"
+            dep-strategy: "newest"
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Get Week
+      id: get-week
+      run: |
+        echo "::set-output name=week::$(/bin/date -u "+%G%V")"
+      shell: bash
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        # Different pip cache for docs (includes numpydoc, sphinx)
+        key: docs-pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-strategy }}
+        restore-keys: |
+          docs-pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
+          docs-pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
+          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.dep-strategy }}
+          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
+          pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
+    - name: Cache cdf
+      uses: actions/cache@v2
+      with:
+        path: ~/cdf
+        # Force-expire the CDF cache weekly
+        key: cdf-v${{ env.cdf-cache-version}}-${{ matrix.cdf-version }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
+    - name: Install dependencies
+      env:
+        NUMPY_VERSION: ${{ matrix.numpy-version }}
+        PIPLIST: ${{ matrix.piplist }}
+        CFLAGS: ${{ matrix.cflags }}
+        CDF_VER: ${{ matrix.cdf-munged-version }}
+      run: |
+        sudo apt-get update -qq
+        # Needed for scipy versions without binary wheels
+        sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb libblas-dev liblapack-dev
+        python -m pip install --upgrade pip
+        # This allows pip to build (and thus cache) binary wheels
+        pip install wheel
+        pip install --force-reinstall "numpy${NUMPY_VERSION}"
+        # Make sure new packages don't override numpy version
+        pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
+        pip freeze
+        if [ ! -d ${HOME}/cdf ]; then wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${CDF_VER}/linux/cdf${CDF_VER}-dist-cdf.tar.gz; tar xzf cdf${CDF_VER}-dist-cdf.tar.gz; cd cdf${CDF_VER}-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
+# Per https://github.com/actions/checkout/issues/15, this gets the MERGE
+# commit of the PR, not just the tip of the PR.
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: Build spacepy and docs
+      working-directory: ${{ github.workspace }}
+      run: |
+        python setup.py build
+        cd Doc
+        . ${HOME}/cdf/bin/definitions.B
+        make html | tee doc_log.txt
+        (! tail -n 20 doc_log.txt | grep -E -q 'build succeeded, [0-9]+ warnings' )
+      shell: bash
+
 # See https://github.community/t/status-check-for-a-matrix-jobs/127354/7
   all-tests:
     name: All tests
     if: ${{ always() }}
     runs-on: ubuntu-20.04
-    needs: [test, irbem-unicode]
+    needs: [test, irbem-unicode, docs]
     steps:
       - name: Check test matrix status
         if: ${{ needs.test.result != 'success' }}
         run: exit 1
       - name: Check IRBEM unicode status
         if: ${{ needs.irbem-unicode.result != 'success' }}
+        run: exit 1
+      - name: Check documentation build status
+        if: ${{ needs.docs.result != 'success' }}
         run: exit 1

--- a/spacepy/coordinates.py
+++ b/spacepy/coordinates.py
@@ -8,22 +8,22 @@ follow the names used by the popular IRBEM library, but for inertial
 systems we use a more consistent, fine-grained naming convention that
 clarifies the different systems.
 
-    Earth-centered Inertial Systems
-    -------------------------------
+Earth-centered Inertial Systems
+-------------------------------
     * **ECI2000** Earth-centered Inertial, J2000 epoch
     * **ECIMOD** Earth-centered Inertial, mean-of-date
     * **ECITOD** Earth-centered Inertial, true-of-date
     * **GEI** Geocentric Equatorial Inertial (IRBEM approximation of TOD)
 
-    Magnetospheric Systems
-    ----------------------
+Magnetospheric Systems
+----------------------
     * **GSM** Geocentric Solar Magnetospheric
     * **GSE** Geocentric Solar Ecliptic
     * **SM** Solar Magnetic
     * **MAG** Geomagnetic Coordinate System (aka CDMAG)
 
-    Earth-fixed Systems
-    -------------------
+Earth-fixed Systems
+-------------------
     * **GEO** Geocentric geographic, aka Earth-centered Earth-fixed
     * **GDZ** Geodetic coordinates
 
@@ -234,7 +234,7 @@ class Coords(object):
         ~Coords.append
         ~Coords.convert
         ~Coords.from_skycoord
-        ~Coord.to_skycoord
+        ~Coords.to_skycoord
     .. automethod:: append
     .. automethod:: convert
     .. automethod:: from_skycoord

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -610,6 +610,23 @@ class SpaceData(dict, MetaMixin):
         for key in flatobj:
             self[key] = copy.copy(flatobj[key])
 
+    # Stubs of partialed-in functions for docs; actual versions populated
+    # when class instantiated
+
+    def toCDF(fname, **kwargs):
+        """Create CDF file from this SpaceData.
+
+        See `toCDF`; this object is provided for ``SDobject``."""
+
+    def toHDF5(fname, **kwargs):
+        """Create HDF5 file from this SpaceData.
+
+        See `toHDF5`; this object is provided for ``SDObject``. """
+
+    def toJSONheadedASCII(fname, **kwargs):
+        """Create JSON-headed ASCII file from this SpaceData.
+
+        See `toJSONheadedASCII`; this object is provided for ``insd``."""
             
 
 def convertKeysToStr(SDobject):

--- a/spacepy/igrf.py
+++ b/spacepy/igrf.py
@@ -131,6 +131,12 @@ class IGRF():
 
         Dipole moments (`dict`).
     """
+    dipole = {}
+    """Characteristics of dipole (`dict`)."""
+
+    moment = {}
+    """Dipole moments (`dict`)."""
+
     def __init__(self):
         self.__status = {'coeffs': False,
                          'init': False,

--- a/spacepy/irbempy/__init__.py
+++ b/spacepy/irbempy/__init__.py
@@ -61,6 +61,7 @@ extMag
 
 Many of these models have limits placed on the valid range of input parameters,
 and outside these limits invalid (NaN) values will be returned.
+
     - MEAD	: Mead & Fairfield [1975] (uses 0<=Kp<=9 - Valid for rGEO<=17. Re)
     - T87SHORT: Tsyganenko short [1987] (uses 0<=Kp<=9 - Valid for rGEO<=30. Re)
     - T87LONG : Tsyganenko long [1987] (uses 0<=Kp<=9 - Valid for rGEO<=70. Re)
@@ -69,10 +70,10 @@ and outside these limits invalid (NaN) values will be returned.
     - OPDYN   : Olson & Pfitzer dynamic [1988] (uses 5.<=dens<=50., 300.<=velo<=500.,
         -100.<=Dst<=20. - Valid for rGEO<=60. Re)
     - T96	 : Tsyganenko [1996] (uses -100.<=Dst (nT)<=20., 0.5<=Pdyn (nPa)<10.,
-        |ByIMF| (nT)<1=0., |BzIMF| (nT)<=10. - Valid for rGEO<=40. Re)
+        \|ByIMF\| (nT)<=10., \|BzIMF\| (nT)<=10. - Valid for rGEO<=40. Re)
     - OSTA	: Ostapenko & Maltsev [1997] (uses dst,Pdyn,BzIMF, Kp)
         T01QUIET: Tsyganenko [2002a,b] (uses -50.<Dst (nT)<20., 0.5<Pdyn (nPa)<=5.,
-        |ByIMF| (nT)<=5., |BzIMF| (nT)<=5., 0.<=G1<=10., 0.<=G2<=10. - Valid for xGSM>=-15. Re)
+        \|ByIMF\| (nT)<=5., \|BzIMF\| (nT)<=5., 0.<=G1<=10., 0.<=G2<=10. - Valid for xGSM>=-15. Re)
     - T01STORM: Tsyganenko, Singer & Kasper [2003] storm  (uses Dst, Pdyn, ByIMF, BzIMF, G2, G3 -
         there is no upper or lower limit for those inputs - Valid for xGSM>=-15. Re)
     - T05	 : Tsyganenko & Sitnov [2005] storm  (uses Dst, Pdyn, ByIMF, BzIMF,

--- a/spacepy/plot/carrington.py
+++ b/spacepy/plot/carrington.py
@@ -12,10 +12,10 @@ Los Alamos National Laboratory
 Copyright 2011-2015 Los Alamos National Security, LLC.
 
 .. autosummary::
-    :template: clean_class.rst
+    :template: clean_function.rst
     :toctree: autosummary
 
-    carrington
+    solarRotationPlot
 """
 from __future__ import division
 import datetime as dt

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -123,7 +123,7 @@ class Spectrogram(dm.SpaceData):
 
         ~Spectrogram.plot
 
-    .. automethod:: plot
+    .. automethod:: Spectrogram.plot
 
     """
 
@@ -570,10 +570,11 @@ def simpleSpectrogram(*args, **kwargs):
     Parameters
     ==========
     *args : 1 or 3 arraylike
+
         Call Signatures::
 
-        simpleSpectrogram(Z, **kwargs)
-        simpleSpectrogram(X, Y, Z, **kwargs)
+            simpleSpectrogram(Z, **kwargs)
+            simpleSpectrogram(X, Y, Z, **kwargs)
 
     Other Parameters
     ================

--- a/spacepy/plot/utils.py
+++ b/spacepy/plot/utils.py
@@ -1436,7 +1436,7 @@ def add_arrows(lines, n=3, size=12, style='->', dorestrict=False,
 
     style : string
         Set the style of the arrow via :class:`~matplotlib.patches.ArrowStyle`,
-        e.g. '->' (default) or '-|>'
+        e.g. '->' (default)
 
     dorestrict : boolean
         If True (default), only points along the line within the current

--- a/spacepy/poppy.py
+++ b/spacepy/poppy.py
@@ -124,6 +124,12 @@ class PPro(object):
     #NB: P2 is the "master" timescale, P1 gets shifted by lags
     #Add lag to p1 to reach p2's timescale, subtract lag from p2 to reach p1's
 
+    ci = None
+    """Upper and lower confidence limits for the association number"""
+
+    conf_above = None
+    """Confidence that the association number is above the asymptotic"""
+
     def __init__(self, process1, process2, lags=None, winhalf=None, verbose=False):
         self.process1 = process1
         self.process2 = process2
@@ -396,23 +402,19 @@ class PPro(object):
             x = [i / xscale for i in x]
         ax0.set_xlim((min(x), max(x)))
 
-        ci = None
+        ci = self.ci
         if norm:
-            if hasattr(self, 'ci'):
+            if self.ci is not None:
                 ci = [[j / self.asympt_assoc for j in self.ci[i]]
                     for i in [0,1]]
             asympt_assoc = 1.0
             assoc_total = [assoc / self.asympt_assoc
                            for assoc in self.assoc_total]
         else:
-            try:
-                ci = self.ci
-            except AttributeError:
-                pass
             asympt_assoc = self.asympt_assoc
             assoc_total = self.assoc_total
 
-        if ci != None:
+        if ci is not None:
             if transparent:
                 ax0.fill_between(x, ci[0], ci[1],
                                  edgecolor='none', facecolor='blue', alpha=0.5)

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -376,16 +376,16 @@ def add_body(ax, rad=2.5, facecolor='lightgrey', show_planet=True,
        selectors (name, hex, etc.)  Defaults to 'lightgrey'.
     show_planet : boolean
        Turns on/off planet indicator inside inner boundary.
-       Defaults to **True**
+       Defaults to ``True``
     ang : float
        Set the rotation of the day-night terminator from the y-axis, in degrees
        Defaults to zero (terminator is aligned with Y-axis.)
     add_night : boolean
-       Add night hemisphere.  Defaults to **True**
+       Add night hemisphere.  Defaults to ``True``
     zorder : int
        Set the matplotlib zorder of the patch to set how other plot
        elements order with the inner boundary patch. Defaults to 1000.
-       If a planet is added, it is given a zorder of *zorder*+5.
+       If a planet is added, it is given a zorder of ``zorder`` + 5.
 
     '''
     from matplotlib.patches import Ellipse
@@ -1164,11 +1164,11 @@ class IdlFile(PbData):
     Parameters
     ----------
     filename : string
-        A *.out or *.outs SWMF output file name.
+        A ``*.out`` or ``*.outs`` SWMF output file name.
 
     Other Parameters
     ----------------
-    header : str or **None**
+    header : str or ``None``
         Determine how to interpret the additional header information.
         Defaults to 'units'.
 

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -155,7 +155,6 @@ class Library(object):
     .. automethod:: epoch16_to_tt2000
     .. automethod:: get_minmax
     .. automethod:: set_backward
-
     .. attribute:: supports_int8
 
        True if this library supports INT8 and TIME_TT2000 types; else False.
@@ -163,60 +162,16 @@ class Library(object):
     .. automethod:: tt2000_to_datetime
     .. automethod:: tt2000_to_epoch
     .. automethod:: tt2000_to_epoch16
-
-    .. method:: v_datetime_to_epoch(datetime)
-    
-        A vectorized version of :meth:`datetime_to_epoch` which takes a
-        numpy array of datetimes as input and returns an array of epochs.
-
-    .. method:: v_datetime_to_epoch16(datetime)
-    
-        A vectorized version of :meth:`datetime_to_epoch16` which takes a
-        numpy array of datetimes as input and returns an array of epoch16.
-
-    .. method:: v_datetime_to_tt2000(datetime)
-    
-        A vectorized version of :meth:`datetime_to_tt2000` which takes a
-        numpy array of datetimes as input and returns an array of TT2000.
-
-    .. method:: v_epoch_to_datetime(epoch)
-    
-        A vectorized version of :meth:`epoch_to_datetime` which takes a
-        numpy array of epochs as input and returns an array of datetimes.
-
-    .. method:: v_epoch_to_tt2000(epoch)
-    
-        A vectorized version of :meth:`epoch_to_tt2000` which takes a
-        numpy array of epochs as input and returns an array of tt2000s.
-
-    .. method:: v_epoch16_to_datetime(epoch0, epoch1)
-    
-        A vectorized version of :meth:`epoch16_to_datetime` which takes
-        a numpy array of epoch16 as input and returns an array of datetimes.
-        An epoch16 is a pair of doubles; the input array's last dimension
-        must be two (and the returned array will have one fewer dimension).
-
-    .. method:: v_epoch16_to_tt2000(epoch16)
-    
-        A vectorized version of :meth:`epoch16_to_tt2000` which takes
-        a numpy array of epoch16 as input and returns an array of tt2000s.
-        An epoch16 is a pair of doubles; the input array's last dimension
-        must be two (and the returned array will have one fewer dimension).
-
-    .. method:: v_tt2000_to_datetime(tt2000)
-    
-        A vectorized version of :meth:`tt2000_to_datetime` which takes
-        a numpy array of tt2000 as input and returns an array of datetimes.
-
-    .. method:: v_tt2000_to_epoch(tt2000)
-    
-        A vectorized version of :meth:`tt2000_to_epoch` which takes
-        a numpy array of tt2000 as input and returns an array of epochs.
-
-    .. method:: v_tt2000_to_epoch16(tt2000)
-    
-        A vectorized version of :meth:`tt2000_to_epoch16` which takes
-        a numpy array of tt2000 as input and returns an array of epoch16.
+    .. automethod:: v_datetime_to_epoch
+    .. automethod:: v_datetime_to_epoch16
+    .. automethod:: v_datetime_to_tt2000
+    .. automethod:: v_epoch_to_datetime
+    .. automethod:: v_epoch_to_tt2000
+    .. automethod:: v_epoch16_to_datetime
+    .. automethod:: v_epoch16_to_tt2000
+    .. automethod:: v_tt2000_to_datetime
+    .. automethod:: v_tt2000_to_epoch
+    .. automethod:: v_tt2000_to_epoch16
 
     .. attribute:: libpath
 
@@ -230,6 +185,13 @@ class Library(object):
 
        Version of the CDF library, (version, release, increment, subincrement)
     """
+    supports_int8 = True
+    """True if this library supports INT8 and TIME_TT2000 types; else False."""
+    libpath = ''
+    """The path where pycdf found the CDF C library, potentially useful in
+       debugging."""
+    version = (0, 0, 0, '')
+    """Version of the CDF library"""
 
     _arm32 = platform.uname()[4].startswith('arm') and sys.maxsize <= 2 ** 32
     """Excuting on 32-bit ARM, which requires typepunned arguments"""
@@ -1233,6 +1195,93 @@ class Library(object):
             raise ValueError('Unknown data type: {}'.format(cdftype))
         return (inf.min, inf.max)
 
+    # Stubs of vectorized functions for documentation; actual versions
+    # are populated when class instantiated.
+
+    def v_datetime_to_epoch(self, datetime):
+        """A vectorized version of `datetime_to_epoch`.
+
+        Takes a numpy array of datetimes as input and returns an array of
+        epochs.
+        """
+        pass
+
+    def v_datetime_to_epoch16(self, datetime):
+        """A vectorized version of `datetime_to_epoch16`.
+
+        Takes a numpy array of datetimes as input and returns an array of
+        epoch16.
+        """
+        pass
+
+    def v_datetime_to_tt2000(self, datetime):
+        """A vectorized version of `datetime_to_tt2000`.
+
+        Takes a numpy array of datetimes as input and returns an array of
+        TT2000.
+        """
+        pass
+
+    def v_epoch_to_datetime(self, epoch):
+        """A vectorized version of `epoch_to_datetime`.
+
+        Takes a numpy array of epochs as input and returns an array of
+        datetimes.
+        """
+        pass
+
+    def v_epoch_to_tt2000(self, epoch):
+        """A vectorized version of `epoch_to_tt2000`.
+
+        Takes a numpy array of epochs as input and returns an array of
+        tt2000s.
+        """
+        pass
+
+    def v_epoch16_to_datetime(self, epoch):
+        """A vectorized version of `epoch16_to_datetime`.
+
+        Takes a numpy array of epoch16 as input and returns an array of
+        datetimes. An epoch16 is a pair of doubles; the input array's last
+        dimension must be two (and the returned array will have one fewer
+        dimension).
+        """
+        pass
+
+    def v_epoch16_to_tt2000(self, epoch16):
+        """A vectorized version of `epoch16_to_tt2000`.
+
+        Takes a numpy array of epoch16 as input and returns an array of
+        tt2000s. An epoch16 is a pair of doubles; the input array's last
+        dimension must be two (and the returned array will have one fewer
+        dimension).
+        """
+        pass
+
+    def v_tt2000_to_datetime(self, tt2000):
+        """A vectorized version of `tt2000_to_datetime`.
+
+        Takes a numpy array of tt2000 as input and returns an array of
+        datetimes.
+        """
+        pass
+
+    def v_tt2000_to_epoch(self, tt2000):
+        """A vectorized version of `tt2000_to_epoch`.
+
+        Takes a numpy array of tt2000 as input and returns an array of
+        epochs.
+        """
+        pass
+
+    def v_tt2000_to_epoch16(self, tt2000):
+        """A vectorized version of `tt2000_to_epoch16`.
+
+        Takes a numpy array of tt2000 as input and returns an array of
+        epoch16.
+        """
+        pass
+
 
 def download_library():
     """Download and install the CDF library"""
@@ -1704,6 +1753,9 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
     .. automethod:: version
 
     """
+    backward = False
+    """True if this CDF was created in backward-compatible mode."""
+
     def __init__(self, pathname, masterpath=None, create=None, readonly=None,
                  encoding='utf-8'):
         """Open or create a CDF file.

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -251,12 +251,12 @@ class Ticktock(MutableSequence):
 
     .. only:: latex
 
-        .. image:: ../images/ticktock_relationships.pdf
+        .. image:: ../images/ticktock_relationships.*
 
     .. only:: html
 
         .. image:: ../images/ticktock_relationships.svg
-            :target: ../_images/ticktock_relationships.svg
+            :target: ../_images/ticktock_relationships1.svg
 
     Parameters
     ==========

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -75,8 +75,7 @@ class assertWarns(warnings.catch_warnings):
         The test case from which this is being called, almost always
         ``self`` (so the :meth:`~unittest.TestCase.fail` method is available).
 
-    action : {'always', ``None``, 'default', 'error', 'ignore', 'module',
-              'once'}
+    action : {'always', ``None``, 'default', 'error', 'ignore', 'module', 'once'}
         Unless ``None``, a warning filter matching the specified warning will
         be added to the filter before executing the block. 'always'
         (default) is generally recommended to make sure the tested


### PR DESCRIPTION
This PR fixes all our current Sphinx warnings and adds checks to CI. If the docs fail to build without warnings, the CI will fail.

Most of the Sphinx warnings are fairly straightforward. Some are a matter of providing temporary objects for the autosummary to find, where we have attributes built at run time. I am NOT trying to fix anything other than the Sphinx warnings here--there are some things not in proper numpydoc format, etc.

A note on the CI: this is testing with oldest and newest set of dependencies, not a whole mess. It also is heavily copy/pasted from the unit test runs. This is probably possible to clean up, but primarily wanted to get it working first, and there are subtle differences throughout. Note that there is a new set of pip caches, because the docs install sphinx and numpydoc. These can be brought together better in the future.

One thing that may not be obvious: if Sphinx exits with an error, this is supposed to fail immediately. The GHA docs claim that, by explicitly specifying bash as the shell, pipefail is set and the job will fail if any command fails.

I chose to not try and build the docs if the unit tests fail. This is because unit test failures can indicate a failure to build (esp. irbem) and so the docs could also fail for the same reason.

EDIT: #653 is merged and pybats docs fixed, so ready to review.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
