### PR TITLE
CI updates for github deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install and run tests
       working-directory: ${{ github.workspace }}
       run: |
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Unicode check
         run: (! file irbem-lib-*/*.f irbem-lib-*/source/*.f | grep -q Unicode )
         working-directory: ${{ github.workspace }}/spacepy/irbempy/
@@ -245,7 +245,7 @@ jobs:
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build spacepy and docs
       working-directory: ${{ github.workspace }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Get Week
       id: get-week
       run: |
-        echo "::set-output name=week::$(/bin/date -u "+%G%V")"
+        echo "week=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache pip
       uses: actions/cache@v2
@@ -204,7 +204,7 @@ jobs:
     - name: Get Week
       id: get-week
       run: |
-        echo "::set-output name=week::$(/bin/date -u "+%G%V")"
+        echo "week=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache pip
       uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
             dep-strategy: "newest"
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get Week
@@ -120,7 +120,7 @@ jobs:
         echo "week=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         # Force-expire the pip cache weekly
@@ -129,7 +129,7 @@ jobs:
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
     - name: Cache cdf
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/cdf
         # Force-expire the CDF cache weekly
@@ -198,7 +198,7 @@ jobs:
             dep-strategy: "newest"
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get Week
@@ -207,7 +207,7 @@ jobs:
         echo "week=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         # Different pip cache for docs (includes numpydoc, sphinx)
@@ -219,7 +219,7 @@ jobs:
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
     - name: Cache cdf
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/cdf
         # Force-expire the CDF cache weekly


### PR DESCRIPTION
This PR makes two changes to the CI because of changes in GitHub Actions:

- Moves from checkout v2 to checkout v3. This [uses the new version of Node](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) now that GHA has deprecated the older version.
- Replace [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) with the new `GITHUB_OUTPUT` environment file
- Change [setup-python](https://github.com/actions/setup-python/releases) to v4 (from v2) and cache to v3 (from v2), also for the Node 16 migration.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
