### PR TITLE
Make spacepy module in docs refer to main module, not root of docs

### DIFF
--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -56,7 +56,7 @@ validate the analysis and receive appropriate credit for his or her
 work.
 
 
-.. module:: spacepy
+.. currentmodule:: spacepy
 
 Getting Started
 ===============


### PR DESCRIPTION
CI failed building docs because the "spacepy module" object was defined twice: once in index.rst and once in the main spacepy `__init__.py`. (It also failed because the SciPy website was down, but that appears to be transient.) This PR fixes that by changing the index.rst to just declare that spacepy is the current module, but it's not actually defining spacepy.

Other than cleaning up the warning, this means the [module index](https://spacepy.github.io/py-modindex.html) now points to [main module](https://spacepy.github.io/spacepy.html) docs, not [root](https://spacepy.github.io/)...I think that's probably right. We want to distinguish between the API-level docs of the root module and the full documentation of the entire SpacePy package.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
