### PR TITLE
Port installer to setuptools (abandon distutils)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython"
             numpy-version: "~=1.15.1"
             piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
@@ -40,7 +40,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.6"
             os: ubuntu-20.04
-            build-deps: "pip setuptools wheel"
+            build-deps: "pip setuptools wheel cython"
             numpy-version: ">=1.19.0,<1.20.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -49,7 +49,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.7"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython"
             numpy-version: ">=1.15.1,<1.16.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -58,7 +58,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.7"
             os: ubuntu-20.04
-            build-deps: "pip setuptools wheel"
+            build-deps: "pip setuptools wheel cython"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -67,7 +67,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.8"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython"
             numpy-version: ">=1.17.0,<1.18.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -76,7 +76,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.8"
             os: ubuntu-20.04
-            build-deps: "pip setuptools wheel"
+            build-deps: "pip setuptools wheel cython"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -85,7 +85,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.9"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -94,7 +94,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.9"
             os: ubuntu-20.04
-            build-deps: "pip setuptools wheel"
+            build-deps: "pip setuptools wheel cython"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -103,7 +103,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.10"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython"
             numpy-version: ">=1.21.0,<1.22.0"
             piplist: "python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1"
             cflags: "-Wno-error=format-security"
@@ -112,7 +112,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.10"
             os: ubuntu-20.04
-            build-deps: "pip setuptools wheel"
+            build-deps: "pip setuptools wheel cython"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -158,10 +158,7 @@ jobs:
         # Needed for scipy versions without binary wheels
         sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb libblas-dev liblapack-dev
         python -m pip install --no-build-isolation ${BUILD_DEPS}
-        # This allows pip to build (and thus cache) binary wheels
-        pip install wheel
-        # ALLOW build isolation here so it can grab cython if necessary
-        pip install --force-reinstall "numpy${NUMPY_VERSION}"
+        pip install --no-build-isolation --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
         if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
             # scipy < 1.5 doesn't build on gcc 10+ without this argument
@@ -206,7 +203,7 @@ jobs:
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython"
             numpy-version: "~=1.15.1"
             piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 sphinx~=1.8.0 numpydoc"
             cflags: "-Wno-error=format-security"
@@ -215,7 +212,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.10"
             os: ubuntu-20.04
-            build-deps: "pip setuptools wheel"
+            build-deps: "pip setuptools wheel cython"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy sphinx numpydoc"
             cflags: ""
@@ -264,10 +261,7 @@ jobs:
         # Needed for scipy versions without binary wheels
         sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb libblas-dev liblapack-dev
         python -m pip install --no-build-isolation ${BUILD_DEPS}
-        # This allows pip to build (and thus cache) binary wheels
-        pip install wheel
-        # ALLOW build isolation here so it can grab cython if necessary
-        pip install --force-reinstall "numpy${NUMPY_VERSION}"
+        pip install --no-build-isolation --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
         if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
             # scipy < 1.5 doesn't build on gcc 10+ without this argument

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
             numpy-version: "~=1.15.1"
             piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
@@ -40,7 +40,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.6"
             os: ubuntu-20.04
-            build-deps: "pip setuptools"
+            build-deps: "pip setuptools wheel"
             numpy-version: ">=1.19.0,<1.20.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -49,7 +49,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.7"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
             numpy-version: ">=1.15.1,<1.16.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -58,7 +58,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.7"
             os: ubuntu-20.04
-            build-deps: "pip setuptools"
+            build-deps: "pip setuptools wheel"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -67,7 +67,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.8"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
             numpy-version: ">=1.17.0,<1.18.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -76,7 +76,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.8"
             os: ubuntu-20.04
-            build-deps: "pip setuptools"
+            build-deps: "pip setuptools wheel"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -85,7 +85,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.9"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -94,7 +94,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.9"
             os: ubuntu-20.04
-            build-deps: "pip setuptools"
+            build-deps: "pip setuptools wheel"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -103,7 +103,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.10"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
             numpy-version: ">=1.21.0,<1.22.0"
             piplist: "python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1"
             cflags: "-Wno-error=format-security"
@@ -112,7 +112,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.10"
             os: ubuntu-20.04
-            build-deps: "pip setuptools"
+            build-deps: "pip setuptools wheel"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -206,7 +206,7 @@ jobs:
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2"
             numpy-version: "~=1.15.1"
             piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 sphinx~=1.8.0 numpydoc"
             cflags: "-Wno-error=format-security"
@@ -215,7 +215,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.10"
             os: ubuntu-20.04
-            build-deps: "pip setuptools"
+            build-deps: "pip setuptools wheel"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy sphinx numpydoc"
             cflags: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
         PIPLIST: ${{ matrix.piplist }}
         CFLAGS: ${{ matrix.cflags }}
         CDF_VER: ${{ matrix.cdf-munged-version }}
+        PYVER: ${{ matrix.python-version }}
+        DEPSTRAT: ${{ matrix.dep-strategy }}
       run: |
         sudo apt-get update -qq
         # Needed for scipy versions without binary wheels
@@ -161,7 +163,12 @@ jobs:
         # ALLOW build isolation here so it can grab cython if necessary
         pip install --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
-        pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
+        if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
+            # scipy < 1.5 doesn't build on gcc 10+ without this argument
+            FOPT="-fallow-argument-mismatch" pip install --no-build-isolation --log=install_log.txt ${NUMPY} ${PIPLIST}
+        else
+            pip install --no-build-isolation ${NUMPY} ${PIPLIST}
+        fi
         pip freeze --all
         if [ ! -d ${HOME}/cdf ]; then wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${CDF_VER}/linux/cdf${CDF_VER}-dist-cdf.tar.gz; tar xzf cdf${CDF_VER}-dist-cdf.tar.gz; cd cdf${CDF_VER}-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
@@ -250,6 +257,8 @@ jobs:
         PIPLIST: ${{ matrix.piplist }}
         CFLAGS: ${{ matrix.cflags }}
         CDF_VER: ${{ matrix.cdf-munged-version }}
+        PYVER: ${{ matrix.python-version }}
+        DEPSTRAT: ${{ matrix.dep-strategy }}
       run: |
         sudo apt-get update -qq
         # Needed for scipy versions without binary wheels
@@ -257,9 +266,15 @@ jobs:
         python -m pip install --no-build-isolation ${BUILD_DEPS}
         # This allows pip to build (and thus cache) binary wheels
         pip install wheel
+        # ALLOW build isolation here so it can grab cython if necessary
         pip install --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
-        pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
+        if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
+            # scipy < 1.5 doesn't build on gcc 10+ without this argument
+            FOPT="-fallow-argument-mismatch" pip install --no-build-isolation ${NUMPY} ${PIPLIST}
+        else
+            pip install --no-build-isolation ${NUMPY} ${PIPLIST}
+        fi
         pip freeze --all
         if [ ! -d ${HOME}/cdf ]; then wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${CDF_VER}/linux/cdf${CDF_VER}-dist-cdf.tar.gz; tar xzf cdf${CDF_VER}-dist-cdf.tar.gz; cd cdf${CDF_VER}-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,8 @@ jobs:
         # pip install . does not cache wheel
         pip install --no-build-isolation --no-deps --log=install_log.txt .
         echo "pip log:" && cat install_log.txt && echo "End pip log"
+        pushd tests; python -c "import spacepy; print(spacepy.__file__); import os.path; print(os.listdir(os.path.dirname(spacepy.__file__)))"; popd
+        ls build/* || true
         cd tests; . ${HOME}/cdf/bin/definitions.B; xvfb-run python test_all.py -v
 
   irbem-unicode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
       run: |
         # Install (not in build)
         # pip install . does not cache wheel
-        pip install --no-build-isolation --no-deps .
+        pip install --no-build-isolation --no-deps --log=install_log.txt .
+        echo "pip log:" && cat install_log.txt && echo "End pip log"
         cd tests; . ${HOME}/cdf/bin/definitions.B; xvfb-run python test_all.py -v
 
   irbem-unicode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
             numpy-version: "~=1.15.1"
             piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1"
             cflags: "-Wno-error=format-security"
@@ -39,6 +40,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.6"
             os: ubuntu-20.04
+            build-deps: "pip setuptools"
             numpy-version: ">=1.19.0,<1.20.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -47,6 +49,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.7"
             os: ubuntu-20.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
             numpy-version: ">=1.15.1,<1.16.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -55,6 +58,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.7"
             os: ubuntu-20.04
+            build-deps: "pip setuptools"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -63,6 +67,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.8"
             os: ubuntu-20.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
             numpy-version: ">=1.17.0,<1.18.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -71,6 +76,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.8"
             os: ubuntu-20.04
+            build-deps: "pip setuptools"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -79,6 +85,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.9"
             os: ubuntu-20.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
             numpy-version: ">=1.18.0,<1.19.0"
             piplist: "python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1"
             cflags: "-Wno-error=format-security"
@@ -87,6 +94,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.9"
             os: ubuntu-20.04
+            build-deps: "pip setuptools"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -95,6 +103,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.10"
             os: ubuntu-20.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
             numpy-version: ">=1.21.0,<1.22.0"
             piplist: "python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1"
             cflags: "-Wno-error=format-security"
@@ -103,6 +112,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.10"
             os: ubuntu-20.04
+            build-deps: "pip setuptools"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
@@ -136,6 +146,7 @@ jobs:
         key: cdf-v${{ env.cdf-cache-version}}-${{ matrix.cdf-version }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
     - name: Install dependencies
       env:
+        BUILD_DEPS: ${{ matrix.build-deps }}
         NUMPY_VERSION: ${{ matrix.numpy-version }}
         PIPLIST: ${{ matrix.piplist }}
         CFLAGS: ${{ matrix.cflags }}
@@ -144,13 +155,14 @@ jobs:
         sudo apt-get update -qq
         # Needed for scipy versions without binary wheels
         sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb libblas-dev liblapack-dev
-        python -m pip install --upgrade pip
+        python -m pip install --no-build-isolation ${BUILD_DEPS}
         # This allows pip to build (and thus cache) binary wheels
         pip install wheel
+        # ALLOW build isolation here so it can grab cython if necessary
         pip install --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
         pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
-        pip freeze
+        pip freeze --all
         if [ ! -d ${HOME}/cdf ]; then wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${CDF_VER}/linux/cdf${CDF_VER}-dist-cdf.tar.gz; tar xzf cdf${CDF_VER}-dist-cdf.tar.gz; cd cdf${CDF_VER}-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
@@ -159,7 +171,9 @@ jobs:
     - name: Install and run tests
       working-directory: ${{ github.workspace }}
       run: |
-        python setup.py build
+        # Install (not in build)
+        # pip install . does not cache wheel
+        pip install --no-build-isolation --no-deps .
         cd tests; . ${HOME}/cdf/bin/definitions.B; xvfb-run python test_all.py -v
 
   irbem-unicode:
@@ -182,6 +196,7 @@ jobs:
         include:
           - python-version: "3.6"
             os: ubuntu-20.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0"
             numpy-version: "~=1.15.1"
             piplist: "python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 sphinx~=1.8.0 numpydoc"
             cflags: "-Wno-error=format-security"
@@ -190,6 +205,7 @@ jobs:
             dep-strategy: "oldest"
           - python-version: "3.10"
             os: ubuntu-20.04
+            build-deps: "pip setuptools"
             numpy-version: ">=1.21.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy sphinx numpydoc"
             cflags: ""
@@ -226,6 +242,7 @@ jobs:
         key: cdf-v${{ env.cdf-cache-version}}-${{ matrix.cdf-version }}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}
     - name: Install dependencies
       env:
+        BUILD_DEPS: ${{ matrix.build-deps }}
         NUMPY_VERSION: ${{ matrix.numpy-version }}
         PIPLIST: ${{ matrix.piplist }}
         CFLAGS: ${{ matrix.cflags }}
@@ -234,13 +251,13 @@ jobs:
         sudo apt-get update -qq
         # Needed for scipy versions without binary wheels
         sudo apt-get install libhdf5-serial-dev gcc gfortran xvfb libblas-dev liblapack-dev
-        python -m pip install --upgrade pip
+        python -m pip install --no-build-isolation ${BUILD_DEPS}
         # This allows pip to build (and thus cache) binary wheels
         pip install wheel
         pip install --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
         pip install "numpy${NUMPY_VERSION}" ${PIPLIST}
-        pip freeze
+        pip freeze --all
         if [ ! -d ${HOME}/cdf ]; then wget https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf${CDF_VER}/linux/cdf${CDF_VER}-dist-cdf.tar.gz; tar xzf cdf${CDF_VER}-dist-cdf.tar.gz; cd cdf${CDF_VER}-dist; make OS=linux ENV=gnu SHARED=yes CURSES=no FORTRAN=no all; make INSTALLDIR=$HOME/cdf/ install.lib install.definitions; rm -f ${HOME}/cdf/lib/libcdf.a; cd ..; fi
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
@@ -249,7 +266,7 @@ jobs:
     - name: Build spacepy and docs
       working-directory: ${{ github.workspace }}
       run: |
-        python setup.py build
+        pip install --no-build-isolation --no-deps .
         cd Doc
         . ${HOME}/cdf/bin/definitions.B
         make html | tee doc_log.txt

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -1,4 +1,4 @@
-Building spacepy for distribution (20220426)
+Building spacepy for distribution (20230725)
 ============================================
 Since this has to happen on multiple platforms, a single script doesn't work.
 
@@ -37,6 +37,7 @@ source ${HOME}/cdf/bin/definitions.B
 Make a clean isolated environment just for SpacePy build:
 ~/miniconda/bin/conda create -y -n spacepy_build python=3
 source ~/miniconda/bin/activate spacepy_build
+conda install -y pip python-build wheel
 conda install -y numpy
 conda install -y scipy matplotlib h5py astropy sphinx numpydoc
 
@@ -56,18 +57,26 @@ Clear out old builds:
 Be sure that LD_LIBRARY_PATH and similar aren't set so that the conda
 environment isn't pulling in anything from the host environment.
 
-Build so getting the latest inputs for the autodocs:
-    PYTHONNOUSERSITE=1 PYTHONPATH= python setup.py build
+    PYTHONNOUSERSITE=1 PYTHONPATH= python-build -s -n -x
+
+(We are only building the source distribution, do not want an isolated
+build environment because already installed the dependencies, and are
+similarly skipping the dependency check...particularly because the
+dependencies for the source build and binary build are different but
+build doesn't support that.)
+
+The resulting .tar.gz is in the dists directory.
+
+Install so getting the latest inputs for the autodocs:
+    PYTHONNOUSERSITE=1 PYTHONPATH= pip install --no-build-isolation --no-deps .
+(This is subject to future review to support installing in a temporary
+location.)
 
 Build the docs:
     cd Doc
     PYTHONNOUSERSITE=1 PYTHONPATH= make html
     PYTHONNOUSERSITE=1 PYTHONPATH= make latexpdf
 Newer sphinx uses latexmk (apt-get install latexmk) not pdflatex...
-
-Then:
-    PYTHONNOUSERSITE=1 PYTHONPATH= python setup.py sdist --formats=gztar,zip
-Tarball and zip are in the dist directory.
 
 Note: Building the source distribution will not build the docs, this
 needs to be done manually so they can be uploaded separately later.
@@ -196,10 +205,10 @@ directory. Use the spacepy_build conda environment and install twine:
 
 and then do the upload:
 
-  PYTHONNOUSERSITE=1 PYTHONPATH= twine upload -r testpypi spacepy-*.zip spacepy-*.whl
+  PYTHONNOUSERSITE=1 PYTHONPATH= twine upload -r testpypi spacepy-*-doc.zip spacepy-*.whl spacepy-*.tar.gz
 
 PyPI does not support Windows standalone installers, and can only take
-one source distribution (zip or tar.gz, so we use zip.)
+one source distribution (zip or tar.gz); build seems to prefer the tarball.
 
 Test installing with:
 
@@ -215,9 +224,10 @@ Release to PyPI
 
 https://python-packaging-tutorial.readthedocs.io/en/latest/uploading_pypi.html
 
-  twine upload spacepy-*.zip spacepy-*.whl
+  twine upload spacepy-*-doc.zip spacepy-*.whl spacepy-*.tar.gz
 
-Do not upload the .tar.gz since can only upload one source package per release.
+Do not make or upload a .zip sdist since can only upload one source
+package per release.
 
 There's no longer any capability to edit information on PyPI, it's
 straight from the setup.py metadata. This may cause problems with the
@@ -236,9 +246,8 @@ necessarily the best) is to use just "x.y.z" as the title with nothing
 the "describe."
 
 Click in the "upload binaries" area and upload all the files: source
-distribution, Windows installers, wheels. Also upload the
-documentation PDF (spacepy-x.y.z-doc.pdf) and a zip
-(spacepy-x.y.z-doc.zip).
+distribution, wheels, documentation PDF (spacepy-x.y.z-doc.pdf) and a
+zip (spacepy-x.y.z-doc.zip).
 
 Documentation update
 --------------------

--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -69,8 +69,8 @@ Then:
     PYTHONNOUSERSITE=1 PYTHONPATH= python setup.py sdist --formats=gztar,zip
 Tarball and zip are in the dist directory.
 
-Note: building the source distribution will build the docs, but no longer needs
-to do a binary build.
+Note: Building the source distribution will not build the docs, this
+needs to be done manually so they can be uploaded separately later.
 
 Prepare the Windows binaries
 ----------------------------

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -291,7 +291,7 @@ epub_copyright = u'2011, The SpacePy Team'
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     'pip': ('https://pip.pypa.io/en/stable/', None),

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -288,12 +288,11 @@ epub_copyright = u'2011, The SpacePy Team'
 # Allow duplicate toc entries.
 #epub_tocdup = True
 
-
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'pip': ('https://pip.pypa.io/en/stable/', None),
 }

--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -143,6 +143,13 @@ history. The oldest version supported according to this policy is in
      - 56.1.0 (2021/5/4)
      - 67.5.0 (2023/3/5)
      - tested with 44.1.1
+   * - `wheel <https://wheel.readthedocs.io/en/stable/news.html>`_
+     - 0.40.0 (2023/3/14)
+     - **0.34.2** (2020/01/30)
+     - 0.37.1 (2021/12/22)
+     - 0.38.0 (2022/10/21)
+     - 0.38.0 (2022/10/21)
+     - tested with 0.34.2
    * - `sphinx <https://www.sphinx-doc.org/en/master/changes.html>`_
        (only needed for developers to build documentation)
      - 5.1.1 (2022/7/26)

--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -129,6 +129,20 @@ history. The oldest version supported according to this policy is in
      - 1.6.0 (2020/12/31)
      - 1.7.0 (2021/6/20)
      - 1.0.0 (2017/10/25)
+   * - `pip <https://pip.pypa.io/en/stable/news/>`_
+     - 23.1.2 (2023/4/26)
+     - **20.0.2** (2020/1/24)
+     - 22.0.2 (2022/1/30)
+     - 21.1 (2021/4/24)
+     - 22.3 (2022/10/15)
+     - tested with 20.0.2
+   * - `setuptools <https://setuptools.pypa.io/en/latest/history.html>`_
+     - 67.7.1 (2023/4/21)
+     - **44.1.1** (c. 2020/1/1)
+     - 59.6.0 (2021/12/12)
+     - 56.1.0 (2021/5/4)
+     - 67.5.0 (2023/3/5)
+     - tested with 44.1.1
    * - `sphinx <https://www.sphinx-doc.org/en/master/changes.html>`_
        (only needed for developers to build documentation)
      - 5.1.1 (2022/7/26)
@@ -137,3 +151,11 @@ history. The oldest version supported according to this policy is in
      - 3.3.0 (2020/11/2)
      - 4.5.0 (2022/3/28)
      - 1.8.0 (2018/9/13)
+   * - `build <https://pypa-build.readthedocs.io/en/latest/changelog.html>`_
+       (only needed for developers to build releases)
+     - 0.10.0 (2023/1/11)
+     - N/A
+     - 0.7.0 (2021/9/16)
+     - **0.4.0** (2021/5/23)
+     - 0.8.0 (2022/5/22)
+     - tested with 0.4.0

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -49,6 +49,16 @@ C compiler
 If you are installing SpacePy from source, a working C compiler
 is required. (Not necessary for the Windows binary installer.)
 
+pip
+---
+`pip <https://pip.pypa.io/>`_ is now the expected installer for Python
+packages. Almost any modern Python installation will include it.
+
+setuptools
+----------
+`setuptools <https://setuptools.pypa.io>`_ is the installer backend. It
+is commonly included and, if necessary, installable with ``pip``.
+
 Soft Dependencies
 =================
 Without these packages, SpacePy will install, but certain features may

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -118,8 +118,7 @@ Fortran compiler
 ----------------
 If installing from source, :mod:`~spacepy.irbempy` requires a Fortran
 compiler. (This is not required for the Windows binary installer).
-Supported compilers are the GNU compiler ``gfortran``, the older GNU
-compiler ``g77``, and the Portland Group PGI compiler.
+The Supported compiler is the GNU compiler ``gfortran``.
 
 If :mod:`~spacepy.irbempy` is to be used, the Fortran compiler (and
 f2py) must be installed before SpacePy.

--- a/Doc/source/install.rst
+++ b/Doc/source/install.rst
@@ -10,8 +10,7 @@ The simplest way from zero (no Python) to a working SpacePy setup is:
 
 If you already have a working Python setup, install SpacePy by:
 
-  1. ``pip install --upgrade numpy``
-  2. ``pip install --upgrade spacepy``
+  1. ``pip install --upgrade spacepy``
 
 This will install a binary build of SpacePy if available (currently
 only on Windows), otherwise it will attempt to compile. It will also
@@ -66,15 +65,15 @@ For source releases, after downloading and
 unpacking, run (a virtual environment, such as a conda environment, is
 recommended)::
 
-    python setup.py install
+    pip install .
 
 or, to install for all users (not in a virtual environment)::
 
-    sudo python setup.py install
+    sudo pip install .
 
 or, to install for a single user (not in a virtual environment)::
 
-    python setup.py install --user
+    pip install . --user
 
 If you do not have administrative privileges, or you will be
 developing for SpacePy, we strongly recommend using virtual
@@ -82,9 +81,57 @@ environments.
 
 To install in custom location, e.g.::
 
-    python setup.py install --home=/n/packages/lib/python
+    pip install . --prefix /n/packages/lib/python
 
-Installs using ``setup.py`` do not require setuptools.
+(See :ref:`\\\\\\-\\\\\\-prefix <install_--prefix>` documentation
+and the related :option:`--target`, :option:`--root`).
+
+The closest analogy to the old ``setup.py`` handling (no dependency
+handling, no isolated build) is::
+
+    pip install . --no-build-isolation --no-deps
+
+This is recommended if dependencies are managed by the OS or manually.
+
+If installing into the system Python version on Linux (and potentially
+some other cases), you will need to pass the flag
+:option:`--break-system-packages`. Despite the frightening name this is
+usually safe, although in this case is recommended to use
+:option:`--no-build-isolation` :option:`--no-deps` and manage the
+dependencies using the system package manager or conda.
+
+Documentation
+=============
+If you want to build the documentation yourself (rather than using the
+online documentation), install sphinx and numpydoc. The easiest way is
+via pip::
+
+  pip install sphinx numpydoc
+
+They are also available via conda::
+
+  conda install sphinx numpydoc
+
+Compiling
+=========
+With the dependencies installed, SpacePy can be built from source.
+You can always get the latest source code for SpacePy from our `github
+repository <https://github.com/spacepy/spacepy>`_ and the latest
+release from `PyPI <https://pypi.org/project/SpacePy/#files>`__
+
+Following the instructions above will compile before the installation,
+if installing from source or a binary installer is not available. If
+this fails, specify a Fortran compiler::
+
+    pip install . --config-setting="--build-option=--fcompiler=gnu95"
+
+The supported compiler is ``gnu95`` (the GNU gfortran compiler); ``none``
+can be specified as a "compiler" to skip all Fortran. You can also specify
+the full path to the Fortran 77 compiler with ``--f77exec`` and to the
+Fortran 90 compiler with ``--f90exec``::
+
+    pip install . --config-setting="--build-option=--fcompiler=gnu95" --config-setting="--build-option=--f77exec=/usr/bin/gfortran" --config-setting="--build-option=--f90exec=/usr/bin/gfortran"
+
 
 Troubleshooting
 ===============
@@ -102,8 +149,8 @@ build environment::
   pip install spacepy --no-build-isolation
 
 Manually installing all dependencies (via ``pip``, ``conda``, or other
-means) and then installing the source release via ``setup.py`` is also
-an option.
+means) and then installing the source release with
+``--no-build-isolation --no-deps``
 
 ``pip`` suppresses detailed output from the build process. To
 troubleshoot a failure to install, it is useful to write this detailed

--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -96,9 +96,8 @@ If this fails, specify a Fortran compiler::
     python setup.py build --fcompiler=gnu95
 
 ``python setup.py build --help-fcompiler`` will list options for
-Fortran compilers. Currently available compilers are ``pg``,
-``gnu95``, ``gnu``, ``intelem``, ``intel`` or ``none`` (to skip all
-Fortran); ``gnu95`` (the GNU gfortran compiler) is recommended.
+Fortran compilers. The supported compiler is ``gnu95`` (the GNU gfortran
+compiler); ``none`` can be specified as a "compiler" to skip all Fortran.
 
 Install for one user::
 

--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -50,6 +50,10 @@ SpacePy usually works with the system Python on Linux. To install dependencies v
 For other distributions, check :doc:`dependencies` and install by hand
 or via your package manager. 
 
+To get the dependencies for building documentation::
+
+  sudo apt-get install python3-sphinx python3-numpydoc
+
 .. _linux_CDF:
 
 CDF
@@ -58,7 +62,6 @@ CDF
 It is recommended to install the ncurses library; on Ubuntu and Debian::
 
     sudo apt-get install ncurses-dev
-
 
 Download the latest `CDF library <http://cdf.gsfc.nasa.gov/>`_. Choose
 the file ending in ``-dist-all.tar.gz`` from the ``linux``
@@ -78,64 +81,16 @@ SpacePy can find it. If you choose to install elsewhere, see the CDF documentati
 particularly the notes on the ``CDF_BASE`` and ``CDF_LIB`` environment variables. 
 SpacePy uses these variables to find the library.
 
-Compiling
-=========
-
-With the dependencies installed, SpacePy can be built from source.
-This uses standard Python distutils.
-You can always get the latest source code for SpacePy from our `github
-repository <https://github.com/spacepy/spacepy>`_ and the latest
-release from `PyPI <https://pypi.org/project/SpacePy/#files>`_
-
-Build::
-
-     python setup.py build
-
-If this fails, specify a Fortran compiler::
-
-    python setup.py build --fcompiler=gnu95
-
-``python setup.py build --help-fcompiler`` will list options for
-Fortran compilers. The supported compiler is ``gnu95`` (the GNU gfortran
-compiler); ``none`` can be specified as a "compiler" to skip all Fortran.
-
-Install for one user::
-
-    python setup.py install --user
-
-If you're using conda, installation as user isn't recommended::
-
-    python setup.py install
-
-Or install for all users on the system::
-
-    sudo python setup.py install
-
-If you want to build the documentation yourself (rather than using the
-documentation shipped with SpacePy), install sphinx and numpydoc. The
-easiest way is via pip::
-
-  pip install sphinx numpydoc
-
-They are also available via conda::
-
-  conda install sphinx numpydoc
-
-Or the package manager::
-
-  sudo apt-get install python3-sphinx python3-numpydoc
-
 Raspberry Pi
 ============
 SpacePy works on Raspberry Pi, using Raspberry Pi OS in 32-bit or
 64-bit flavors. A few tips:
 
    * It is highly recommended to install all dependencies (numpy,
-     etc.)  via the system package manager ``apt-get`` rather than
+     etc.) via the system package manager ``apt-get`` rather than
      pip, as prebuilt wheels are not generally available and compiling
      dependencies on the Pi can take a very long time::
 
       sudo apt-get install gfortran python3-numpy python3-dateutil python3-scipy python3-h5py python3-matplotlib
 
-   * Similarly, if installing SpacePy via pip, use the
-     ``--no-build-isolation`` flag to use the system numpy.
+   * Similarly, use the ``--no-build-isolation`` flag to use the system numpy.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -24,6 +24,11 @@ Not all dependencies are required for all functionality; see
 :doc:`dependencies` for full details, including what functionality is
 lost if a dependency is not installed.
 
+The ``setup.py`` based install process is no longer supported; as such,
+``pip`` and ``setuptools`` are now required. ``wheel`` is required if
+building from source. The vast majority of modern Python distributions
+already have these requirements.
+
 The minimum supported version of all dependencies was updated in
 SpacePy 0.5.0. Minimum versions are:
 

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -36,6 +36,10 @@ SpacePy 0.5.0. Minimum versions are:
   * numpy 1.15.1
   * scipy 1.0
 
+The only supported compiler is the GNU gfortran compiler, aka
+"gnu95". Support for the older g77 compiler, as well as the Portland
+Group and Intel compilers, has been removed.
+
 New features
 ************
 `~.datamodel.readJSONheadedASCII` and `~.datamodel.readJSONMetadata`

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,11 +4,9 @@ include INSTALL
 include CHANGELOG
 # Defining build requirements (numpy)
 include pyproject.toml
-#Sphinx docs and source
-graft Doc/build/html
+# Sphinx docs source
 include Doc/Makefile
 graft Doc/source
-include Doc/build/latex/SpacePy.pdf
 #Data. Despite distutils docs, package_data not auto-included.
 graft spacepy/data
 graft spacepy/pybats/sample_data

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,6 @@ include Doc/Makefile
 graft Doc/source
 #Data. Despite distutils docs, package_data not auto-included.
 graft spacepy/data
-graft spacepy/pybats/sample_data
 #C and Fortan sources, not in extension modules
 graft spacepy/irbempy/irbem-lib-*
 include spacepy/libspacepy/*.h

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -17,16 +17,16 @@ source ${HOME}/cdf/bin/definitions.B
 # coupled with what's the earliest and latest version of each dep
 # which works with that Python.
 TESTS=(
-       "3.6|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy~=1.15.1|python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1|old"
-       "3.6|pip setuptools wheel|numpy>=1.19.0,<1.20.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.7|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.15.1,<1.16.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
-       "3.7|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.8|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.17.0,<1.18.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
-       "3.8|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.18.0,<1.19.0|python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
-       "3.9|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.10|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.21.0,<1.22.0|python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1|old"
-       "3.10|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.6|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython|numpy~=1.15.1|python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1|old"
+       "3.6|pip setuptools wheel cython|numpy>=1.19.0,<1.20.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.7|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython|numpy>=1.15.1,<1.16.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
+       "3.7|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.8|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython|numpy>=1.17.0,<1.18.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
+       "3.8|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.18.0,<1.19.0|python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
+       "3.9|pip setuptools wheel|numpy>=1.21.0 cython|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.10|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython|numpy>=1.21.0,<1.22.0|python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1|old"
+       "3.10|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
       )
 for thisTest in "${TESTS[@]}"
 do
@@ -39,13 +39,12 @@ do
     ENVNAME=py${PYVER//.}
     ~/miniconda/bin/conda create -y -n ${ENVNAME} python=${PYVER}
     source ~/miniconda/bin/activate ${ENVNAME}
-    # Get the preferred version of pip and setuptools
+    # Get the preferred version of install tools, numpy's dependencies
     pip install --no-build-isolation ${PIP}
     # Get numpy in first (lots uses distutils)
-    # ALLOW build isolation here so it can grab cython if necessary
-    pip install ${NUMPY}
-    # But don't let it grab a different version of numpy later,
-    # and build against the installed numpy
+    pip install --no-build-isolation ${NUMPY}
+    # Don't let it grab a different version of numpy later,
+    # and always build against the installed numpy
     if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
 	# scipy < 1.5 doesn't build on gcc 10+ without this argument
 	FOPT="-fallow-argument-mismatch" pip install --no-build-isolation ${NUMPY} ${PIPLIST}

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -17,16 +17,16 @@ source ${HOME}/cdf/bin/definitions.B
 # coupled with what's the earliest and latest version of each dep
 # which works with that Python.
 TESTS=(
-       "3.6|pip~=20.0.0 setuptools~=44.1.0|numpy~=1.15.1|python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1|old"
-       "3.6|pip setuptools|numpy>=1.19.0,<1.20.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.7|pip~=20.0.0 setuptools~=44.1.0|numpy>=1.15.1,<1.16.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
-       "3.7|pip setuptools|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.8|pip~=20.0.0 setuptools~=44.1.0|numpy>=1.17.0,<1.18.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
-       "3.8|pip setuptools|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.9|pip~=20.0.0 setuptools~=44.1.0|numpy>=1.18.0,<1.19.0|python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
-       "3.9|pip setuptools|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
-       "3.10|pip~=20.0.0 setuptools~=44.1.0|numpy>=1.21.0,<1.22.0|python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1|old"
-       "3.10|pip setuptools|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.6|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy~=1.15.1|python-dateutil~=2.1.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1|old"
+       "3.6|pip setuptools wheel|numpy>=1.19.0,<1.20.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.7|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.15.1,<1.16.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
+       "3.7|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.8|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.17.0,<1.18.0|python-dateutil~=2.1.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
+       "3.8|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.18.0,<1.19.0|python-dateutil~=2.1.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1|old"
+       "3.9|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
+       "3.10|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2|numpy>=1.21.0,<1.22.0|python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1|old"
+       "3.10|pip setuptools wheel|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy|new"
       )
 for thisTest in "${TESTS[@]}"
 do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,4 @@ packages = ["spacepy"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-spacepy = ["data/*.*", "pybats/sample_data/*", "data/LANLstar/*",
-           "data/TS07D/TAIL_PAR/*"]
+spacepy = ["data/*.*", "data/LANLstar/*", "data/TS07D/TAIL_PAR/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,55 @@ requires = ["setuptools", "wheel",
     "numpy ~= 1.21.0 ; python_version == '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'",
     "numpy ~= 1.21.0 ; python_version >= '3.10'",
     ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "spacepy"
+version = "0.5.0a0"
+description = "SpacePy: Tools for Space Science Applications"
+readme = "README.md"
+requires-python = ">=3.6"
+license = { "file" = "LICENSE.md" }
+authors = [{ "name" = "SpacePy team", "email" = "spacepy@lanl.gov" }]
+maintainers = [
+  {"name" = "Steve Morley", "email" = "smorley@lanl.gov"},
+  {"name" = "Dan Welling", "email" = "dwelling@umich.edu"},
+  {"name" = "Brian Larsen", "email" = "balarsen@lanl.gov"},
+  {"name" = "Jon Niehof", "email" = "Jonathan.Niehof@unh.edu"},
+]
+keywords = ["magnetosphere","plasma","physics","space","solar.wind","space.weather","magnetohydrodynamics"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Python Software Foundation License",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: C",
+  "Programming Language :: Fortran",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Scientific/Engineering :: Astronomy",
+  "Topic :: Scientific/Engineering :: Atmospheric Science",
+  "Topic :: Scientific/Engineering :: Physics",
+  "Topic :: Scientific/Engineering :: Visualization",
+  "Topic :: Software Development :: Libraries :: Python Modules"
+]
+urls = { "homepage" = "https://spacepy.github.io/", "repository" = "https://github.com/spacepy/spacepy.git" }
+dependencies = [
+  "numpy>=1.15.1",
+  "scipy>=1.0",
+  "matplotlib>=3.1",
+  "h5py>=2.10",
+  "python_dateutil>=2.1",
+]
+
+[tool.setuptools]
+packages = ["spacepy"]
+zip-safe = false
+
+[tool.setuptools.package-data]
+spacepy = ["data/*.*", "pybats/sample_data/*", "data/LANLstar/*",
+           "data/TS07D/TAIL_PAR/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["spacepy"]
+packages = ["spacepy", "spacepy.irbempy", "spacepy.pycdf",
+  "spacepy.plot", "spacepy.pybats", "spacepy.toolbox", "spacepy.ctrans",
+]
 zip-safe = false
 
 [tool.setuptools.package-data]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ if 'bdist_wheel' in sys.argv:
     import setuptools
     import wheel
 use_setuptools = "setuptools" in globals()
-use_wininst = "bdist_wininst" in sys.argv
 
 import copy
 import os, shutil, getopt, glob, re
@@ -42,11 +41,6 @@ else:
     from distutils.command.install import install as _install
     from distutils.command.sdist import sdist as _sdist
 
-if use_wininst:
-    if use_setuptools:
-        from setuptools.command.bdist_wininst import bdist_wininst as _bdist_wininst
-    else:
-        from distutils.command.bdist_wininst import bdist_wininst as _bdist_wininst
 if 'bdist_wheel' in sys.argv:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 import distutils.ccompiler
@@ -694,7 +688,7 @@ class build(_build):
         self.compile_libspacepy()
         if sys.platform == 'win32':
             #Copy mingw32 DLLs. This keeps them around if ming is uninstalled,
-            #but more important puts them where bdist_wininst and bdist_wheel
+            #but more important puts them where bdist_wheel
             #will include them in binary installers
             copy_dlls(os.path.join(self.build_lib, 'spacepy', 'mingw'))
         _build.run(self) #need subcommands BEFORE building irbem
@@ -765,21 +759,6 @@ def copy_dlls(outdir):
         os.makedirs(outdir)
     for f in libnames:
         shutil.copy(os.path.join(libdir, f), outdir)
-
-
-if use_wininst:
-    class bdist_wininst(_bdist_wininst):
-        """Handle compiler options, libraries for build on Windows install"""
-
-        user_options = _bdist_wininst.user_options + compiler_options
-
-        def initialize_options(self):
-            initialize_compiler_options(self)
-            _bdist_wininst.initialize_options(self)
-
-        def finalize_options(self):
-            _bdist_wininst.finalize_options(self)
-            finalize_compiler_options(self)
 
 
 if 'bdist_wheel' in sys.argv:
@@ -871,8 +850,6 @@ setup_kwargs = {
                  'sdist': sdist,
           },
 }
-if use_wininst:
-    setup_kwargs['cmdclass']['bdist_wininst'] = bdist_wininst
 
 if use_setuptools:
 #Sadly the format here is DIFFERENT than the distutils format

--- a/setup.py
+++ b/setup.py
@@ -688,7 +688,7 @@ packages = ['spacepy', 'spacepy.irbempy', 'spacepy.pycdf',
             'spacepy.plot', 'spacepy.pybats', 'spacepy.toolbox',
             'spacepy.ctrans', ]
 #If adding to package_data, also put in MANIFEST.in
-package_data = ['data/*.*', 'pybats/sample_data/*', 'data/LANLstar/*', 'data/TS07D/TAIL_PAR/*']
+package_data = ['data/*.*', 'data/LANLstar/*', 'data/TS07D/TAIL_PAR/*']
 
 # Duplicated between here and pyproject.toml because pyproject.toml support
 # requires setuptools 61.0.0

--- a/setup.py
+++ b/setup.py
@@ -284,7 +284,7 @@ def is_win_exec(*args):
 
 compiler_options = [
         ('fcompiler=', None,
-         'specify the fortran compiler to use: pg, gnu95, gnu, intelem, intel, none [gnu95]'),
+         'specify the fortran compiler to use: gnu95, none [gnu95]'),
         ('f2py=', None,
          'specify name (or full path) of f2py executable [{0}]'.format(
         default_f2py())),

--- a/setup.py
+++ b/setup.py
@@ -690,6 +690,8 @@ packages = ['spacepy', 'spacepy.irbempy', 'spacepy.pycdf',
 #If adding to package_data, also put in MANIFEST.in
 package_data = ['data/*.*', 'pybats/sample_data/*', 'data/LANLstar/*', 'data/TS07D/TAIL_PAR/*']
 
+# Duplicated between here and pyproject.toml because pyproject.toml support
+# requires setuptools 61.0.0
 setup_kwargs = {
     'name': 'spacepy',
     'version': '0.5.0a0',
@@ -697,13 +699,9 @@ setup_kwargs = {
     'long_description': 'SpacePy: Tools for Space Science Applications',
     'author': 'SpacePy team',
     'author_email': 'spacepy@lanl.gov',
-    'maintainer': 'Steve Morley, Josef Koller, Dan Welling, Brian Larsen, Mike Henderson, Jon Niehof',
+    'maintainer': 'Steve Morley, Dan Welling, Brian Larsen, Jon Niehof',
     'maintainer_email': 'spacepy@lanl.gov',
     'url': 'https://github.com/spacepy/spacepy',
-#download_url will override pypi, so leave it out http://stackoverflow.com/questions/17627343/why-is-my-package-not-pulling-download-url
-#    'download_url': 'https://sourceforge.net/projects/spacepy/files/spacepy/',
-    'requires': ['numpy (>=1.15.1)', 'scipy (>=1.0)', 'matplotlib (>=3.1)', 'python_dateutil (>=2.1)',
-                 'h5py (>=2.10)', 'python (>=3.6)'],
     'packages': packages,
     'package_data': {'spacepy': package_data},
     'classifiers': [
@@ -728,23 +726,23 @@ setup_kwargs = {
     'keywords': ['magnetosphere', 'plasma', 'physics', 'space', 'solar.wind', 'space.weather', 'magnetohydrodynamics'],
     'license':  'PSF',
     'platforms':  ['Windows', 'Linux', 'MacOS X', 'Unix'],
+    'install_requires': [
+        'numpy>=1.15.1',
+        'scipy>=1.0',
+        'matplotlib>=3.1',
+        'h5py>=2.10',
+        'python_dateutil>=2.1',
+        # AstroPy is only required to convert to/from AstroPy, so either
+        # user has it or don't care.
+        #'astropy>=1.0',
+    ],
+    'python_requires': '>=3.6',
     'cmdclass': {'build': build,
                  'install': install,
           },
+    'zip_safe': False,
 }
 
-#Sadly the format here is DIFFERENT than the distutils format
-setup_kwargs['install_requires'] = [
-    'numpy>=1.15.1',
-    'scipy>=1.0',
-    'matplotlib>=3.1',
-    'h5py>=2.10',
-    'python_dateutil>=2.1',
-    # AstroPy is only required to convert to/from AstroPy, so either
-    # user has it or don't care.
-    #'astropy>=1.0',
-]
-setup_kwargs['python_requires'] = '>=3.6'
 if 'bdist_wheel' in sys.argv:
     setup_kwargs['cmdclass']['bdist_wheel'] = bdist_wheel
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ import distutils.ccompiler
 from setuptools import setup
 from distutils.command.build import build as _build
 from setuptools.command.install import install as _install
-from setuptools.command.sdist import sdist as _sdist
 
 if 'bdist_wheel' in sys.argv:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
@@ -294,31 +293,6 @@ compiler_options = [
         ('f90exec=', None,
          'specify the path to the F90 compiler'),
         ]
-
-
-def rebuild_static_docs():
-    """Rebuild the 'static' documentation in Doc/build"""
-    builddir = os.path.join(os.path.join('Doc', 'build', 'doctrees'))
-    indir = os.path.join('Doc', 'source')
-    outdir = os.path.join('Doc', 'build', 'html')
-    cmd = '{0} -b html -d {1} {2} {3}'.format(
-        os.environ['SPHINXBUILD'] if 'SPHINXBUILD' in os.environ
-        else 'sphinx-build',
-        builddir, indir, outdir)
-    subprocess.check_call(cmd.split())
-    os.chdir('Doc')
-    try:
-        cmd = '{0}{1} latexpdf'.format(
-            os.environ['MAKE'] if 'MAKE' in os.environ else 'make',
-            ('SPHINXBUILD=' + os.environ['SPHINXBUILD'])
-            if 'SPHINXBUILD' in os.environ else '')
-        subprocess.check_call(cmd.split())
-    except:
-        warnings.warn('PDF documentation rebuild failed:')
-        (t, v, tb) = sys.exc_info()
-        print(v)
-    finally:
-        os.chdir('..')
 
 
 #Possible names of the irbem output library. Unfortunately this seems
@@ -710,24 +684,6 @@ if 'bdist_wheel' in sys.argv:
             self.root_is_pure = False
 
 
-class sdist(_sdist):
-    """Rebuild the docs before making a source distribution"""
-
-    user_options = _sdist.user_options + compiler_options
-
-    def initialize_options(self):
-        initialize_compiler_options(self)
-        _sdist.initialize_options(self)
-
-    def finalize_options(self):
-        _sdist.finalize_options(self)
-        finalize_compiler_options(self)
-
-    def run(self):
-        rebuild_static_docs()
-        _sdist.run(self)
-
-
 packages = ['spacepy', 'spacepy.irbempy', 'spacepy.pycdf',
             'spacepy.plot', 'spacepy.pybats', 'spacepy.toolbox',
             'spacepy.ctrans', ]
@@ -774,7 +730,6 @@ setup_kwargs = {
     'platforms':  ['Windows', 'Linux', 'MacOS X', 'Unix'],
     'cmdclass': {'build': build,
                  'install': install,
-                 'sdist': sdist,
           },
 }
 

--- a/setup.py
+++ b/setup.py
@@ -644,14 +644,16 @@ def copy_dlls(outdir):
     """
     libdir = None
     libnames = None
-    libneeded = ('libgfortran', 'libgcc_s', 'libquadmath', 'libwinpthread')
+    libneeded = ('libgfortran', 'libgcc_s', 'libquadmath',)
+    liboptional = ('libwinpthread',)
     for p in os.environ['PATH'].split(';'):
         if not os.path.isdir(p):
             continue
         libnames = [
-            f for f in os.listdir(p) if f[-4:].lower() == '.dll'
-            and f.startswith(libneeded)]
-        if len(libnames) == len(libneeded):
+            f for f in os.listdir(p) if f.lower().endswith('.dll')
+            and f.startswith(libneeded + liboptional)]
+        if len([f for f in libnames if f.startswith(libneeded)])\
+           == len(libneeded):
             libdir = p
             break
     if libdir is None:

--- a/setup.py
+++ b/setup.py
@@ -39,39 +39,6 @@ import setuptools.errors
 import importlib.machinery
 
 
-#These are files that are no longer in spacepy (or have been moved)
-#having this here makes sure that during an upgrade old versions are
-#not hanging out
-#Files will be deleted in the order specified, so list files
-#before directories containing them!
-#Paths are relative to spacepy. Unix path separators are OK
-#Don't forget to delete the .pyc
-deletefiles = ['toolbox.py', 'toolbox.pyc', 'LANLstar/LANLstar.py',
-               'LANLstar/LANLstar.pyc', 'LANLstar/libLANLstar.so',
-               'LANLstar/LANLstar.pyd', 'LANLstar/__init__.py',
-               'LANLstar/__init__.pyc', 'LANLstar',
-               'time/__init__.py', 'time/__init__.pyc',
-               'time/_dates.so', 'time/_dates.dylib',
-               'time/_dates.pyd',
-               'time/time.py', 'time/time.pyc', 'time',
-               'data/LANLstar/*.net',
-               'pycdf/_pycdf.*', 'toolbox/toolbox.py*', ]
-
-
-def delete_old_files(basepath):
-    """Delete files from old versions of spacepy, under a particular path"""
-    for f in deletefiles:
-        path = os.path.join(basepath, 'spacepy',
-                            os.path.normpath(f)) #makes pathing portable
-        for p in glob.glob(path):
-            if os.path.exists(p):
-                print('Deleting {0} from old version of spacepy.'.format(p))
-                if os.path.isdir(p):
-                    os.rmdir(p)
-                else:
-                    os.remove(p)
-
-
 #Patch out bad options in Python's view of mingw
 if sys.platform == 'win32':
     import distutils.cygwinccompiler
@@ -654,7 +621,6 @@ class build(_build):
             copy_dlls(os.path.join(self.build_lib, 'spacepy', 'mingw'))
         _build.run(self) #need subcommands BEFORE building irbem
         self.compile_irbempy()
-        delete_old_files(self.build_lib)
 
 
 class install(_install):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,11 @@ if 'bdist_wheel' in sys.argv:
 import setuptools.dep_util
 
 import distutils.sysconfig
-import setuptools.errors
+# setuptools goes back and forth on having setuptools.errors
+try:
+    from setuptools.errors import OptionError
+except ImportError:
+    from distutils.errors import DistutilsOptionError as OptionError
 import importlib.machinery
 
 
@@ -218,7 +222,7 @@ def finalize_compiler_options(cmd):
                 setattr(cmd, option, defaults[option])
     #Special-case defaults, checks
     if not cmd.fcompiler in ('gnu95', 'none', 'None'):
-        raise setuptools.errors.OptionError(
+        raise OptionError(
             '--fcompiler={0} unknown'.format(cmd.fcompiler) +
             ', options: gnu95, None')
     if cmd.compiler == None and sys.platform == 'win32':


### PR DESCRIPTION
This PR reworks the installer into a modern setuptools framework rather than the existing distutils-based setup.py. Some functionality in the distutils namespace is still used; this is provided by setuptools (pypa/setuptools#2806). This also includes, of course, dropping the deprecated numpy distutils. Some other results/implications:

- The required versions of pip, setuptools, and build are now explicitly documented (and testsed)
- Support for Intel and PG compilers is dropped...gfortran only
- A lot of the installer docs are updated since it's all pip, all the way
- Built docs are no longer included in the source distribution (rst source is); it just seems a rare use case and this lets me simplify setup.py
- The installer no longer clears out old files if installing on top of old spacepy...again, this simplifies setup.py, and pip should(?) do the uninstall first instead of mixing stuff together.

Closes #688. Also fixes the current CI failure, which is due to numpy 1.18 not building under the latest cython.

I still have a personal punchlist for installer tasks, but this is getting the foundation laid for hopefully smaller task-focused updates later.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
