### PR TITLE
Plot support for SpaceData

### DIFF
--- a/Doc/source/datamodel.rst
+++ b/Doc/source/datamodel.rst
@@ -17,6 +17,7 @@ datamodel - easy to use general data model
     SpaceData
     dmarray
     ISTPContainer
+    ISTPArray
     DMWarning
 
 .. rubric:: Functions

--- a/Doc/source/datamodel.rst
+++ b/Doc/source/datamodel.rst
@@ -16,6 +16,7 @@ datamodel - easy to use general data model
 
     SpaceData
     dmarray
+    ISTPContainer
     DMWarning
 
 .. rubric:: Functions

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -42,6 +42,11 @@ New features
 now support reading from gzipped input files; filenames ending with
 ``.gz`` are assumed to be gzipped.
 
+`.datamodel` now has explicit support for operations using
+ISTP-compliant metadata; see `~.datamodel.dmarray` and
+`~.datamodel.SpaceData` for details. In particular note the plotting
+support with `~.datamodel.ISTPContainer.plot`.
+
 :mod:`.pycdf` :meth:`~.pycdf.Library.set_backward` now returns the prior
 state of backward compatibility mode.
 

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -47,6 +47,9 @@ ISTP-compliant metadata; see `~.datamodel.dmarray` and
 `~.datamodel.SpaceData` for details. In particular note the plotting
 support with `~.datamodel.ISTPContainer.plot`.
 
+`~.plot.spectrogram.simpleSpectrogram()` supports plotting zeros as
+valid data.
+
 :mod:`.pycdf` :meth:`~.pycdf.Library.set_backward` now returns the prior
 state of backward compatibility mode.
 

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -47,8 +47,8 @@ ISTP-compliant metadata; see `~.datamodel.dmarray` and
 `~.datamodel.SpaceData` for details. In particular note the plotting
 support with `~.datamodel.ISTPContainer.plot`.
 
-`~.plot.spectrogram.simpleSpectrogram()` supports plotting zeros as
-valid data.
+`~.plot.spectrogram.simpleSpectrogram()` supports treating zeros as
+valid data on log plots.
 
 :mod:`.pycdf` :meth:`~.pycdf.Library.set_backward` now returns the prior
 state of backward compatibility mode.

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -227,8 +227,8 @@ class MetaMixin(object):
 class ISTPArray:
     """Mixin class for array using ISTP metadata.
 
-    Additional methods for array types, such as `dmarray`, assuming
-    that the attributes of the array use the
+    Array types like `dmarray` provide all these methods if attributes
+    of the array use the
     `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
 
     Note that some operations that may seem to relate to an array (e.g.
@@ -301,9 +301,9 @@ class ISTPArray:
 class ISTPContainer(collections.abc.Mapping):
     """Mixin class for containers using ISTP metadata.
 
-    Additional methods for container types, such as `SpaceData`, assuming
-    that the attributes of the container and the arrays it contains use
-    the `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+    Container types like `SpaceData` provide all these methods if attributes
+    of the container and the arrays it contains use the
+    `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
 
     .. autosummary::
         ~ISTPContainer.lineplot
@@ -419,6 +419,26 @@ class ISTPContainer(collections.abc.Mapping):
         -------
         fig : `matplotlib.figure.Figure`
             The figure on which the variables were plotted
+
+        See Also
+        --------
+        lineplot : to line plot a single variable
+        spectrogram : to make a spectrogram of a single variable
+
+        Examples
+        --------
+
+        >>> import spacepy.pycdf
+        # https://rbsp-ect.newmexicoconsortium.org/data_pub/rbspa/ECT/level2/
+        >>> with spacepy.pycdf.CDF('rbspa_ect-elec-L2_20140115_v2.1.0.cdf') as f:
+        ...     data = f.copy()
+        >>> fig = data.plot(['FESA', 'Position'])
+        >>> fig.show  # if needed
+        # https://spp-isois.sr.unh.edu/data_public/ISOIS/level2/
+        >>> with spacepy.pycdf.CDF('psp_isois_l2-summary_20201130_v13.cdf') as f:
+        ...     data = f.copy()
+        >>> fig = data.plot(['A_H_Rate_TS', 'H_CountRate_ChanP_SP'])
+        >>> fig.show  # if needed
         """
         if fig is None:
             import matplotlib.pyplot
@@ -552,6 +572,8 @@ class dmarray(numpy.ndarray, MetaMixin, ISTPArray):
 
     >>> name.tolist()
     'TestName'
+
+    See methods of `ISTPArray` if attributes are ISTP-compliant.
 
     .. currentmodule:: spacepy.datamodel
     .. autosummary::

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -314,16 +314,18 @@ class ISTPContainer(object):
         if v.attrs.get('LABL_PTR_1'):
             labels = self[v.attrs['LABL_PTR_1']]
         deltas = self.get_deltas(vname)
+        plot_kwargs = {}
         for dim in range(v.shape[-1]):
+            if labels is not None:
+                plot_kwargs['label'] = labels[dim]
             if deltas:
                 if len(deltas) == 1:
                     yerr = deltas[0][:, dim]
                 else:
                     yerr = numpy.stack((deltas[0][:, dim], deltas[1][:, dim]))
-                ax.errorbar(numpy.array(x), data[:, dim], label=labels[dim],
-                            yerr=yerr)
+                ax.errorbar(numpy.array(x), data[:, dim], yerr=yerr, **plot_kwargs)
             else:
-                ax.plot(numpy.array(x), data[:, dim], label=labels[dim])
+                ax.plot(numpy.array(x), data[:, dim], **plot_kwargs)
         ylabel = ''
         if v.attrs.get('LABLAXIS'):
             ylabel = v.attrs['LABLAXIS']
@@ -334,7 +336,7 @@ class ISTPContainer(object):
             ax.set_ylabel(ylabel)
         if x.attrs.get('LABLAXIS'):
             ax.set_xlabel(x.attrs['LABLAXIS'])
-        if target is not ax:
+        if labels is not None and target is not ax:
             ax.legend(loc='best')
         if target is None and v.attrs.get('CATDESC'):
             fig.suptitle(v.attrs['CATDESC'])

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -283,7 +283,9 @@ class ISTPContainer(collections.abc.Mapping):
 
     .. autosummary::
         ~ISTPContainer.lineplot
+        ~ISTPContainer.spectrogram
     .. automethod:: lineplot
+    .. automethod:: spectrogram
     """
     attrs:  collections.abc.Mapping
 
@@ -345,6 +347,38 @@ class ISTPContainer(collections.abc.Mapping):
             ax.legend(loc='best')
         if target is None and v.attrs.get('CATDESC'):
             fig.suptitle(v.attrs['CATDESC'])
+        spacepy.plot.utils.applySmartTimeTicks(ax, x)
+        return ax
+
+    def spectrogram(self, vname, target=None):
+        """Spectrogram plot of a value (array) from this container
+
+        Parameters
+        ----------
+        vname : `str`
+            The key into this container of the value to plot (i.e.,
+            the name of the variable).
+
+        target : `matplotlib.axes.Axes` or `matplotlib.figure.Figure`, optional
+            Where to draw the plot. Default is to create a new figure with
+            a single subplot. If ``Axes``, will draw into that subplot (and
+            will not set figure title); if ``Figure``, will make a single
+            subplot (and not set figure title). Handled by
+            `~.plot.utils.set_target`.
+
+        Returns
+        -------
+        ax : `matplotlib.axes.Axes`
+            The subplot on which the variable was plotted
+        """
+        import spacepy.plot.utils
+        v = self[vname]
+        fig, ax = spacepy.plot.utils.set_target(target)
+        x = self[v.attrs['DEPEND_0']]
+        data = v.replace_invalid()
+        x = self[v.attrs['DEPEND_0']]
+        y = self[v.attrs['DEPEND_1']]
+        ax = spacepy.plot.simpleSpectrogram(numpy.array(x), numpy.array(y), data)
         spacepy.plot.utils.applySmartTimeTicks(ax, x)
         return ax
 

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -235,6 +235,8 @@ class ISTPArray:
     uncertainties) may require the use of other arrays in a container;
     these are in `ISTPContainer`.
 
+    .. versionadded:: 0.5.0
+
     .. autosummary::
         ~ISTPArray.plot_as_line
         ~ISTPArray.replace_invalid
@@ -261,6 +263,8 @@ class ISTPArray:
 
         Notes
         -----
+        .. versionadded:: 0.5.0
+
         Comparisons with ``FILLVAL`` are done using `~numpy.isclose` and
         so may NaN values thare are near, but not identical, to fill.
         """
@@ -286,6 +290,10 @@ class ISTPArray:
         `bool`
             ``True`` if should be a lineplot, ``False`` if should be a
             spectrogram
+
+        Notes
+        -----
+        .. versionadded:: 0.5.0
         """
         if 'DISPLAY_TYPE' in self.attrs:
             return self.attrs['DISPLAY_TYPE'] == 'time_series'
@@ -304,6 +312,8 @@ class ISTPContainer(collections.abc.Mapping):
     Container types like `SpaceData` provide all these methods if attributes
     of the container and the arrays it contains use the
     `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+
+    .. versionadded:: 0.5.0
 
     .. autosummary::
         ~ISTPContainer.lineplot
@@ -337,6 +347,10 @@ class ISTPContainer(collections.abc.Mapping):
         -------
         ax : `matplotlib.axes.Axes`
             The subplot on which the variable was plotted
+
+        Notes
+        -----
+        .. versionadded:: 0.5.0
         """
         import spacepy.plot.utils
         v = self[vname]
@@ -389,6 +403,10 @@ class ISTPContainer(collections.abc.Mapping):
         Returns
         -------
         `list` of `str`
+
+        Notes
+        -----
+        .. versionadded:: 0.5.0
         """
         referenced = set()
         for k, v in self.items():
@@ -424,6 +442,10 @@ class ISTPContainer(collections.abc.Mapping):
         --------
         lineplot : to line plot a single variable
         spectrogram : to make a spectrogram of a single variable
+
+        Notes
+        -----
+        .. versionadded:: 0.5.0
 
         Examples
         --------
@@ -479,6 +501,10 @@ class ISTPContainer(collections.abc.Mapping):
         -------
         ax : `matplotlib.axes.Axes`
             The subplot on which the variable was plotted
+
+        Notes
+        -----
+        .. versionadded:: 0.5.0
         """
         import spacepy.plot.utils
         v = self[vname]
@@ -526,6 +552,10 @@ class ISTPContainer(collections.abc.Mapping):
         deltas : `tuple` of `~numpy.ndarray`
             Deltas for ``vname``. Empty if no deltas available;
             one-element if symmetric; two-element if not symmetric.
+
+        Notes
+        -----
+        .. versionadded:: 0.5.0
         """
         v = self[vname]
         asymmetric_msg = 'Only one of DELTA_(MINUS|PLUS)_VAR specified.'

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -365,7 +365,7 @@ class ISTPContainer(collections.abc.Mapping):
             one-element if symmetric; two-element if not symmetric.
         """
         v = self[vname]
-        asymmetric_msg = 'Only one of DELTA_(MINUS_PLUS)_VAR specified.'
+        asymmetric_msg = 'Only one of DELTA_(MINUS|PLUS)_VAR specified.'
         if 'DELTA_PLUS_VAR' not in v.attrs:
             if 'DELTA_MINUS_VAR' in v.attrs:
                 raise ValueError(asymmetric_msg)

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -227,9 +227,10 @@ class MetaMixin(object):
 class ISTPArray:
     """Mixin class for array using ISTP metadata.
 
-    Array types like `dmarray` provide all these methods if attributes
-    of the array use the
+    Array types like `dmarray` provide all these methods; they assume
+    attributes of the array use the
     `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+    and are unlikely to give good results if that is not the case.
 
     Note that some operations that may seem to relate to an array (e.g.
     uncertainties) may require the use of other arrays in a container;
@@ -266,7 +267,7 @@ class ISTPArray:
         .. versionadded:: 0.5.0
 
         Comparisons with ``FILLVAL`` are done using `~numpy.isclose` and
-        so may replace values thare are near, but not identical, to fill.
+        so may replace values that are near, but not identical, to fill.
         """
         data = numpy.array(self)
         idx = numpy.zeros_like(data, dtype=bool)
@@ -309,9 +310,10 @@ class ISTPArray:
 class ISTPContainer(collections.abc.Mapping):
     """Mixin class for containers using ISTP metadata.
 
-    Container types like `SpaceData` provide all these methods if attributes
-    of the container and the arrays it contains use the
+    Container types like `SpaceData` provide all these methods; they assume
+    attributes of the container and the arrays it contains use the
     `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+    and are unlikely to give good results if that is not the case.
 
     .. versionadded:: 0.5.0
 
@@ -450,17 +452,21 @@ class ISTPContainer(collections.abc.Mapping):
         Examples
         --------
 
-        >>> import spacepy.pycdf
+        >>> import spacepy.datamodel
         # https://rbsp-ect.newmexicoconsortium.org/data_pub/rbspa/ECT/level2/
-        >>> with spacepy.pycdf.CDF('rbspa_ect-elec-L2_20140115_v2.1.0.cdf') as f:
-        ...     data = f.copy()
+        >>> data = spacepy.datamodel.fromCDF(
+        ...     'rbspa_ect-elec-L2_20140115_v2.1.0.cdf')
         >>> fig = data.plot(['FESA', 'Position'])
         >>> fig.show()  # if needed
+
+        >>> import spacepy.pycdf
         # https://rbsp-ect.newmexicoconsortium.org/data_pub/rbspa/hope/level2/spinaverage/
         >>> with spacepy.pycdf.CDF('rbspa_rel04_ect-hope-sci-L2SA_20140108_v6.1.0.cdf') as f:
         ...     data = f.copy()
         >>> fig = data.plot(['FESA', 'FPSA'])
         >>> fig.show()  # if needed
+
+        >>> import spacepy.pycdf
         # https://spp-isois.sr.unh.edu/data_public/ISOIS/level2/
         >>> with spacepy.pycdf.CDF('psp_isois_l2-summary_20201130_v13.cdf') as f:
         ...     data = f.copy()

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -318,7 +318,11 @@ class ISTPContainer(collections.abc.Mapping):
             labels = self[v.attrs['LABL_PTR_1']]
         deltas = self.get_deltas(vname)
         plot_kwargs = {}
-        for dim in range(v.shape[-1]):
+        if len(data.shape) == 1:
+            data = data[..., None]
+        if deltas and len(deltas[0].shape) == 1:
+            deltas = tuple([d[..., None] for d in deltas])
+        for dim in range(data.shape[-1]):
             if labels is not None:
                 plot_kwargs['label'] = labels[dim]
             if deltas:

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -160,6 +160,7 @@ The file looks like:
 
 """
 
+import collections.abc
 import copy
 import datetime
 import gzip
@@ -223,7 +224,7 @@ class MetaMixin(object):
         del self.attrs
 
 
-class ISTPArray(object):
+class ISTPArray:
     """Mixin class for array using ISTP metadata.
 
     Additional methods for array types, such as `dmarray`, assuming
@@ -238,6 +239,7 @@ class ISTPArray(object):
         ~ISTPArray.replace_invalid
     .. automethod:: replace_invalid
     """
+    attrs: collections.abc.Mapping
 
     def replace_invalid(self):
         """Return data from array with invalid values replaced by `~numpy.nan`.
@@ -272,17 +274,18 @@ class ISTPArray(object):
         return data
 
 
-class ISTPContainer(object):
+class ISTPContainer(collections.abc.Mapping):
     """Mixin class for containers using ISTP metadata.
 
     Additional methods for container types, such as `SpaceData`, assuming
     that the attributes of the container and the arrays it contains use
-    the  `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
+    the `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
 
     .. autosummary::
         ~ISTPContainer.lineplot
     .. automethod:: lineplot
     """
+    attrs:  collections.abc.Mapping
 
     def lineplot(self, vname, target=None):
         """Line plot of a value (array) from this container
@@ -326,9 +329,7 @@ class ISTPContainer(object):
                 ax.errorbar(numpy.array(x), data[:, dim], yerr=yerr, **plot_kwargs)
             else:
                 ax.plot(numpy.array(x), data[:, dim], **plot_kwargs)
-        ylabel = ''
-        if v.attrs.get('LABLAXIS'):
-            ylabel = v.attrs['LABLAXIS']
+        ylabel = v.attrs.get('LABLAXIS', '')
         if v.attrs.get('UNITS'):
             ylabel = '{}{}({})'.format(
                 ylabel, ' ' if ylabel else '', v.attrs['UNITS'])
@@ -368,8 +369,7 @@ class ISTPContainer(object):
         if 'DELTA_PLUS_VAR' not in v.attrs:
             if 'DELTA_MINUS_VAR' in v.attrs:
                 raise ValueError(asymmetric_msg)
-            else:
-                return ()
+            return ()
         elif 'DELTA_MINUS_VAR' not in v.attrs:
             raise ValueError(asymmetric_msg)
         dp = self[v.attrs['DELTA_PLUS_VAR']].replace_invalid()

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -254,11 +254,20 @@ class ISTPContainer(object):
         target = None
         fig, ax = spacepy.plot.utils.set_target(target)
         x = self[v.attrs['DEPEND_0']]
+        data = numpy.array(v)
+        idx = numpy.zeros_like(data, dtype=bool)
+        if v.attrs.get('FILLVAL') is not None:
+            idx |= numpy.isclose(data, v.attrs['FILLVAL'])
+        if v.attrs.get('VALIDMIN') is not None:
+            idx |= data < v.attrs['VALIDMIN']
+        if v.attrs.get('VALIDMAX') is not None:
+            idx |= data > v.attrs['VALIDMAX']
+        data[idx] = numpy.nan
         labels = None
         if v.attrs.get('LABL_PTR_1'):
             labels = self[v.attrs['LABL_PTR_1']]
         for dim in range(v.shape[-1]):
-            ax.plot(numpy.array(x), numpy.array(v[:, dim]), label=labels[dim])
+            ax.plot(numpy.array(x), data[:, dim], label=labels[dim])
         ylabel = ''
         if v.attrs.get('LABLAXIS'):
             ylabel = v.attrs['LABLAXIS']

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -266,7 +266,7 @@ class ISTPArray:
         .. versionadded:: 0.5.0
 
         Comparisons with ``FILLVAL`` are done using `~numpy.isclose` and
-        so may NaN values thare are near, but not identical, to fill.
+        so may replace values thare are near, but not identical, to fill.
         """
         data = numpy.array(self)
         idx = numpy.zeros_like(data, dtype=bool)

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -493,7 +493,7 @@ class ISTPContainer(collections.abc.Mapping):
                 zlabel, ' ' if zlabel else '', v.attrs['UNITS'])
         zlabel = zlabel if zlabel else None
         ax = spacepy.plot.simpleSpectrogram(numpy.array(x), numpy.array(y), data, cbtitle=zlabel,
-                                            ax=ax)
+                                            ax=ax, zero_valid=True)
         ylabel = y.attrs.get('LABLAXIS', '')
         if y.attrs.get('UNITS'):
             ylabel = '{}{}({})'.format(

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -378,7 +378,23 @@ class ISTPContainer(collections.abc.Mapping):
         data = v.replace_invalid()
         x = self[v.attrs['DEPEND_0']]
         y = self[v.attrs['DEPEND_1']]
-        ax = spacepy.plot.simpleSpectrogram(numpy.array(x), numpy.array(y), data)
+        zlabel = v.attrs.get('LABLAXIS', '')
+        if v.attrs.get('UNITS'):
+            zlabel = '{}{}({})'.format(
+                zlabel, ' ' if zlabel else '', v.attrs['UNITS'])
+        zlabel = zlabel if zlabel else None
+        ax = spacepy.plot.simpleSpectrogram(numpy.array(x), numpy.array(y), data, cbtitle=zlabel,
+                                            ax=ax)
+        ylabel = y.attrs.get('LABLAXIS', '')
+        if y.attrs.get('UNITS'):
+            ylabel = '{}{}({})'.format(
+                ylabel, ' ' if ylabel else '', y.attrs['UNITS'])
+        if ylabel:
+            ax.set_ylabel(ylabel)
+        if x.attrs.get('LABLAXIS'):
+            ax.set_xlabel(x.attrs['LABLAXIS'])
+        if target is None and v.attrs.get('CATDESC'):
+            fig.suptitle(v.attrs['CATDESC'])
         spacepy.plot.utils.applySmartTimeTicks(ax, x)
         return ax
 

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -293,6 +293,13 @@ class ISTPContainer(object):
             The key into this container of the value to plot (i.e.,
             the name of the variable).
 
+        target : `matplotlib.axes.Axes` or `matplotlib.figure.Figure`, optional
+            Where to draw the plot. Default is to create a new figure with
+            a single subplot. If ``Axes``, will draw into that subplot (and
+            will not draw a legend or figure title); if ``Figure``, will
+            make a single subplot (and not set figure title). Handled by
+            `~.plot.utils.set_target`.
+
         Returns
         -------
         ax : `matplotlib.axes.Axes`
@@ -300,7 +307,6 @@ class ISTPContainer(object):
         """
         import spacepy.plot.utils
         v = self[vname]
-        target = None
         fig, ax = spacepy.plot.utils.set_target(target)
         x = self[v.attrs['DEPEND_0']]
         data = v.replace_invalid()

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -280,12 +280,12 @@ class ISTPContainer(object):
     the  `ISTP metadata standard <https://spdf.gsfc.nasa.gov/sp_use_of_cdf.html>`_
 
     .. autosummary::
-        ~ISTPContainer.plot
-    .. automethod:: plot
+        ~ISTPContainer.lineplot
+    .. automethod:: lineplot
     """
 
-    def plot(self, vname):
-        """Plot a value (array) from this container
+    def lineplot(self, vname, target=None):
+        """Line plot of a value (array) from this container
 
         Parameters
         ----------

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -50,6 +50,7 @@ import matplotlib
 import matplotlib.axes
 import matplotlib.collections as mcoll
 from matplotlib.dates import date2num, num2date
+import matplotlib.colors
 from matplotlib.colors import LogNorm
 import matplotlib.transforms as mtransforms
 import matplotlib.pyplot as plt
@@ -648,20 +649,20 @@ def simpleSpectrogram(*args, **kwargs):
     else:
         fig = ax.get_figure()
     Z = Z.filled(0)
+    Norm = matplotlib.colors.LogNorm if zlog else matplotlib.colors.Normalize
     if len(Y.shape) > 1:
-        for yy in Y_uniq:
+        for i, yy in enumerate(Y_uniq):
             # which indices in X have these values
             ind = (yy == Y_orig).all(axis=1)
-            print(Y_orig[ind][0].min(), Y_orig[ind][0].max())
-            Y_tmp = np.zeros_like(Y_orig)
-            Y_tmp[ind] = Y_orig[ind][0]
+            Y_tmp = np.zeros((Y_orig.shape[0], Y.shape[1]), dtype=Y.dtype)
+            Y_tmp[ind] = Y[i]
             Z_tmp = np.zeros_like(Z)
             Z_tmp[ind] = Z[ind]
             pc = ax.pcolormesh(X, Y_tmp[ind][0], Z_tmp.T,
-                               norm=LogNorm(vmin=vmin, vmax=vmax), cmap=cmap,
+                               norm=Norm(vmin=vmin, vmax=vmax), cmap=cmap,
                                alpha=alpha)
     else:
-        pc = ax.pcolormesh(X, Y, Z.T, norm=LogNorm(vmin=vmin, vmax=vmax),
+        pc = ax.pcolormesh(X, Y, Z.T, norm=Norm(vmin=vmin, vmax=vmax),
                            cmap=cmap,
                            alpha=alpha)
     if ylog: ax.set_yscale('log')

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -597,6 +597,12 @@ def simpleSpectrogram(*args, **kwargs):
         Plot a colorbar (default: True)
     cbtitle : string
         Label to go on the colorbar (default: None)
+    zero_valid : bool
+        Treat zero as a valid value on zlog plots and use same color as
+        other under-minimum values. No effect with linear colorbar.
+        (default: False, draw as fill)
+
+        .. versionadded:: 0.5.0
 
     Returns
     =======
@@ -633,6 +639,7 @@ def simpleSpectrogram(*args, **kwargs):
 
     # deal with all the default keywords
     zlog    = kwargs.pop('zlog', True)
+    zero_valid = kwargs.pop('zero_valid', False)
     ylog    = kwargs.pop('ylog', True)
     alpha   = kwargs.pop('alpha', None)
     cmap    = kwargs.pop('cmap', None)
@@ -648,6 +655,8 @@ def simpleSpectrogram(*args, **kwargs):
         ax = fig.add_subplot(111)
     else:
         fig = ax.get_figure()
+    if zlog and zero_valid:
+        Z[Z == 0] = vmin / 2.
     Z = Z.filled(0)
     Norm = matplotlib.colors.LogNorm if zlog else matplotlib.colors.Normalize
     if len(Y.shape) > 1:

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -9,6 +9,7 @@ import os.path
 import re
 import sys
 import sysconfig
+import unittest
 import warnings
 
 
@@ -178,6 +179,29 @@ class assertDoesntWarn(assertWarns):
               + assertWarns.__doc__[assertWarns.__doc__.index('\n'):]
     requireWarning = False
     pass
+
+
+class TestPlot(unittest.TestCase):
+    """Support for unit tests of plot functionality"""
+    save_plots = False
+    """Save current figure at end of test, can be set by subclass or instance"""
+
+    def setUp(self):
+        super().setUp()
+        import matplotlib
+        import matplotlib.pyplot
+        self.old_backend = matplotlib.get_backend()
+        matplotlib.use('agg')
+
+    def tearDown(self):
+        super().tearDown()
+        import matplotlib
+        import matplotlib.pyplot
+        if self.save_plots and matplotlib.pyplot.get_fignums():
+            fname = 'output_{}.png'.format('_'.join(self.id().split('.')[1:]))
+            matplotlib.pyplot.savefig(fname)
+            matplotlib.pyplot.close()
+        matplotlib.use(self.old_backend)
 
 
 add_build_to_path()

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1574,6 +1574,12 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         ylim = cb.get_ylim()
         self.assertAlmostEqual(self.sd['H_Rate'].min(), ylim[0])
         self.assertAlmostEqual(self.sd['H_Rate'].max(), ylim[1])
+        self.assertEqual('UT', ax.get_xlabel())
+        self.assertEqual('Energy (keV)', ax.get_ylabel())
+        self.assertEqual('H rate (counts/s)', cb.get_ylabel())
+        self.assertEqual(1, len(fig.texts))
+        self.assertEqual(self.sd['H_Rate'].attrs['CATDESC'],
+                         fig.texts[0].get_text())
 
 
 if __name__ == "__main__":

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1387,6 +1387,33 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
             self.sd.get_deltas('B_vec')
         self.assertEqual('Only one of DELTA_(MINUS|PLUS)_VAR specified.', str(cm.exception))
 
+    def test_plot_as_line(self):
+        """See if a variable should be a lineplot"""
+        self.assertTrue(self.sd['B_vec'].plot_as_line())
+        self.assertTrue(self.sd['B_mag'].plot_as_line())
+        self.assertFalse(self.sd['H_Rate'].plot_as_line())
+        for k in ('B_vec', 'B_mag', 'H_Rate'):
+            del self.sd[k].attrs['DISPLAY_TYPE']
+        self.assertTrue(self.sd['B_vec'].plot_as_line())
+        self.assertTrue(self.sd['B_mag'].plot_as_line())
+        self.assertFalse(self.sd['H_Rate'].plot_as_line())
+
+    def test_main_vars(self):
+        """Get list of main variables"""
+        expected = ['B_mag', 'B_vec', 'H_Rate']
+        out = self.sd.main_vars()
+        self.assertEqual(expected, out)
+        del self.sd['B_mag'].attrs['VAR_TYPE']
+        expected = ['B_vec', 'H_Rate']
+        out = self.sd.main_vars()
+        self.assertEqual(expected, out)
+        for v in self.sd.values():
+            if 'VAR_TYPE' in v.attrs:
+                del v.attrs['VAR_TYPE']
+        expected = ['B_mag', 'B_vec', 'H_Rate']
+        out = self.sd.main_vars()
+        self.assertEqual(expected, out)
+
     def test_lineplot_timeseries(self):
         """Plot a timeseries"""
         ax = self.sd.lineplot('B_vec')

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1335,9 +1335,9 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         np.testing.assert_array_equal(
             self.sd['B_err_hi'], res[1])
 
-    def test_plot_timeseries(self):
+    def test_lineplot_timeseries(self):
         """Plot a timeseries"""
-        ax = self.sd.plot('B_vec')
+        ax = self.sd.lineplot('B_vec')
         lines = ax.get_lines()
         self.assertEqual(3, len(lines))
         for i in range(3):
@@ -1352,12 +1352,12 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual(self.sd['B_vec'].attrs['CATDESC'],
                          fig.texts[0].get_text())
 
-    def test_plot_ts_w_fill(self):
+    def test_lineplot_ts_w_fill(self):
         """Plot a timeseries with fill data"""
         self.sd['B_vec'][5, 0] = -1e31
         self.sd['B_vec'][10, 1] = 1.e4
         self.sd['B_vec'][15, 2] = -1.e4
-        ax = self.sd.plot('B_vec')
+        ax = self.sd.lineplot('B_vec')
         lines = ax.get_lines()
         self.assertTrue(np.isnan(lines[0].get_ydata()[5]))
         self.assertTrue(np.isnan(lines[1].get_ydata()[10]))
@@ -1366,7 +1366,7 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertFalse(np.isnan(lines[1].get_ydata()[11:]).any())
         self.assertFalse(np.isnan(lines[2].get_ydata()[16:]).any())
 
-    def test_plot_ts_w_fill_and_errs(self):
+    def test_lineplot_ts_w_fill_and_errs(self):
         """Plot a timeseries with errorbars"""
         self.sd['B_vec'][5, 0] = -1e31
         self.sd['B_vec'][10, 1] = 1.e4
@@ -1403,7 +1403,7 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
             'DELTA_MINUS_VAR': 'B_err_lo',
             'DELTA_PLUS_VAR': 'B_err_hi',
         })
-        ax = self.sd.plot('B_vec')
+        ax = self.sd.lineplot('B_vec')
         lines = ax.get_lines()
         self.assertEqual(3, len(lines))
         import matplotlib.collections

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1608,6 +1608,35 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual(self.sd['H_Rate'].attrs['CATDESC'],
                          fig.texts[0].get_text())
 
+    def test_plot_all(self):
+        """Plot everything in this SpaceData"""
+        fig = self.sd.plot()
+        axes = fig.get_axes()
+        self.assertEqual(4, len(axes))  # 3 plots, one colorbar
+        ylabels = [ax.get_ylabel() for ax in axes]
+        self.assertEqual(
+            ['B (nT)', 'B (nT)', 'Energy (keV)', 'H rate (counts/s)'], ylabels)
+        self.assertFalse(axes[1].get_legend() is None)
+        self.assertIs(axes[0].get_legend(), None)
+
+    def test_plot_one(self):
+        """Plot one array in this SpaceData"""
+        fig = self.sd.plot('B_vec')
+        axes = fig.get_axes()
+        self.assertEqual(1, len(axes))
+
+    def test_plot_some(self):
+        """Plot specfic variables in this SpaceData, specify figure"""
+        import matplotlib.pyplot
+        fig = matplotlib.pyplot.figure()
+        figout = self.sd.plot(['B_vec', 'H_Rate'], fig=fig)
+        self.assertIs(fig, figout)
+        axes = fig.get_axes()
+        self.assertEqual(3, len(axes))  # 2 plots, one colorbar
+        ylabels = [ax.get_ylabel() for ax in axes]
+        self.assertEqual(
+            ['B (nT)', 'Energy (keV)', 'H rate (counts/s)'], ylabels)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -45,7 +45,8 @@ except NameError:
     str_classes = (str, bytes)
     unicode = str
 
-__all__ = ['SpaceDataTests', 'dmarrayTests', 'converterTests', 'JSONTests', 'converterTestsCDF']
+__all__ = ['SpaceDataTests', 'dmarrayTests', 'converterTests', 'JSONTests', 'converterTestsCDF',
+           'VariableTests', 'ISTPPlotTests']
 
 
 class SpaceDataTests(unittest.TestCase):

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1270,6 +1270,20 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
                        'UNITS': 'nT',
                        'VALIDMAX': 1000.,
                        'VALIDMIN': -1000.,
+                       'VAR_TYPE': 'data'}),
+            'B_mag': dm.dmarray(
+                10 * np.sin(x),  # fake but pretty
+                attrs={'CATDESC': 'Magnetic field',
+                       'DEPEND_0': 'Epoch',
+                       'DISPLAY_TYPE': 'time_series',
+                       'FIELDNAM': 'B_mag',
+                       'FILLVAL': -1e+31,
+                       'FORMAT': 'F6.1',
+                       'LABLAXIS': 'B',
+                       'SCALETYP': 'linear',
+                       'UNITS': 'nT',
+                       'VALIDMAX': 1000.,
+                       'VALIDMIN': -1000.,
                        'VAR_TYPE': 'data'})
             })
 
@@ -1361,6 +1375,17 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual(1, len(fig.texts))
         self.assertEqual(self.sd['B_vec'].attrs['CATDESC'],
                          fig.texts[0].get_text())
+
+    def test_lineplot_timeseries_1D(self):
+        """Plot a timeseries with a single line"""
+        ax = self.sd.lineplot('B_mag')
+        lines = ax.get_lines()
+        self.assertEqual(1, len(lines))
+        np.testing.assert_array_equal(lines[0].get_xdata(), self.sd['Epoch'])
+        np.testing.assert_array_equal(lines[0].get_ydata(), self.sd['B_mag'])
+        self.assertEqual('B (nT)', ax.get_ylabel())
+        self.assertEqual('UT', ax.get_xlabel())
+        self.assertIs(None, ax.get_legend())
 
     def test_lineplot_timeseries_target_fig(self):
         """Plot a timeseries, specify a figure"""

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1343,7 +1343,7 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         for i in range(3):
             np.testing.assert_array_equal(lines[i].get_xdata(), self.sd['Epoch'])
             np.testing.assert_array_equal(lines[i].get_ydata(),
-                                             self.sd['B_vec'][:, i])
+                                          self.sd['B_vec'][:, i])
         self.assertEqual('B (nT)', ax.get_ylabel())
         self.assertEqual('UT', ax.get_xlabel())
         self.assertEqual(['X', 'Y', 'Z'], [t.get_text() for t in ax.get_legend().texts])

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1303,7 +1303,6 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
             'Energy': dm.dmarray(
                 np.logspace(1, 3, 20),
                 attrs={'CATDESC': 'Energy bins for H',
-                       'DISPLAY_TYPE': 'spectrogram',
                        'FIELDNAM': 'H_Rate',
                        'FILLVAL': -1e+31,
                        'FORMAT': 'F6.1',

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1371,6 +1371,14 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual(0, len(fig.texts))
         self.assertIs(None, ax.get_legend())
 
+    def test_lineplot_nolabel(self):
+        """Plot a timeseries without a line label"""
+        del self.sd['B_vec'].attrs['LABL_PTR_1']
+        ax = self.sd.lineplot('B_vec')
+        lines = ax.get_lines()
+        self.assertEqual(3, len(lines))
+        self.assertIs(None, ax.get_legend())
+
     def test_lineplot_ts_w_fill(self):
         """Plot a timeseries with fill data"""
         self.sd['B_vec'][5, 0] = -1e31

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1288,6 +1288,20 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual(self.sd['B_vec'].attrs['CATDESC'],
                          fig.texts[0].get_text())
 
+    def test_plot_ts_w_fill(self):
+        """Plot a timeseries with fill data"""
+        self.sd['B_vec'][5, 0] = -1e31
+        self.sd['B_vec'][10, 1] = 1.e4
+        self.sd['B_vec'][15, 2] = -1.e4
+        ax = self.sd.plot('B_vec')
+        lines = ax.get_lines()
+        self.assertTrue(np.isnan(lines[0].get_ydata()[5]))
+        self.assertTrue(np.isnan(lines[1].get_ydata()[10]))
+        self.assertTrue(np.isnan(lines[2].get_ydata()[15]))
+        self.assertFalse(np.isnan(lines[0].get_ydata()[6:]).any())
+        self.assertFalse(np.isnan(lines[1].get_ydata()[11:]).any())
+        self.assertFalse(np.isnan(lines[2].get_ydata()[16:]).any())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1527,8 +1527,8 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         errs = [c for c in ax.get_children()
                 if isinstance(c, matplotlib.collections.LineCollection)]
         for i in range(3):
-            bottoms = np.array([s[0, 1] for s in errs[i].get_segments()])
-            tops = np.array([s[1, 1] for s in errs[i].get_segments()])
+            bottoms = np.array([s[0, 1] for s in errs[i].get_segments() if s.size])
+            tops = np.array([s[1, 1] for s in errs[i].get_segments() if s.size])
             expected = self.sd['B_vec'][:, i] - self.sd['B_err_lo'][:, i]
             valid = (self.sd['B_vec'][:, i] < 5e3) & (self.sd['B_vec'][:, i] > -5e3)
             expected = expected[valid]

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1572,7 +1572,7 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
             np.testing.assert_array_equal(expected, tops)
 
     def test_spectrogram(self):
-        """Plot a timeseries"""
+        """Plot a spectrogram"""
         ax = self.sd.spectrogram('H_Rate')
         import matplotlib.collections
         import matplotlib.dates

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1352,6 +1352,25 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual(self.sd['B_vec'].attrs['CATDESC'],
                          fig.texts[0].get_text())
 
+    def test_lineplot_timeseries_target_fig(self):
+        """Plot a timeseries, specify a figure"""
+        import matplotlib.pyplot
+        fig = matplotlib.pyplot.figure()
+        ax = self.sd.lineplot('B_vec', target=fig)
+        self.assertIs(ax.get_figure(), fig)
+        self.assertEqual(0, len(fig.texts))
+
+    def test_lineplot_timeseries_target_ax(self):
+        """Plot a timeseries, specify an AxesSubplot"""
+        import matplotlib.pyplot
+        fig = matplotlib.pyplot.figure()
+        ax_in = fig.add_subplot(111)
+        ax = self.sd.lineplot('B_vec', target=ax_in)
+        self.assertIs(fig, ax.get_figure())
+        self.assertIs(ax_in, ax)
+        self.assertEqual(0, len(fig.texts))
+        self.assertIs(None, ax.get_legend())
+
     def test_lineplot_ts_w_fill(self):
         """Plot a timeseries with fill data"""
         self.sd['B_vec'][5, 0] = -1e31

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1220,7 +1220,8 @@ class VariableTests(unittest.TestCase):
 
 
 class ISTPPlotTests(spacepy_testing.TestPlot):
-    """Plotting functions of ISTP-based SpaceData"""
+    """Test ISTP-based SpaceData"""
+    # Not all tests use plotting, but many do, and need a single line of inheritance
 
     def setUp(self):
         super().setUp()
@@ -1270,6 +1271,22 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
                        'VALIDMIN': -1000.,
                        'VAR_TYPE': 'data'})
             })
+
+    def test_replace_invalid(self):
+        """Test replacing invalid values with NaN"""
+        self.sd['B_vec'][5, 0] = -1e31
+        self.sd['B_vec'][10, 1] = 1.e4
+        self.sd['B_vec'][15, 2] = -1.e4
+        out = self.sd['B_vec'].replace_invalid()
+        self.assertTrue(np.isnan(out[5, 0]))
+        self.assertTrue(np.isnan(out[10, 1]))
+        self.assertTrue(np.isnan(out[15, 2]))
+        self.assertFalse(np.isnan(out[:5, 0]).any())
+        self.assertFalse(np.isnan(out[6:, 0]).any())
+        self.assertFalse(np.isnan(out[:10, 1]).any())
+        self.assertFalse(np.isnan(out[11:, 1]).any())
+        self.assertFalse(np.isnan(out[:15, 2]).any())
+        self.assertFalse(np.isnan(out[16:, 2]).any())
 
     def test_plot_timeseries(self):
         """Plot a timeseries"""

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -208,6 +208,32 @@ class SimpleSpectrogramTests(spacepy_testing.TestPlot):
         self.assertGreater(ylim[1], y[-1])
         self.assertLess(ylim[1], 250)
 
+    def testLinearZ(self):
+        """Linear Z axis"""
+        z = np.arange(72).reshape((12, 6))
+        x = np.arange(12)
+        y = np.arange(6)
+        ax = spacepy.plot.simpleSpectrogram(x, y, z, zlog=False, ylog=False)
+        mesh =  [c for c in ax.get_children() if isinstance(c, matplotlib.collections.QuadMesh)]
+        self.assertEqual(1, len(mesh))
+        mesh = mesh[0]
+        np.testing.assert_array_almost_equal(
+            z, mesh.get_array().reshape(z.shape[::-1]).transpose())  # mesh swaps row/column
+
+    def testTimeDepY(self):
+        """Time-dependent Y axis, linear Z"""
+        z = np.full((12, 6), 1.)
+        x = np.arange(12)
+        # Values are all the same, but "time-dependent"
+        y = np.tile(np.logspace(0, 2, 6), (12, 1))
+        ax = spacepy.plot.simpleSpectrogram(x, y, z)
+        mesh =  [c for c in ax.get_children() if isinstance(c, matplotlib.collections.QuadMesh)]
+        self.assertEqual(1, len(mesh))
+        mesh = mesh[0]
+        data = mesh.get_array()
+        np.testing.assert_array_almost_equal(1., data)
+        self.assertEqual(6 * 12, data.size)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR provides methods to plot data in SpaceData assuming they are ISTP-compliant. There are also several helper methods to support this which I intend to continue to flesh out in the future.

This is not going to make a perfect plot of everything yet (for instance, the EPI-Lo data in the example, which I will check on; likely a simpleSpectrogram issue). And we can always add thousands of knobs to tweak. I'd like to try and focus this PR on the core functionality and then we can open up enhancements to build on it.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
