### PR TITLE
Check for mingw32 libs before adding to path

### DIFF
--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -82,16 +82,13 @@ __all__ = ["seapy", "toolbox", "poppy", "coordinates", "time", "omni",
            "irbempy", "empiricals", "radbelt", "data_assimilation", "pycdf",
            "datamanager", "datamodel", "ae9ap9"]
 
-# on windows, make sure the mingw runtime libs are findable
-if sys.platform == 'win32':
-    minglibs = os.path.join(os.path.dirname(__file__), 'mingw')
-    if 'PATH' in os.environ:
+# Make sure the mingw runtime libs from our binary wheel are findable
+minglibs = os.path.join(os.path.dirname(__file__), 'mingw')
+if sys.platform == 'win32' and os.path.isdir(minglibs):
+    if os.environ.get('PATH'):
         if not minglibs in os.environ['PATH']:
-            if os.environ['PATH']:
-                os.environ['PATH'] += (';' + minglibs)
-            else: #empth PATH
-                os.environ['PATH'] = minglibs
-    else:
+            os.environ['PATH'] += (';' + minglibs)
+    else:  # empty or nonexistent PATH
         os.environ['PATH'] = minglibs
     try:
         os.add_dll_directory(minglibs)


### PR DESCRIPTION
Our Windows binary wheels ship the mingw32 runtime so that people don't need it installed to run. This involves adding our shipped runtime to the DLL path. Unfortunately this addition was hard-coded, and the runtime _isn't_ there if you build from source on Windows. The result is an error of the form `FileNotFoundError: [WinError 2] The system cannot find the file specified: 'C:\\Users\\user\\python\\spacepy\\spacepy\\mingw'`.

This PR makes the DLL path change contingent on the directory actually existing.

I need to muck about a bit to make sure I reproduce the problem and also that this fix works, so draft for now.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
