### PR TITLE
Use oldest-supported-numpy in build reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel",
-    "numpy ~= 1.12.0 ; python_version == '3.6'",
-    "numpy ~= 1.15.0 ; python_version == '3.7' and (platform_system != 'Darwin' or platform_machine != 'arm64')",
-    "numpy ~= 1.20.0 ; python_version == '3.7' and platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "numpy ~= 1.17.0 ; python_version == '3.8' and (platform_system != 'Darwin' or platform_machine != 'arm64')",
-    "numpy ~= 1.20.0 ; python_version == '3.8' and platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "numpy ~= 1.18.0 ; python_version == '3.9' and (platform_system != 'Darwin' or platform_machine != 'arm64')",
-    "numpy ~= 1.21.0 ; python_version == '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "numpy ~= 1.21.0 ; python_version >= '3.10'",
-    ]
+requires = ["setuptools", "wheel", "oldest-supported-numpy"]


### PR DESCRIPTION
Fixes https://github.com/spacepy/spacepy/issues/679. As described at https://github.com/scipy/oldest-supported-numpy, this should avoid the numpy versions having to be continually updated in the requirements, and will keep them up to date.

- [ ] Pull request has descriptive title
- [ ] Pull request gives overview of changes
- [ ] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to release notes if fixing a significant bug or providing a new feature
- [ ] New features and bug fixes should have unit tests
- [ ] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

