### PR TITLE
Document B vector returned in GEO coordinates by irbempy.get_Bfield

### DIFF
--- a/spacepy/irbempy/irbempy.py
+++ b/spacepy/irbempy/irbempy.py
@@ -145,24 +145,31 @@ def updateTS07Coeffs(path=None, force=False, verbose=False, **kwargs):
 # -----------------------------------------------
 def get_Bfield(ticks, loci, extMag='T01STORM', options=[1, 0, 0, 0, 0], omnivals=None):
     """
-    call get_bfield in irbem lib and return a dictionary with the B-field vector and
-    strenght.
+    Return magnetic field vector (in GEO) and magnitude
+
+    Calls get_bfield from IRBEMlib and uses the underlying model
+    implementations and coordinate transforms in IRBEMlib to obtain the
+    result.
 
     Parameters
     ----------
         - ticks (Ticktock class) : containing time information
         - loci (Coords class) : containing spatial information
-        - extMag (string) : optional; will choose the external magnetic field model
-                            possible values ['0', 'MEAD', 'T87SHORT', 'T87LONG', 'T89',
-                            'OPQUIET', 'OPDYN', 'T96', 'OSTA', 'T01QUIET', 'T01STORM',
-                            'T05', 'ALEX', 'TS07']
+        - extMag (string) : optional; will choose the external magnetic
+                            field model possible values ['0', 'MEAD',
+                            'T87SHORT', 'T87LONG', 'T89', 'OPQUIET',
+                            'OPDYN', 'T96', 'OSTA', 'T01QUIET',
+                            'T01STORM', 'T05', 'ALEX', 'TS07']
         - options (optional list or array of integers length=5) : explained in Lstar
-        - omni values as dictionary (optional) : if not provided, will use lookup table
+        - omni values as dictionary (optional) : if not provided, will
+                                                 use OMNI module to
+                                                 look up
         - (see Lstar documentation for further explanation)
 
     Returns
     -------
         - results (dictionary) : containing keys: Bvec, and Blocal
+                                 Bvec is specified in GEO coordinates
 
     Examples
     --------


### PR DESCRIPTION
#377 raises the issue that `spacepy.irbempy.get_Bfield` always returns vector B expressed in Cartesian GEO coordinates. This was not documented and this PR updates the docstring to make clear that GEO coordinates are used.

I'm not setting this PR to close the related issue as we should probably actually handle the case, but that's extra work. This covers the minimal documentation need so hopefully it trips fewer people up. Probably the tag on #377 should change from documentation to enhancement though.

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

