### PR TITLE
Update NumPy/Python build requirements to enable Python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,9 @@ jobs:
             cdf-version: "3.5.1"
             cdf-munged-version: "35_1"
             dep-strategy: "oldest"
-          - python-version: "3.10"
-            os: ubuntu-20.04
-            numpy-version: ">=1.21.0"
+          - python-version: "3.11"
+            os: ubuntu-22.04
+            numpy-version: ">=1.22.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy"
             cflags: ""
             cdf-version: "3.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,7 @@ requires = ["setuptools", "wheel",
     "numpy ~= 1.20.0 ; python_version == '3.8' and platform_system == 'Darwin' and platform_machine == 'arm64'",
     "numpy ~= 1.18.0 ; python_version == '3.9' and (platform_system != 'Darwin' or platform_machine != 'arm64')",
     "numpy ~= 1.21.0 ; python_version == '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "numpy >= 1.21.0 ; python_version >= '3.10'",
+    "numpy ~= 1.21.0 ; python_version == '3.10'",
+    "numpy ~= 1.22.0 ; python_version == '3.11'",
+    "numpy >= 1.23.0 ; python_version >= '3.12'",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,5 @@ requires = ["setuptools", "wheel",
     "numpy ~= 1.20.0 ; python_version == '3.8' and platform_system == 'Darwin' and platform_machine == 'arm64'",
     "numpy ~= 1.18.0 ; python_version == '3.9' and (platform_system != 'Darwin' or platform_machine != 'arm64')",
     "numpy ~= 1.21.0 ; python_version == '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "numpy ~= 1.21.0 ; python_version >= '3.10'",
+    "numpy >= 1.21.0 ; python_version >= '3.10'",
     ]


### PR DESCRIPTION
This PR changes the `build_requires` settings in `pyproject.toml` to enable spacepy to work on Python 3.11.  
 
I'll probably try adding Python 3.11 to the CI also.

Closes #679.  Related to #680.

## PR Checklist

- [x] Pull request has descriptive title
- [ ] Pull request gives overview of changes
- [ ] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to release notes if fixing a significant bug or providing a new feature
- [ ] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

