### PR TITLE
Fix SeaPy test on matplotlib 3.7

### DIFF
--- a/tests/test_seapy.py
+++ b/tests/test_seapy.py
@@ -8,6 +8,7 @@ Copyright 2010-2012 Los Alamos National Security, LLC.
 """
 
 import datetime as dt
+import matplotlib.axes
 import unittest
 import warnings
 import numpy as np
@@ -160,7 +161,7 @@ class SEATestsUniform(unittest.TestCase):
     def testSeaPlotShowFalse(self):
         '''Test that plot method (show=False) returns axes'''
         ax = self.obj.plot(show=False)
-        self.assertTrue(hasattr(ax, '_axes_class'))
+        self.assertTrue(isinstance(ax, matplotlib.axes.SubplotBase))
 
 
 class SEATestsUniWithBad(unittest.TestCase):


### PR DESCRIPTION
`testSeaPlotShowFalse` uses private members of the `AxesSubplot` class to check if it's actually a subplot. This changed in 3.7.0, breaking CI.

This PR changes to a check for the SubplotBase class. The actual class used is constructed at runtime so it's a lot more involved to check for that. [This discussion](https://stackoverflow.com/questions/65082998/test-if-object-is-subplot-in-matplotlib) is relevant.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
