### PR TITLE
Seapy: warn on bad input

### DIFF
--- a/spacepy/seapy.py
+++ b/spacepy/seapy.py
@@ -75,6 +75,17 @@ class SeaBase(object):
             self.times=times.UTC
         else:
             self.times = times
+        td = np.diff(times)
+        noncontig = (not np.isclose(td, td[0]).all()) if np.issubdtype(td.dtype, np.inexact)\
+              else (len(np.unique(td)) > 1)
+        nonmon = ((np.array([t.total_seconds() for t in td])
+                if isinstance(td[0], dt.timedelta) else td) < 0).any()
+        if nonmon or noncontig:
+            warnings.warn('Input time not {}; results are unlikely to be valid.'.format(
+                          ('monotonic or contiguous' if nonmon else 'contiguous')
+                          if noncontig else 'monotonic'))
+        if len(epochs) > len(times) / 2:
+            warnings.warn('Too many epochs; results are unlikely to be valid.')
         if isinstance(epochs, spt.Ticktock):
             self.epochs = epochs.UTC
         else:
@@ -208,9 +219,21 @@ class Sea(SeaBase):
     data : array_like
         list or array of data
     times : array_like
-        list of datetime objects (or list of serial times)
+        list of datetime objects (or list of serial times). Must be contiguous
+        (constant cadence) and monotonically increasing.
+
+        .. versionchanged:: 0.5.0
+           Issues a warning for non-contiguous/non-monotonic times.
+
     epochs : array_like
-        list of datetime objects (or serial times) for zero epochs in SEA
+        list of datetime objects (or serial times) for zero epochs in SEA.
+        For a suitable SEA, this should be substantially shorter than
+        ``times``.
+
+        .. versionchanged:: 0.5.0
+           Issues a warning for too many epochs; arbitrarily defined as
+           more than half the number of times.
+
     window : datetime.timedelta
         size of the half-window for the SEA (can also be given as serial time)
     delta : datetime.timedelta
@@ -557,9 +580,21 @@ class Sea2d(SeaBase):
     data : array_like
         2-D array of data (0th dimension is quantity y, 1st dimension is time)
     times : array_like
-        list of datetime objects (or list of serial times)
+        list of datetime objects (or list of serial times). Must be contiguous
+        (constant cadence) and monotonically increasing.
+
+        .. versionchanged: 0.5.0
+           Issues a warning for non-contiguous/non-monotonic times.
+
     epochs : array_like
-        list of datetime objects (or serial times) for zero epochs in SEA
+        list of datetime objects (or serial times) for zero epochs in SEA.
+        For a suitable SEA, this should be substantially shorter than
+        ``times``.
+
+        .. versionchanged: 0.5.0
+           Issues a warning for too many epochs; arbitrarily defined as
+           more than half the number of times.
+
     window : datetime.timedelta
         size of the half-window for the SEA (can also be given as serial time)
     delta : datetime.timedelta

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -79,12 +79,8 @@ class assertWarns(warnings.catch_warnings):
         Unless ``None``, a warning filter matching the specified warning will
         be added to the filter before executing the block. 'always'
         (default) is generally recommended to make sure the tested
-        warning will be raised. If 'always' is specified, on Python 2 the log
-        of previously-issued warnings will be edited to work around a
-        `Python bug <https://stackoverflow.com/questions/56821539/>`_. In this
-        case using ``module`` is strongly recommended to minimize the impact
-        of this editing. This filter will be removed on completion of the
-        block.
+        warning will be raised. This filter will be removed on completion
+        of the block.
 
     message : str, optional
         Regular expression to match the start of warning message. Default
@@ -133,21 +129,6 @@ class assertWarns(warnings.catch_warnings):
         """Log of warnings issued within context block."""
         if self._filterspec[0] is not None:
             warnings.filterwarnings(*self._filterspec)
-        if self._filterspec[0] == 'always' and sys.version_info[0:2] == (2, 7):
-            # Bug in 2.7: 'always' doesn't work if warning was previously
-            # issued, so remove any record of it being issued, which
-            # is stored by module.
-            msg_pat = re.compile(self._filterspec[1], re.I)
-            cat = self._filterspec[2]
-            mod_pat = re.compile(self._filterspec[3])
-            for m in list(sys.modules):
-                if mod_pat.match(m)\
-                   and hasattr(sys.modules[m], '__warningregistry__'):
-                    reg = sys.modules[m].__warningregistry__
-                    for k in list(reg.keys()):
-                        if msg_pat.match(k[0]) and issubclass(k[1], cat):
-                            del reg[k]
-                            break
 
     def __exit__(self, *exc_info):
         """Exit context manager, called at exit of block"""

--- a/tests/test_seapy.py
+++ b/tests/test_seapy.py
@@ -233,6 +233,36 @@ class SeaClassExceptions(unittest.TestCase):
         re_fun = self.obj.restoreepochs
         self.assertRaises(AttributeError, re_fun)
 
+    def testWarnNonContiguous(self):
+        """Warn if time inputs appear non-contiguous/non-monotonic"""
+        with spacepy_testing.assertWarns(self, message='Input time not monotonic;'
+                                         ' results are unlikely to be valid.'):
+            seapy.Sea(self.unidata, self.time[::-1], self.epochs, verbose=False)
+        time = [dt.datetime(2020, 1, 1) + dt.timedelta(seconds = 60 * i)
+                for i in range(202)]
+        del time[2:4]  # Introduce a gap
+        with spacepy_testing.assertWarns(self, message='Input time not contiguous;'
+                                         ' results are unlikely to be valid.'):
+            seapy.Sea(self.unidata, time, self.epochs, verbose=False)
+        time = [dt.datetime(2020, 1, 1) + dt.timedelta(seconds = 60 * i)
+                for i in range(200)]
+        time[2] = dt.datetime(2019, 12, 31, 23, 59, 59)  # Go backwards
+        with spacepy_testing.assertWarns(self, message='Input time not monotonic or contiguous;'
+                                         ' results are unlikely to be valid.'):
+            seapy.Sea(self.unidata, time, self.epochs, verbose=False)
+        time = [dt.datetime(2020, 1, 1) - dt.timedelta(seconds = 60 * i)
+                for i in range(200)]
+        with spacepy_testing.assertWarns(self, message='Input time not monotonic;'
+                                         ' results are unlikely to be valid.'):
+            seapy.Sea(self.unidata, time, self.epochs, verbose=False)
+
+    def testWarnTooManyEpochs(self):
+        """Warn if there are too many time epochs"""
+        with spacepy_testing.assertWarns(self, message='Too many epochs;'
+                                         ' results are unlikely to be valid.'):
+            seapy.Sea(self.unidata, self.time, list(range(0, 202, 2)), verbose=False)
+
+
 class SEATests2dUniform(unittest.TestCase):
     """Tests of the sea method using uniform input"""
 


### PR DESCRIPTION
There are a few ways to provide input to SeaPy that are likely to result in meaningless output. This PR issues a warning on a couple of them: a time series that isn't a simple consistent cadence, and a number of epochs that is large compared to the number of times.

It is possible this is the issue with #665 but there isn't enough information to conclude that.

The PR also removes some Python 2 specific code from spacepy_testing.assertWarns, because that function is used in the tests.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
