### PR TITLE
Fix quad tree edge cases and allow non-default block sizes (Closes #696)

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -63,6 +63,10 @@ with temperature and density naming.
 perpendicular velocities with new `~.pybats.bats.Bats2d.calc_uperp`
 and `~.pybats.bats.Bats2d.calc_upar` methods.
 
+`~.pybats.bats.Bats2d` objects and the class that handles quad tree building
+(`~.pybats.qotree.QTree`) now accepts a keyword argument to set the size
+of each block: `blocksize`. Default value is 8.
+
 Deprecations and removals
 *************************
 Since plot styles are no longer applied on import, importing

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -83,6 +83,10 @@ that documentation for details. Thanks Lutz Rastaetter.
 Plot styles are not automatically applied on import of :mod:`.plot`. Use
 `.plot.style` directly to apply the desired style.
 
+`~.pybats.bats.Bats2d` plot functions will no longer raise an exception when
+trying to add a planet/inner boundary patch without an 'rbody' attribute
+present. Rather, the patch will not be applied to the axes object.
+
 0.4 Series
 ==========
 0.4.1 (2022-09-15)

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -42,10 +42,10 @@ slowly being brought up-to-date with each release.
 Visualization methods have two prefixes: *plot_* and *add_*.  Whenever a method
 begins with *plot_*, a quick-look product will be created that is not highly-
 configurable.  These methods are meant to yeild either simple
-diagnostic plots or static, often-used products.  There are few methods that use
-this prefix.  The prefix *add_* is always followed by *plot_type*; it indicates
-a plotting method that is highly configurable and meant to be combined with
-other *add_*-like methods and matplotlib commands.
+diagnostic plots or static, often-used products.  There are few methods that
+use this prefix.  The prefix *add_* is always followed by *plot_type*; it
+indicates a plotting method that is highly configurable and meant to be
+combined with other *add_*-like methods and matplotlib commands.
 
 Common calculations, such as calculating Alfven wave speeds of MHD results,
 are strewn about PyBats' classes.  They are always given the method prefix
@@ -133,10 +133,12 @@ def calc_wrapper(meth):
     @wraps(meth)
     def wrapped(self, *args, **kwargs):
         # Establish list of calculations:
-        if not hasattr(self, '_calcs'): self._calcs = {}
+        if not hasattr(self, '_calcs'):
+            self._calcs = {}
 
         # Check to see if we're in the list, return if true.
-        if meth.__name__ in self._calcs: return
+        if meth.__name__ in self._calcs:
+            return
 
         # If not, add to list and stash args/kwargs:
         self._calcs[meth.__name__] = [args, kwargs]
@@ -222,12 +224,14 @@ def parse_filename_time(filename):
         groups = re.findall('\d+', subname)
         if len(groups[0]) == 14:
             time = [parse(x) for x in groups]
-            if len(time) == 1: time = time[0]
+            if len(time) == 1:
+                time = time[0]
             runtime = None
         else:
             runtime = [3600*float(x[:-4])+60*float(x[-4:-2])+float(x[-2:])
                        for x in groups]
-            if len(runtime) == 1: runtime = runtime[0]
+            if len(runtime) == 1:
+                runtime = runtime[0]
     else:
         runtime = None
 
@@ -236,7 +240,8 @@ def parse_filename_time(filename):
         subname = re.search('_n((\d+\_?)+)', filename).groups()[0]
         i_iter = [int(x) for x in re.findall('\d+', subname)]
         # Reduce to scalar if necessary.
-        if len(i_iter) == 1: i_iter = i_iter[0]
+        if len(i_iter) == 1:
+            i_iter = i_iter[0]
     else:
         i_iter = None
 
@@ -344,7 +349,8 @@ def add_planet(ax, rad=1.0, ang=0.0, add_night=True, zorder=1000,
                  zorder=zorder+5, **extra_kwargs)
 
     ax.add_artist(body)
-    if add_night: ax.add_artist(arch)
+    if add_night:
+        ax.add_artist(arch)
 
     return body, arch
 
@@ -473,7 +479,6 @@ def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True):
     pbdat.attrs['ndim'] = abs(pbdat.attrs['ndim'])
 
     # Quick ref vars:
-    time = pbdat.attrs['runtime']
     gtyp = pbdat['grid'].attrs['gtype']
     npts = pbdat['grid'].attrs['npoints']
     ndim = pbdat['grid'].size
@@ -508,7 +513,8 @@ def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True):
     # in file but only X and Y are present.)  Let's try to work
     # around this rather egregious error.
     nSkip = len(units)+npar-len(names)
-    if nSkip < 0: nSkip = 0
+    if nSkip < 0:
+        nSkip = 0
 
     # Save grid names (e.g. 'x' or 'r') and save associated params.
     pbdat['grid'].attrs['dims'] = tuple(names[0:ndim])
@@ -517,7 +523,7 @@ def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True):
 
     # Create containers for the rest of the data:
     for v, u in zip(names, units[nSkip:]):
-        pbdat[v] = dmarray(np.zeros(npts), {'units':u})
+        pbdat[v] = dmarray(np.zeros(npts), {'units': u})
 
     # Load grid points and data:
     for i, line in enumerate(infile.readlines()):
@@ -529,10 +535,10 @@ def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True):
     infile.close()
 
     # Arrange data into multidimentional arrays if necessary.
-    gridnames = names[:ndim]
     if gtyp == 'Irregular':
         for v in names:
-            if v not in pbdat: continue
+            if v not in pbdat:
+                continue
             pbdat[v] = dmarray(np.reshape(pbdat[v], pbdat['grid'], order='F'),
                                attrs=pbdat[v].attrs)
     elif gtyp == 'Regular':
@@ -542,7 +548,8 @@ def _read_idl_ascii(pbdat, header='units', start_loc=0, keep_case=True):
             pbdat[x] = dmarray(pbdat[x][0:prod[i+1]-prod[i]+1:prod[i]],
                                attrs=pbdat[x].attrs)
         for v in names:
-            if v not in pbdat.keys(): continue
+            if v not in pbdat.keys():
+                continue
             if v not in pbdat['grid'].attrs['dims']:
                 pbdat[v] = dmarray(np.reshape(pbdat[v], pbdat['grid'],
                                               order='F'), attrs=pbdat[v].attrs)
@@ -703,7 +710,7 @@ def _scan_bin_header(f, endchar, inttype, floattype):
     rec_start = f.tell()
 
     # Create a dictionary to store the info from the file:
-    info = {'start':rec_start}
+    info = {'start': rec_start}
 
     # Read initial header:
     headline = readarray(f, str, inttype)
@@ -943,7 +950,8 @@ def _read_idl_bin(pbdat, header='units', start_loc=0, keep_case=True,
         names = readarray(infile, str, inttype).decode('utf-8')
 
         # Preserve or destroy original case of variable names:
-        if not keep_case: names = names.lower()
+        if not keep_case:
+            names = names.lower()
 
         names.strip()
         names = names.split()
@@ -964,7 +972,8 @@ def _read_idl_bin(pbdat, header='units', start_loc=0, keep_case=True,
         # in file but only X and Y are present.)  Let's try to work
         # around this curiousity:
         nSkip = len(units) + npar - len(names)
-        if nSkip < 0: nSkip = 0
+        if nSkip < 0:
+            nSkip = 0
 
         # Save grid names (e.g. 'x' or 'r') and save associated params.
         pbdat['grid'].attrs['dims'] = tuple(names[0:ndim])
@@ -993,14 +1002,17 @@ def _read_idl_bin(pbdat, header='units', start_loc=0, keep_case=True,
                 for j in range(int(pbdat['grid'][i])):
                     pbdat[names[i]][j] = tempgrid[j*int(prod[i])]
             else:
-                raise ValueError('Unknown grid type: {0}'.format(pbdat.gridtype))
+                raise ValueError('Unknown grid type: {0}'.format(
+                    pbdat.gridtype))
             # Add units to grid.
-            if units: pbdat[names[i]].attrs['units'] = units.pop(nSkip)
+            if units:
+                pbdat[names[i]].attrs['units'] = units.pop(nSkip)
 
         # Get the actual data and sort.
         for i in range(ndim, nvar+ndim):
             pbdat[names[i]] = dmarray(readarray(infile, floattype, inttype))
-            if units: pbdat[names[i]].attrs['units'] = units.pop(nSkip)
+            if units:
+                pbdat[names[i]].attrs['units'] = units.pop(nSkip)
             if gtyp != 'Unstructured':
                 # Put data into multidimensional arrays.
                 pbdat[names[i]] = pbdat[names[i]].reshape(
@@ -1056,7 +1068,8 @@ class PbData(SpaceData):
         keys.sort()
         length = 0
         for key in keys:
-            if len(key) > length: length = len(key)
+            if len(key) > length:
+                length = len(key)
         form = "%%%is:%%s" % length
         for key in keys:
             if 'units' in self[key].attrs:
@@ -1084,8 +1097,10 @@ class PbData(SpaceData):
         for v in self:
             # Only combine vectors that are the same size as time and are
             # in both objects.
-            if v not in obj: continue
-            if self[v].size != npts: continue
+            if v not in obj:
+                continue
+            if self[v].size != npts:
+                continue
             # Append away.
             self[v] = dmarray(np.append(self[v], obj[v]), self[v].attrs)
 
@@ -1206,7 +1221,8 @@ class IdlFile(PbData):
         # Gather information about time range of file from name:
         t_info = list(parse_filename_time(filename))
         for i in range(len(t_info)):
-            if type(t_info[i]) != list: t_info[i] = [t_info[i]]
+            if type(t_info[i]) != list:
+                t_info[i] = [t_info[i]]
         self.attrs['iter_range'] = t_info[0]
         self.attrs['runtime_range'] = t_info[1]
         self.attrs['time_range'] = t_info[2]
@@ -1256,7 +1272,8 @@ class IdlFile(PbData):
 
             # Loop over all data frames and collect information:
             while f.tell() < file_size:
-                info = _scan_bin_header(f, self._endchar, self._int, self._float)
+                info = _scan_bin_header(f, self._endchar,
+                                        self._int, self._float)
                 # Stash information into lists:
                 offset.append(info['start'])
                 iters.append(info['iter'])
@@ -1318,7 +1335,8 @@ class IdlFile(PbData):
         self.read(iframe)
 
         # Update information about the current frame:
-        self.attrs['iframe'] = self.attrs['nframe'] + iframe if iframe < 0 else iframe
+        self.attrs['iframe'] = self.attrs['nframe'] \
+            + iframe if iframe < 0 else iframe
         self.attrs['iter'] = self.attrs['iters'][iframe]
         self.attrs['runtime'] = self.attrs['runtimes'][iframe]
         self.attrs['time'] = self.attrs['times'][iframe]
@@ -1449,7 +1467,8 @@ class LogFile(PbData):
         # Parse the header.
         self.attrs['descrip'] = raw.pop(0)
         raw_names = raw.pop(0)
-        if not keep_case: raw_names = raw_names.lower()
+        if not keep_case:
+            raw_names = raw_names.lower()
         names = raw_names.split()
         loc = {}
         # Keep track of in which column each data vector lies.
@@ -1467,11 +1486,12 @@ class LogFile(PbData):
         # Pop time/date/iteration names off of Namevar.
         for key in ['year', 'mo', 'dy', 'hr', 'mn', 'sc', 'msc',
                     't', 'it', 'yy', 'mm', 'dd', 'hh', 'ss', 'ms']:
-            if key in loc: names.pop(names.index(key))
+            if key in loc:
+                names.pop(names.index(key))
 
         # Create containers for data:
         time = dmarray(np.zeros(npts, dtype=object))
-        runtime = dmarray(np.zeros(npts), attrs={'units':'s'})
+        runtime = dmarray(np.zeros(npts), attrs={'units': 's'})
         self['iter'] = dmarray(np.zeros(npts))
         for name in names:
             self[name] = dmarray(np.zeros(npts))
@@ -1490,7 +1510,7 @@ class LogFile(PbData):
                                 int(vals[loc['hr']]),  # Hour
                                 int(vals[loc['mn']]),  # Minute
                                 int(vals[loc['sc']]),  # Second
-                                int(vals[loc['msc']]) * 1000  #microsec
+                                int(vals[loc['msc']]) * 1000  # microsec
                                 ))
                 elif 'yy' in loc:
                     # RIM date format
@@ -1944,7 +1964,7 @@ class ImfInput(PbData):
         # Number of variables check:
         if len(var) > len(key):
             print('Not enough variables in IMF object:')
-            print('\t%i listed, %i actual.\n' % (len(var),len(key)))
+            print('\t%i listed, %i actual.\n' % (len(var), len(key)))
             return False
 
         # Each variable corresponds to only one in the dict
@@ -2039,7 +2059,8 @@ class ImfInput(PbData):
 
         # Check that the var attribute agrees with the data dictionary.
         if not self.varcheck():
-            raise Exception('Number of variables does not match variable order.')
+            raise Exception('Number of variables does ' +
+                            'not match variable order.')
 
         if not outfile:
             if self.attrs['file'] is not None:
@@ -2053,7 +2074,8 @@ class ImfInput(PbData):
             var = self.attrs['var']
 
             # Write the header:
-            out.write('File created on {}\n'.format(dt.datetime.now().isoformat())
+            writetime = dt.datetime.now().isoformat()
+            out.write('File created on {}\n'.format(writetime)
                       .encode())
             for head in self.attrs['header']:
                 out.write(head.encode())

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -803,7 +803,7 @@ class Bats2d(IdlFile):
                 try:
                     points = np.array([self[xdim], self[ydim]])
                     self._qtree = qo.QTree(points, blocksize=self.blocksize)
-                except:
+                except Exception:
                     from traceback import print_exc
                     print_exc()
                     self._qtree = False
@@ -2484,7 +2484,10 @@ class Bats2d(IdlFile):
         if add_cbar:
             cbar = plt.colorbar(pcol, ax=ax, pad=0.01)
             if clabel is None:
-                clabel = "%s (%s)" % (value, self[value].attrs['units'])
+                if 'units' in self[value].attrs:
+                    clabel = f"{value}, ({self[value].attrs['units']})"
+                else:
+                    clabel = f"{value}"
             cbar.set_label(clabel)
         else:
             cbar = None  # Need to return something, even if none.
@@ -2621,7 +2624,10 @@ class Bats2d(IdlFile):
         if add_cbar:
             cbar = plt.colorbar(cont, ax=ax, ticks=ticks, format=fmt, pad=0.01)
             if clabel is None:
-                clabel = "%s (%s)" % (value, self[value].attrs['units'])
+                if 'units' in self[value].attrs:
+                    clabel = f"{value}, ({self[value].attrs['units']})"
+                else:
+                    clabel = f"{value}"
             cbar.set_label(clabel)
         else:
             cbar = None  # Need to return something, even if none.
@@ -2835,7 +2841,10 @@ class ShellSlice(IdlFile):
             cbar = plt.colorbar(cnt, ax=ax, ticks=ticks, format=fmt,
                                 shrink=.85)
             if clabel is None:
-                clabel = "{} ({})".format(value, self[value].attrs['units'])
+                if 'units' in self[value].attrs:
+                    clabel = f"{value}, ({self[value].attrs['units']})"
+                else:
+                    clabel = f"{value}"
             cbar.set_label(clabel)
         else:
             cbar = None  # Need to return something, even if none.
@@ -3531,8 +3540,11 @@ class MagGridFile(IdlFile):
             cbar = plt.colorbar(cont, ax=ax, ticks=ticks, format=fmt, pad=0.01)
             if clabel is None:
                 varname = mhdname_to_tex(value)
-                units = mhdname_to_tex(self[value].attrs['units'])
-                clabel = "%s (%s)" % (varname, units)
+                if 'units' in self[value].attrs:
+                    units = mhdname_to_tex(self[value].attrs['units'])
+                else:
+                    units = 'unitless'
+                clabel = f"{varname} ({units})"
             cbar.set_label(clabel)
         else:
             cbar = None  # Need to return something, even if none.

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -27,8 +27,8 @@ from spacepy.datamodel import dmarray
 
 # Module-level variables:
 # recognized species:
-mass = {'hp':1.0, 'op':16.0, 'he':4.0,
-        'sw':1.0, 'o':16.0, 'h':1.0, 'iono':1.0, '':1.0}
+mass = {'hp': 1.0, 'op': 16.0, 'he': 4.0,
+        'sw': 1.0, 'o': 16.0, 'h': 1.0, 'iono': 1.0, '': 1.0}
 
 RE = 6371000  # Earth radius in meters.
 
@@ -104,11 +104,11 @@ def _calc_ndens(obj):
         else:
             m = 1.0
         obj[n+'N'] = dmarray(obj[s]/m,
-                             attrs={'units':'$cm^{-3}$', 'amu mass':m})
+                             attrs={'units': '$cm^{-3}$', 'amu mass': m})
 
     # Total N is sum of individual  number densities.
     obj['N'] = dmarray(np.zeros(obj[rho].shape),
-                       attrs={'units':'$cm^{-3}$'})
+                       attrs={'units': '$cm^{-3}$'})
     if species:
         # Total number density:
         for n in names:
@@ -116,10 +116,10 @@ def _calc_ndens(obj):
         # Composition as fraction of total per species:
         for n in names:
             obj[n+'Frac'] = dmarray(100.*obj[n+'N']/obj['N'],
-                                    {'units':'Percent'})
+                                    {'units': 'Percent'})
     else:
         # No individual species => no composition, simple ndens.
-        obj['N'] += dmarray(obj[rho], attrs={'units':'$cm^{-3}$'})
+        obj['N'] += dmarray(obj[rho], attrs={'units': '$cm^{-3}$'})
 
 
 # Classes:
@@ -173,8 +173,8 @@ class BatsLog(LogFile):
         Fetch the observed SYM-H index for the time period covered in the
         logfile.  Return *True* on success.
 
-        Observed SYM-H is automatically fetched from the Kyoto World Data Center
-        via the :mod:`spacepy.pybats.kyoto` module.  The associated
+        Observed SYM-H is automatically fetched from the Kyoto World Data
+        Center via the :mod:`spacepy.pybats.kyoto` module.  The associated
         :class:`spacepy.pybats.kyoto.KyotoSym` object, which holds the observed
         Dst, is stored as *self.obs_sym* for future use.
         '''
@@ -201,8 +201,8 @@ class BatsLog(LogFile):
 
     def add_dst_quicklook(self, target=None, loc=111, plot_obs=False,
                           epoch=None, add_legend=True, plot_sym=False,
-                          dstvar=None, lw=2.0, obs_kwargs={'ls':'-.'},
-                          sym_kwargs={'ls':'-'}, **kwargs):
+                          dstvar=None, lw=2.0, obs_kwargs={'ls': '-.'},
+                          sym_kwargs={'ls': '-'}, **kwargs):
         '''
         Create a quick-look plot of Dst (if variable present in file)
         and compare against observations.
@@ -268,13 +268,13 @@ class BatsLog(LogFile):
         ax.set_xlabel('Time from ' + self['time'][0].isoformat()+' UTC')
 
         # Add observations (Dst and/or SYM-H):
-        if(plot_obs):
+        if plot_obs:
             # Attempt to fetch observations, plot if success.
             if self.fetch_obs_dst():
                 ax.plot(self.obs_dst['time'], self.obs_dst['dst'],
                         **obs_kwargs)
                 applySmartTimeTicks(ax, self['time'])
-        if(plot_sym):
+        if plot_sym:
             # Attempt to fetch SYM-h observations, plot if success.
             if self.fetch_obs_sym():
                 ax.plot(self.obs_sym['time'], self.obs_sym['sym-h'],
@@ -314,7 +314,8 @@ class Extraction(PbData):
     y : float or sequence
         Y value(s) for points at which to extract data values.
     dataset : Bats
-        :class:`~spacepy.pybats.bats.Bats2d` object from which to extract values
+        :class:`~spacepy.pybats.bats.Bats2d` object from which to extract
+        values.
 
     Other Parameters
     ----------------
@@ -540,7 +541,7 @@ class Stream(Extraction):
         xnow, ynow = self.xstart, self.ystart
 
         # Trace forwards.
-        while(block):
+        while block:
             # Grab indices of all values inside current block.
             # Ghost cell check is for experimental testing:
             if hasattr(bats.qtree[block], 'ghost'):
@@ -557,7 +558,8 @@ class Stream(Extraction):
             newblock = bats.find_block(xnow, ynow)
             # If we didn't leave the block, stop tracing.
             # Additionally, if inside rBody, stop.
-            if(block == newblock) or (xnow**2+ynow**2) < bats.attrs['rbody'] * .8 :
+            radnow = xnow**2+ynow**2
+            if (block == newblock) or radnow < bats.attrs['rbody']*0.8:
                 block = False
             elif newblock:
                 block = newblock
@@ -566,8 +568,7 @@ class Stream(Extraction):
             # Append to full trace vectors.
             xfwd = np.append(xfwd, x[1:])
             yfwd = np.append(yfwd, y[1:])
-            del(x)
-            del(y)
+            del x, y
             # It's possible to get stuck swirling around across
             # a few blocks.  If we spend a lot of time tracing,
             # call it quits.
@@ -579,7 +580,7 @@ class Stream(Extraction):
         xbwd = [self.xstart]
         ybwd = [self.ystart]
         xnow, ynow = self.xstart, self.ystart
-        while(block):
+        while block:
             if hasattr(bats.qtree[block], 'ghost'):
                 loc = bats.qtree[block].ghost
             else:
@@ -589,7 +590,8 @@ class Stream(Extraction):
                        bats[grid[1]][loc][:, 0], ds=-0.01)
             xnow, ynow = x[-1], y[-1]
             newblock = bats.find_block(xnow, ynow)
-            if(block == newblock) or (xnow**2+ynow**2) < bats.attrs['rbody'] * .8:
+            radnow = xnow**2+ynow**2
+            if (block == newblock) or radnow < bats.attrs['rbody'] * .8:
                 block = False
             elif newblock:
                 block = newblock
@@ -759,7 +761,10 @@ class Bats2d(IdlFile):
        `~pybats.IdlFile` for details.
     '''
     # Init by calling IdlFile init and then building qotree, etc.
-    def __init__(self, filename, *args, **kwargs):
+    def __init__(self, filename, *args, blocksize=8, **kwargs):
+
+        # Stash blocksize as an attribute:
+        self.blocksize = blocksize
 
         # Create quad tree object attribute:
         self._qtree = None
@@ -796,7 +801,8 @@ class Bats2d(IdlFile):
             if self['grid'].attrs['gtype'] != 'Regular':
                 xdim, ydim = self['grid'].attrs['dims'][0:2]
                 try:
-                    self._qtree = qo.QTree(np.array([self[xdim], self[ydim]]))
+                    points = np.array([self[xdim], self[ydim]])
+                    self._qtree = qo.QTree(points, blocksize=self.blocksize)
                 except:
                     from traceback import print_exc
                     print_exc()
@@ -855,7 +861,7 @@ class Bats2d(IdlFile):
                 continue
             self[key[:-1]+'t'] = dmarray(
                 conv[units] * self[key[:-1]+'p']/self[key],
-                attrs={'units':units})
+                attrs={'units': units})
 
     @calc_wrapper
     def calc_b(self):
@@ -868,16 +874,16 @@ class Bats2d(IdlFile):
         if 'b' in self:
             return
 
-        self['b'] = np.sqrt(self['bx']**2.0 + self['by']**2.0 + self['bz']**2.0)
-        self['b'].attrs = {'units':self['bx'].attrs['units']}
+        self['b'] = np.sqrt(self['bx']**2 + self['by']**2 + self['bz']**2)
+        self['b'].attrs = {'units': self['bx'].attrs['units']}
 
         self['bx_hat'] = self['bx'] / self['b']
         self['by_hat'] = self['by'] / self['b']
         self['bz_hat'] = self['bz'] / self['b']
 
-        self['bx_hat'].attrs = {'units':'unitless'}
-        self['by_hat'].attrs = {'units':'unitless'}
-        self['bz_hat'].attrs = {'units':'unitless'}
+        self['bx_hat'].attrs = {'units': 'unitless'}
+        self['by_hat'].attrs = {'units': 'unitless'}
+        self['bz_hat'].attrs = {'units': 'unitless'}
 
     @calc_wrapper
     def calc_j(self):
@@ -885,8 +891,8 @@ class Bats2d(IdlFile):
         Calculates total current density strength using all three J components.
         Retains units of components, stores in self['j']
         '''
-        self['j'] = np.sqrt(self['jx']**2.0 + self['jy']**2.0 + self['jz']**2.0)
-        self['j'].attrs = {'units':self['jx'].attrs['units']}
+        self['j'] = np.sqrt(self['jx']**2 + self['jy']**2.0 + self['jz']**2)
+        self['j'].attrs = {'units': self['jx'].attrs['units']}
 
     @calc_wrapper
     def calc_uperp(self):
@@ -967,8 +973,8 @@ class Bats2d(IdlFile):
         '''
 
         # Some quick declarations for more readable code.
-        ux = self['ux']; uy = self['uy']; uz = self['uz']
-        bx = self['bx']; by = self['by']; bz = self['bz']
+        ux, uy, uz = self['ux'], self['uy'], self['uz']
+        bx, by, bz = self['bx'], self['by'], self['bz']
 
         # Check units.  Should be nT(=Volt*s/m^2) and km/s.
         if (bx.attrs['units'] != 'nT') or (ux.attrs['units'] != 'km/s'):
@@ -978,9 +984,9 @@ class Bats2d(IdlFile):
         self['Ex'] = -1.0*(uy*bz - uz*by) / 1000.0
         self['Ey'] = -1.0*(uz*bx - ux*bz) / 1000.0
         self['Ez'] = -1.0*(ux*by - uy*bx) / 1000.0
-        self['Ex'].attrs = {'units':'mV/m'}
-        self['Ey'].attrs = {'units':'mV/m'}
-        self['Ez'].attrs = {'units':'mV/m'}
+        self['Ex'].attrs = {'units': 'mV/m'}
+        self['Ey'].attrs = {'units': 'mV/m'}
+        self['Ez'].attrs = {'units': 'mV/m'}
 
         # Total magnitude.
         self['E'] = np.sqrt(self['Ex']**2+self['Ey']**2+self['Ez']**2)
@@ -1023,7 +1029,7 @@ class Bats2d(IdlFile):
         temp_b[temp_b < 1E-8] = -1.0*mu_naught*self['p'][temp_b == 0.0]
         temp_beta = mu_naught*self['p']/temp_b
         self['beta'] = temp_beta
-        self['beta'].attrs = {'units':'unitless'}
+        self['beta'].attrs = {'units': 'unitless'}
 
     @calc_wrapper
     def calc_jxb(self):
@@ -1041,14 +1047,14 @@ class Bats2d(IdlFile):
         conv = 1E-6
         # Calculate cross product, convert units.
         self['jbx'] = dmarray((self['jy']*self['bz']-self['jz']*self['by'])*conv,
-                              {'units':'nN/m^3'})
+                              {'units': 'nN/m^3'})
         self['jby'] = dmarray((self['jz']*self['bx']-self['jx']*self['bz'])*conv,
-                              {'units':'nN/m^3'})
+                              {'units': 'nN/m^3'})
         self['jbz'] = dmarray((self['jx']*self['by']-self['jy']*self['bx'])*conv,
-                              {'units':'nN/m^3'})
+                              {'units': 'nN/m^3'})
         self['jb'] = dmarray(np.sqrt(self['jbx']**2 +
                                      self['jby']**2 +
-                                     self['jbz']**2), {'units':'nN/m^3'})
+                                     self['jbz']**2), {'units': 'nN/m^3'})
 
     @calc_wrapper
     def calc_alfven(self):
@@ -1061,7 +1067,7 @@ class Bats2d(IdlFile):
 
         if 'b' not in self:
             self.calc_b()
-        #M_naught * conversion from #/cm^3 to kg/m^3
+        # M_naught * conversion from #/cm^3 to kg/m^3
         mu_naught = 4.0E-7 * np.pi * 1.6726E-27 * 1.0E6
 
         # Get all rho-like variables.  Save in new list.
@@ -1075,7 +1081,7 @@ class Bats2d(IdlFile):
         for k in rho_names:
             self[k[:-3]+'alfven'] = dmarray(self['b']*1E-12 /
                                             np.sqrt(mu_naught*self[k]),
-                                            attrs={'units':'km/s'})
+                                            attrs={'units': 'km/s'})
 
     @calc_wrapper
     def _calc_divmomen(self):
@@ -1093,8 +1099,8 @@ class Bats2d(IdlFile):
 
         # Create empty arrays to hold new values.
         size = self['ux'].shape
-        self['divmomx'] = dmarray(np.zeros(size), {'units':'nN/m3'})
-        self['divmomz'] = dmarray(np.zeros(size), {'units':'nN/m3'})
+        self['divmomx'] = dmarray(np.zeros(size), {'units': 'nN/m3'})
+        self['divmomz'] = dmarray(np.zeros(size), {'units': 'nN/m3'})
 
         # Units!
         c1 = 1000. / 6371.0  # km2/Re/s2 -> m/s2
@@ -1111,8 +1117,10 @@ class Bats2d(IdlFile):
             ux = self['ux'][leaf.locs]
             uz = self['uz'][leaf.locs]
 
-            self['divmomx'][leaf.locs] = ux*d_dx(ux, leaf.dx)+uz*d_dy(ux, leaf.dx)
-            self['divmomz'][leaf.locs] = ux*d_dx(uz, leaf.dx)+uz*d_dy(uz, leaf.dx)
+            self['divmomx'][leaf.locs] = ux*d_dx(ux, leaf.dx) + \
+                uz*d_dy(ux, leaf.dx)
+            self['divmomz'][leaf.locs] = ux*d_dx(uz, leaf.dx) + \
+                uz*d_dy(uz, leaf.dx)
 
         # Unit conversion.
         self['divmomx'] *= self['rho']*c1*c2*c3
@@ -1176,7 +1184,7 @@ class Bats2d(IdlFile):
         for s in species:
             # Create new arrays to hold curl.
             size = self[s+'ux'].shape
-            self[s+w] = dmarray(np.zeros(size), {'units':'1/s'})
+            self[s+w] = dmarray(np.zeros(size), {'units': '1/s'})
 
             # Navigate quad tree, calculate curl at every leaf.
             for k in self.qtree:
@@ -1190,7 +1198,8 @@ class Bats2d(IdlFile):
                 u2 = self[s+'u'+dim2][leaf.locs]
 
                 # Calculate curl
-                self[s+w][leaf.locs] = conv * (dx1(u1, leaf.dx) - dx2(u2, leaf.dx))
+                self[s+w][leaf.locs] = conv * (dx1(u1, leaf.dx) -
+                                               dx2(u2, leaf.dx))
 
     @calc_wrapper
     def calc_gradP(self):
@@ -1210,9 +1219,9 @@ class Bats2d(IdlFile):
         # Create new arrays to hold pressure.
         dims = self['grid'].attrs['dims']
         size = self['p'].shape
-        self['gradP'] = dmarray(np.zeros(size), {'units':'nN/cm^3'})
+        self['gradP'] = dmarray(np.zeros(size), {'units': 'nN/cm^3'})
         for d in dims:
-            self['gradP_'+d] = dmarray(np.zeros(size), {'units':'nN/m^3'})
+            self['gradP_'+d] = dmarray(np.zeros(size), {'units': 'nN/m^3'})
 
         for k in self.qtree:
             # Plot only leafs of the tree.
@@ -1259,7 +1268,7 @@ class Bats2d(IdlFile):
             self[s+'u'] = dmarray(np.sqrt(self[s+'ux']**2 +
                                           self[s+'uy']**2 +
                                           self[s+'uz']**2),
-                                  attrs={'units':units})
+                                  attrs={'units': units})
 
     @calc_wrapper
     def _calc_Ekin(self, units='eV'):
@@ -1290,7 +1299,7 @@ class Bats2d(IdlFile):
                                              self[s+'uy']**2 +
                                              self[s+'uz']**2)
                                      * conv * mass[s.lower()],
-                                     attrs={'units':units})
+                                     attrs={'units': units})
 
     def calc_all(self, exclude=[]):
         '''
@@ -1354,9 +1363,7 @@ class Bats2d(IdlFile):
         Result is stored in self['cfl'].
         """
 
-        try:
-            U = self['u']
-        except KeyError:
+        if 'u' not in self:
             self.calc_utotal()
 
         cfl = np.zeros(self['u'].shape)
@@ -1373,7 +1380,7 @@ class Bats2d(IdlFile):
 
             cfl[pts] = self['u'][pts]*dt/child.dx
 
-        self['cfl'] = dmarray(cfl, attrs={'units':''})
+        self['cfl'] = dmarray(cfl, attrs={'units': ''})
 
     def vth(self, m_avg=3.1):
         """
@@ -1386,7 +1393,7 @@ class Bats2d(IdlFile):
         m_avg_kg = m_avg*1.6276e-27
         ndensity = self['rho']/m_avg*1e6
         self['vth'] = dmarray(np.sqrt(self['p']*1e-9/ndensity/(m_avg_kg))
-                              / 1000, attrs={'units':'km/s'})
+                              / 1000, attrs={'units': 'km/s'})
 
     def gyroradius(self, velocities=('u', 'vth'), m_avg=3.1):
         """
@@ -1407,11 +1414,8 @@ class Bats2d(IdlFile):
             except KeyError:
                 self.vth()
 
-        if 'u' in velocities:
-            try:
-                U = self['u']
-            except KeyError:
-                self.calc_utotal()
+        if 'u' in velocities and 'u' not in self:
+            self.calc_utotal()
 
         velocities_squared_sum = self[velocities[0]]**2
 
@@ -1430,7 +1434,7 @@ class Bats2d(IdlFile):
         q = 1.6022e-19
 
         self['gyroradius'] = dmarray(m_avg_kg*v/(q*B)/6378000,
-                                     attrs={'units':'Re'})
+                                     attrs={'units': 'Re'})
 
     def plasma_freq(self, m_avg=3.1):
         """
@@ -1445,7 +1449,7 @@ class Bats2d(IdlFile):
         ndensity = self['rho']/m_avg*1e6
         q = 1.6022e-19
         self['plasma_freq'] = dmarray(np.sqrt(4*np.pi*ndensity*q**2/m_avg_kg),
-                                      attrs={'units':'rad/s'})
+                                      attrs={'units': 'rad/s'})
 
     def inertial_length(self, m_avg=3.1):
         """
@@ -1465,7 +1469,7 @@ class Bats2d(IdlFile):
             self.calc_alfven()
 
         self['inertial_length'] = dmarray(self['alfven']/self['plasma_freq']
-                                          / 6378000, attrs={'units':'Re'})
+                                          / 6378000, attrs={'units': 'Re'})
 
     def regrid(self, cellsize=1.0, dim1range=-1, dim2range=-1, debug=False):
         '''
@@ -1630,7 +1634,7 @@ class Bats2d(IdlFile):
         ax.set_ylim([self.qtree[1].lim[2], self.qtree[1].lim[3]])
         # Plot.
 
-        if(show_borders):
+        if show_borders:
             for key in list(self.qtree.keys()):
                 self.qtree[key].plotbox(ax)
         self.qtree.plot_res(ax, tag_leafs=show_nums, do_label=do_label,
@@ -1762,7 +1766,8 @@ class Bats2d(IdlFile):
             except IndexError:
                 continue
 
-            lines.append(np.array([stream.x, stream.y][::1-2*flip]).transpose())
+            iflip = 1-2*flip
+            lines.append(np.array([stream.x, stream.y][::iflip]).transpose())
 
         # Create line collection & plot.
         collect = LineCollection(lines, **kwargs)
@@ -1841,7 +1846,7 @@ class Bats2d(IdlFile):
             nIter += 1
 
             # Are we closed or open?  Day or nightside?
-            closed = not(s1.open)    # open or closed?
+            closed = not s1.open     # open or closed?
             isNig = s1.x.mean() < 0  # line on day or night side?
             isDay = not isNig
 
@@ -1891,7 +1896,7 @@ class Bats2d(IdlFile):
             s1 = self.get_stream(R*np.cos(theta), R*np.sin(theta), 'bx', 'bz',
                                  method=method, maxPoints=1E6)
             # Closed?  Nightside?
-            closed = not(s1.open)
+            closed = not s1.open
             isNig = s1.x.mean() < 0
             isDay = not isNig
 
@@ -2037,7 +2042,7 @@ class Bats2d(IdlFile):
         from spacepy.plot import add_arrows
 
         # Set ax and fig based on given target.
-        adj_lims = not(target)  # If no target set, adjust axes limits.
+        adj_lims = not target  # If no target set, adjust axes limits.
         fig, ax = set_target(target, figsize=(10, 10), loc=111)
         self.add_body(ax)
 
@@ -2313,7 +2318,8 @@ class Bats2d(IdlFile):
 
         # Add open field lines.
         if DoOpen:
-            for theta in np.linspace(daymax, 0.99*(2.0*(np.pi+tilt))-nightmax, 15):
+            for theta in np.linspace(daymax,
+                                     0.99*(2.0*(np.pi+tilt))-nightmax, 15):
                 x = self.attrs['rbody'] * np.cos(theta)
                 y = self.attrs['rbody'] * np.sin(theta)
                 stream = self.get_stream(x, y, 'bx', 'bz', method=method)
@@ -2458,7 +2464,7 @@ class Bats2d(IdlFile):
             z = self[value]
             norm = Normalize(vmin=zlim[0], vmax=zlim[1])
 
-        if self['grid'].attrs['gtype']=='Regular':
+        if self['grid'].attrs['gtype'] == 'Regular':
             pass
         else:
             # Indices corresponding to QTree dimensions:
@@ -2689,8 +2695,8 @@ class ShellSlice(IdlFile):
 
         # Get grid spacing.  If npoints ==1, set to 1 to avoid math errors.
         self.drad = (self['r'][-1] - self['r'][0])/max(self['grid'][0]-1, 1)
-        self.dlon = (self['lon'][-1] - self['lon'][0])/max(self['grid'][1]-1, 1)
-        self.dlat = (self['lat'][-1] - self['lat'][0])/max(self['grid'][2]-1, 1)
+        self.dlon = (self['lon'][-1]-self['lon'][0])/max(self['grid'][1]-1, 1)
+        self.dlat = (self['lat'][-1]-self['lat'][0])/max(self['grid'][2]-1, 1)
 
         self.dphi = d2r*self.dlon
         self.dtheta = d2r*self.dlat
@@ -2707,10 +2713,10 @@ class ShellSlice(IdlFile):
         Calculate radial velocity.
         '''
         ur = self['ux']*np.sin(self.theta)*np.cos(self.phi) + \
-             self['uy']*np.sin(self.theta)*np.sin(self.phi) + \
-             self['uz']*np.cos(self.theta)
+            self['uy']*np.sin(self.theta)*np.sin(self.phi) + \
+            self['uz']*np.cos(self.theta)
 
-        self['ur'] = dmarray(ur, {'units':self['ux'].attrs['units']})
+        self['ur'] = dmarray(ur, {'units': self['ux'].attrs['units']})
 
     @calc_wrapper
     def calc_radflux(self, var, conv=1000. * (100.0)**3):
@@ -2841,12 +2847,14 @@ class ShellSlice(IdlFile):
         ax.yaxis.set_major_locator(MultipleLocator(latticks))
         ax.set_ylim([0, colat_max])
         ax.set_yticklabels('')
-        opts = {'size':yticksize, 'rotation':-45, 'ha':'center', 'va':'center'}
+        opts = {'size': yticksize, 'rotation': -45,
+                'ha': 'center', 'va': 'center'}
         for theta in np.arange(90-latticks, 90-colat_max, -latticks):
             txt = '{:02.0f}'.format(theta)+r'$^{\circ}$'
             ax.text(np.pi/4., 90.-theta, txt, color='w', weight='extra bold',
                     **opts)
-            ax.text(np.pi/4., 90.-theta, txt, color='k', weight='light', **opts)
+            ax.text(np.pi/4., 90.-theta, txt, color='k', weight='light',
+                    **opts)
 
         # Use MLT-type labels.
         lt_labels = ['Noon', '18', '00',   '06']
@@ -2955,7 +2963,8 @@ class Mag(PbData):
         '''
 
         # If values already exist, do not overwrite.
-        if 'dBn' in self: return
+        if 'dBn' in self:
+            return
 
         # New containers:
         self['totaln'] = np.zeros(self.attrs['nlines'])
@@ -2971,16 +2980,18 @@ class Mag(PbData):
                 self['totald'] = self['totald']+self[key]
 
         # Old names -> new names:
-        varmap = {'totaln':'dBn',       'totale':'dBe',      'totald':'dBd',
-                  'gm_dBn':'dBnMhd',    'gm_dBe':'dBeMhd',   'gm_dBd':'dBdMhd',
-                  'gm_facdBn':'dBnFac', 'gm_facdBe':'dBeFac','gm_facdBd':'dBdFac',
-                  'ie_JhdBn':'dBnHal',  'ie_JhdBe':'dBeHal', 'ie_JhdBd':'dBdHal',
-                  'ie_JpBn':'dBnPed',   'ie_JpBe':'dBePed',  'ie_JpBd':'dBdPed'}
+        varmap = {'totaln': 'dBn', 'totale': 'dBe', 'totald': 'dBd',
+                  'gm_dBn': 'dBnMhd', 'gm_dBe': 'dBeMhd', 'gm_dBd': 'dBdMhd',
+                  'gm_facdBn': 'dBnFac', 'gm_facdBe': 'dBeFac',
+                  'gm_facdBd': 'dBdFac', 'ie_JhdBn': 'dBnHal',
+                  'ie_JhdBe': 'dBeHal', 'ie_JhdBd': 'dBdHal',
+                  'ie_JpBn': 'dBnPed',  'ie_JpBe': 'dBePed',
+                  'ie_JpBd': 'dBdPed'}
 
         # Replace variable names.
         for key in list(self.keys()):
             if key in varmap:
-                self[ varmap[key] ] = self.pop(key)
+                self[varmap[key]] = self.pop(key)
 
     def calc_h(self):
         '''
@@ -3017,7 +3028,8 @@ class Mag(PbData):
         '''
 
         # Do not calculate twice.
-        if 'dBdtn' in self: return
+        if 'dBdtn' in self:
+            return
 
         # Get dt values:
         dt = np.array([x.total_seconds() for x in np.diff(self['time'])])
@@ -3025,23 +3037,24 @@ class Mag(PbData):
         # Loop through variables:
         oldvars = list(self.keys())
         for k in oldvars:
-            if 'dB' not in k: continue
+            if 'dB' not in k:
+                continue
 
             # Create new variable name and container:
-            new = k.replace('dB','dBdt')
-            self[new] = dmarray(np.zeros(self.attrs['nlines']),{'units':'nT/s'})
+            new = k.replace('dB', 'dBdt')
+            self[new] = dmarray(np.zeros(self.attrs['nlines']),
+                                {'units': 'nT/s'})
 
             # Central diff:
             self[new][1:-1] = (self[k][2:]-self[k][:-2])/(dt[1:]+dt[:-1])
 
             # Forward diff:
             self[new][0] = (-self[k][2] + 4*self[k][1] - 3*self[k][0]) \
-                           / (dt[1]+dt[0])
+                / (dt[1]+dt[0])
 
             # Backward diff:
             self[new][-1] = (3*self[k][-1] - 4*self[k][-2] + self[k][-3]) \
-                            / (dt[-1]+dt[-2])
-
+                / (dt[-1]+dt[-2])
 
         self['dBdth'] = np.sqrt(self['dBdtn']**2+self['dBdte']**2)
 
@@ -3084,15 +3097,13 @@ class Mag(PbData):
 
         '''
 
-        import matplotlib.pyplot as plt
-
         if not label:
-            label=value
+            label = value
 
         # Set figure and axes based on target:
-        fig, ax = set_target(target, figsize=(10,4), loc=loc)
+        fig, ax = set_target(target, figsize=(10, 4), loc=loc)
 
-        line=ax.plot(self['time'], self[value], style, label=label, **kwargs)
+        ax.plot(self['time'], self[value], style, label=label, **kwargs)
         applySmartTimeTicks(ax, self['time'], dolabel=True)
 
         return fig, ax
@@ -3145,40 +3156,43 @@ class Mag(PbData):
         prefix = 'dB'+direc
 
         # Use a dictionary to assign line styles, widths.
-        styles={prefix+'Mhd':'--', prefix+'Fac':'--',
-                prefix+'Hal':'-.', prefix+'Ped':'-.',
-                prefix:'-'}
-        widths={prefix+'Mhd':lw, prefix+'Fac':lw,
-                prefix+'Hal':lw, prefix+'Ped':lw,
-                prefix:1.5*lw}
-        colors={prefix+'Mhd':'#FF6600', prefix+'Fac':'r',
-                prefix+'Hal':'b',       prefix+'Ped':'c',
-                prefix:'k'}
+        styles = {prefix+'Mhd': '--', prefix+'Fac': '--',
+                  prefix+'Hal': '-.', prefix+'Ped': '-.',
+                  prefix: '-'}
+        widths = {prefix+'Mhd': lw, prefix+'Fac': lw,
+                  prefix+'Hal': lw, prefix+'Ped': lw,
+                  prefix: 1.5*lw}
+        colors = {prefix+'Mhd': '#FF6600', prefix+'Fac': 'r',
+                  prefix+'Hal': 'b',       prefix+'Ped': 'c',
+                  prefix: 'k'}
 
         # Labels:
-        labels={prefix+'Mhd':r'$J_{Mag}$',  prefix+'Fac':r'$J_{Gap}$',
-                prefix+'Hal':r'$J_{Hall}$', prefix+'Ped':r'$J_{Peder}$',
-                prefix:r'Total $\Delta B'+'_{}$'.format(direc)}
+        labels = {prefix+'Mhd': r'$J_{Mag}$',  prefix+'Fac': r'$J_{Gap}$',
+                  prefix+'Hal': r'$J_{Hall}$', prefix+'Ped': r'$J_{Peder}$',
+                  prefix: r'Total $\Delta B'+'_{}$'.format(direc)}
 
         # Plot.
         for k in sorted(self):
-            if ('dB'+direc not in k) or (k=='time') or (k[:4]=='dBdt'):continue
+            if ('dB'+direc not in k) or (k == 'time') or (k[:4] == 'dBdt'):
+                continue
             ax.plot(self['time'], self[k], label=labels[k],
-                    lw=widths[k], c=colors[k])#,ls=styles[k]
+                    lw=widths[k], c=colors[k])  # ,ls=styles[k]
 
         # Ticks, zero-line, and legend:
         applySmartTimeTicks(ax, self['time'], True, True)
         ax.hlines(0.0, self['time'][0], self['time'][-1],
                   linestyles=':', lw=2.0, colors='k')
-        if add_legend: ax.legend(ncol=3, loc='best')
+        if add_legend:
+            ax.legend(ncol=3, loc='best')
 
         # Axis labels:
-        ax.set_ylabel(r'$\Delta B_{%s}$ ($nT$)'%(direc.upper()))
+        ax.set_ylabel(r'$\Delta B_{%s}$ ($nT$)' % (direc.upper()))
 
-        if target==None:
+        if target is None:
             fig.tight_layout()
 
         return fig, ax
+
 
 class MagFile(PbData):
     '''
@@ -3222,23 +3236,22 @@ class MagFile(PbData):
         self.attrs['gmfile'] = filename
 
         # Try to find the IE file based on our current location.
-        if(find_ie and not ie_name):
+        if find_ie and not ie_name:
             basedir = filename[0:filename.rfind('/')+1]
             if glob(basedir + '../IE/IE_mag_*.mag'):
-                self.attrs['iefile']=glob(basedir + '../IE/IE_mag_*.mag')[-1]
+                self.attrs['iefile'] = glob(basedir + '../IE/IE_mag_*.mag')[-1]
             elif glob(basedir + '../../IE/ionosphere/IE_mag_*.mag'):
                 self.attrs['iefile'] = \
                     glob(basedir + '../../IE/ionosphere/IE_mag_*.mag')[-1]
             elif glob(basedir + '/IE_mag_*.mag'):
-                self.attrs['iefile']= glob(basedir + '/IE_mag_*.mag')[-1]
+                self.attrs['iefile'] = glob(basedir + '/IE_mag_*.mag')[-1]
             else:
-                self.attrs['iefile']=None
+                self.attrs['iefile'] = None
         else:
-            self.attrs['iefile']=ie_name
+            self.attrs['iefile'] = ie_name
 
         # Set legacy mode to handle old variable names:
         self.legacy = find_ie or bool(ie_name)
-
 
         self.readfiles()
 
@@ -3255,7 +3268,7 @@ class MagFile(PbData):
 
         # Parse header:
         # Get number of stations.
-        nmags=int((lines[0].split(':')[0]).split()[0])
+        nmags = int((lines[0].split(':')[0]).split()[0])
 
         # Get station names.
         names = lines[0].split(':')[1]
@@ -3282,8 +3295,8 @@ class MagFile(PbData):
             infile = open(self.attrs['iefile'], 'r')
             ielns = infile.readlines()
             infile.close()
-            nmags=int((ielns[0].split(':')[0]).split()[0])
-            iestats=(ielns[0].split(':')[1]).split()
+            nmags = int((ielns[0].split(':')[0]).split()[0])
+            iestats = (ielns[0].split(':')[1]).split()
             # Check nmags vs number of mags in header.
             if nmags != len(iestats):
                 raise BaseException(
@@ -3292,11 +3305,11 @@ class MagFile(PbData):
             if iestats != self.attrs['namemag']:
                 raise RuntimeError("Files do not have matching stations.")
             ie_namevar = ielns[1].split()[11:]
-            self.attrs['ie_namevar']=ie_namevar
+            self.attrs['ie_namevar'] = ie_namevar
             if (len(ielns)/self.attrs['nmag']) != (nrecords-1):
                 print('Number of lines do not match: GM=%d, IE=%d!' %
                       (nrecords-1, len(ielns)/self.attrs['nmag']))
-                nrecords=min(ielns, nrecords-1)
+                nrecords = min(ielns, nrecords-1)
         else:
             ie_namevar = ()
             self.attrs['ie_namevar'] = ()
@@ -3307,7 +3320,7 @@ class MagFile(PbData):
         for name in namemag:
             self[name] = Mag(nrecords, self['time'], gm_namevar, ie_namevar)
 
-        data_buffer = np.zeros((nrecords,nmags,(len(gm_namevar)+3)))
+        data_buffer = np.zeros((nrecords, nmags, (len(gm_namevar)+3)))
 
         # Read file data.
         for i in range(nrecords):
@@ -3325,12 +3338,12 @@ class MagFile(PbData):
                 )
             for j in range(nmags):
                 line = lines[i*nmags+j+2]
-                if j>0:
+                if j > 0:
                     parts = line.split()
                 values = [float(part) for part in parts[9:]]
-                data_buffer[i,j] = values
+                data_buffer[i, j] = values
 
-            if self.attrs['iefile'] and i>0:
+            if self.attrs['iefile'] and i > 0:
                 line = ielns[i*nmags+2]
                 self[namemag[0]].parse_ieline(i, line, ie_namevar)
                 for j in range(1, nmags):
@@ -3339,9 +3352,9 @@ class MagFile(PbData):
 
         for j in range(nmags):
             mag = self[namemag[j]]
-            mag['x'] = data_buffer[:,j,0]
-            mag['y'] = data_buffer[:,j,1]
-            mag['z'] = data_buffer[:,j,2]
+            mag['x'] = data_buffer[:, j, 0]
+            mag['y'] = data_buffer[:, j, 1]
+            mag['z'] = data_buffer[:, j, 2]
             for k, key in enumerate(gm_namevar):
                 mag[key] = data_buffer[:, j, k+3]
 
@@ -3393,6 +3406,7 @@ class MagFile(PbData):
                 continue
             self[k].calc_dbdt()
 
+
 class MagGridFile(IdlFile):
     '''
     Magnetometer grids are a recent addition to BATS-R-US: instead of
@@ -3405,7 +3419,6 @@ class MagGridFile(IdlFile):
     def __init__(self, *args, **kwargs):
         import re
         from spacepy.pybats import parse_filename_time
-        from spacepy.coordinates import Coords
 
         # Initialize as an IdlFile.
         super(MagGridFile, self).__init__(header=None, *args, **kwargs)
@@ -3429,9 +3442,9 @@ class MagGridFile(IdlFile):
             if v == 'grid':
                 continue
             elif v in self['grid'].attrs['dims']:
-                self[v].attrs['units']=unit1
+                self[v].attrs['units'] = unit1
             else:
-                self[v].attrs['units']=unit2
+                self[v].attrs['units'] = unit2
 
     @calc_wrapper
     def calc_h(self):
@@ -3447,7 +3460,7 @@ class MagGridFile(IdlFile):
             if v[:3] == 'dBn':
                 v_east = v.replace('dBn', 'dBe')
                 self[v.replace('dBn', 'dBh')] = dmarray(
-                    np.sqrt(self[v]**2 + self[v_east]**2), {'units':'nT'})
+                    np.sqrt(self[v]**2 + self[v_east]**2), {'units': 'nT'})
 
     def add_contour(self, value, nlev=30, target=None, loc=111,
                     title=None, xlabel=None, ylabel=None,
@@ -3462,12 +3475,12 @@ class MagGridFile(IdlFile):
         from spacepy.pybats import mhdname_to_tex
 
         import matplotlib.pyplot as plt
-        from matplotlib.colors import (LogNorm, Normalize)
-        from matplotlib.ticker import (LogLocator, LogFormatter, FuncFormatter,
+        from matplotlib.colors import LogNorm
+        from matplotlib.ticker import (LogLocator, FuncFormatter,
                                        LogFormatterMathtext, MultipleLocator)
 
         # Set ax and fig based on given target.
-        fig, ax = set_target(target, figsize=(10,7), loc=loc)
+        fig, ax = set_target(target, figsize=(10, 7), loc=loc)
 
         # Get max/min if none given.
         if zlim is None:
@@ -3478,27 +3491,27 @@ class MagGridFile(IdlFile):
 
         # No zero-level for log scales:
         if dolog and zlim[0] <= 0:
-            zlim[0] = np.min( [0.0001, zlim[1]/1000.0] )
+            zlim[0] = np.min([0.0001, zlim[1]/1000.0])
 
         # Better default color maps:
         if 'cmap' not in kwargs:
             # If zlim spans positive and negative:
-            if zlim[1]-zlim[0]>np.max(zlim):
+            if zlim[1]-zlim[0] > np.max(zlim):
                 kwargs['cmap'] = 'bwr'
             else:
                 kwargs['cmap'] = 'Reds'
 
         # Set contour command based on filled/unfilled contours:
         if filled:
-            contour=ax.contourf
+            contour = ax.contourf
         else:
-            contour=ax.contour
+            contour = ax.contour
 
-                # Create levels and set norm based on dolog.
+        # Create levels and set norm based on dolog.
         if dolog:
             levs = np.power(10, np.linspace(np.log10(zlim[0]),
                                             np.log10(zlim[1]), nlev))
-            z = np.where(self[value]>zlim[0], self[value], 1.01*zlim[0])
+            z = np.where(self[value] > zlim[0], self[value], 1.01*zlim[0])
             norm = LogNorm()
             ticks = LogLocator()
             fmt = LogFormatterMathtext()
@@ -3506,7 +3519,7 @@ class MagGridFile(IdlFile):
             levs = np.linspace(zlim[0], zlim[1], nlev)
             z = self[value]
             norm = None
-            ticks = MultipleLocator((zlim[1]-zlim[0])/10) ### fix this
+            ticks = MultipleLocator((zlim[1]-zlim[0])/10)  # fix this
             fmt = None
 
         # Add Contour to plot:
@@ -3516,7 +3529,7 @@ class MagGridFile(IdlFile):
         # Add cbar if necessary.
         if add_cbar:
             cbar = plt.colorbar(cont, ax=ax, ticks=ticks, format=fmt, pad=0.01)
-            if clabel == None:
+            if clabel is None:
                 varname = mhdname_to_tex(value)
                 units = mhdname_to_tex(self[value].attrs['units'])
                 clabel = "%s (%s)" % (varname, units)
@@ -3529,9 +3542,9 @@ class MagGridFile(IdlFile):
             ax.set_title(title)
         coord_sys = self['grid'].attrs['coord']
         if ylabel is None:
-            ylabel='Latitude ({})'.format(coord_sys)
+            ylabel = 'Latitude ({})'.format(coord_sys)
         if xlabel is None:
-            xlabel='Longitude ({})'.format(coord_sys)
+            xlabel = 'Longitude ({})'.format(coord_sys)
         ax.set_ylabel(ylabel)
         ax.set_xlabel(xlabel)
         if type(xlim) is not None:
@@ -3590,7 +3603,7 @@ class GeoIndexFile(LogFile):
         super(GeoIndexFile, self).__init__(filename, *args, **kwargs)
 
         # Re-parse the file header; look for key info.
-        head  = (self.attrs['descrip']).replace('=',' ')
+        head = (self.attrs['descrip']).replace('=', ' ')
         parts = head.split()
         if 'DtOutput=' in head:
             self.attrs['dt'] = float(parts[parts.index('DtOutput=') + 1])
@@ -3600,8 +3613,7 @@ class GeoIndexFile(LogFile):
         if 'Lat' in head:
             self.attrs['lat'] = float(parts[parts.index('Lat') + 1])
         if 'K9' in head:
-            self.attrs['k9']  = float(parts[parts.index('K9') + 1])
-
+            self.attrs['k9'] = float(parts[parts.index('K9') + 1])
 
     def fetch_obs_kp(self):
         '''
@@ -3617,7 +3629,8 @@ class GeoIndexFile(LogFile):
         import spacepy.pybats.kyoto as kt
 
         # Return if already obtained:
-        if hasattr(self, 'obs_kp'): return True
+        if hasattr(self, 'obs_kp'):
+            return True
 
         # Start and end time to collect observations:
         stime = self['time'][0]
@@ -3647,7 +3660,8 @@ class GeoIndexFile(LogFile):
         import spacepy.pybats.kyoto as kt
 
         # Return if already obtained:
-        if hasattr(self, 'obs_ae'): return True
+        if hasattr(self, 'obs_ae'):
+            return True
 
         # Start and end time to collect observations:
         stime = self['time'][0]
@@ -3665,10 +3679,12 @@ class GeoIndexFile(LogFile):
 
     def add_kp_quicklook(self, target=None, loc=111, label=None,
                          plot_obs=False, add_legend=True,
-                         obs_kwargs={'c':'k', 'ls':'--', 'lw':2}, **kwargs):
+                         obs_kwargs={'c': 'k', 'ls': '--', 'lw': 2}, **kwargs):
         '''
         Similar to "dst_quicklook"-type functions, this method fetches observed
-        Kp from the web and plots it alongside the Kp read from the GeoInd file.
+        Kp from the web and plots it alongside the Kp read from the GeoIndex
+        file.
+
         Usage:
         >>> obj.kp_quicklook(target=SomeMplTarget)
         The target kwarg works like in other PyBats plot functions: it can be
@@ -3685,13 +3701,12 @@ class GeoIndexFile(LogFile):
         The observed line can be customized via the *obs_kwargs* kwarg, which
         is a dictionary of plotting keyword arguments.
         '''
-        import matplotlib.pyplot as plt
 
         # Set up plot target.
         fig, ax = set_target(target, figsize=(10, 4), loc=loc)
 
         # Create label:
-        if not(label):
+        if not label:
             label = 'fa$K$e$_{P}$'
             if ('lat' in self.attrs) and ('k9' in self.attrs):
                 label += ' (Lat=%04.1f$^{\circ}$, K9=%03i)' % \
@@ -3699,14 +3714,16 @@ class GeoIndexFile(LogFile):
 
         # Sometimes, the "Kp" varname is caps, sometimes not.
         kp = 'Kp'
-        if kp not in self.keys(): kp='kp'
+        if kp not in self.keys():
+            kp = 'kp'
 
-        ax.plot(self['time'], self['Kp'], label=label,**kwargs)
+        ax.plot(self['time'], self['Kp'], label=label, **kwargs)
         ax.set_ylabel('$K_{P}$')
-        ax.set_xlabel('Time from '+ self['time'][0].isoformat()+' UTC')
+        ax.set_xlabel('Time from ' + self['time'][0].isoformat()+' UTC')
         applySmartTimeTicks(ax, self['time'])
 
-        if target==None: fig.tight_layout()
+        if target is None:
+            fig.tight_layout()
 
         if plot_obs:
             # Attempt to fetch Kp:
@@ -3715,12 +3732,14 @@ class GeoIndexFile(LogFile):
                 self.obs_kp.add_histplot(target=ax, **obs_kwargs)
                 applySmartTimeTicks(ax, self['time'])
 
-        if add_legend: ax.legend(loc='best')
+        if add_legend:
+            ax.legend(loc='best')
         return fig, ax
 
     def add_ae_quicklook(self, target=None, loc=111, label=None,
                          plot_obs=False, val='AE', add_legend=True,
-                         obs_kwargs={'c':'k', 'ls':'--', 'lw':1.5}, **kwargs):
+                         obs_kwargs={'c': 'k', 'ls': '--', 'lw': 1.5},
+                         **kwargs):
         '''
         Similar to "dst_quicklook"-type functions, this method fetches observed
         AE indices from the web and plots it alongside the corresponding
@@ -3743,15 +3762,14 @@ class GeoIndexFile(LogFile):
         The observed line can be customized via the *obs_kwargs* kwarg, which
         is a dictionary of plotting keyword arguments.
         '''
-        import matplotlib.pyplot as plt
 
         # Set up plot target.
-        fig, ax = set_target(target, figsize=(10,4), loc=loc)
+        fig, ax = set_target(target, figsize=(10, 4), loc=loc)
 
-        if not(label):
+        if not label:
             label = 'Virtual {}'.format(val)
 
-        ax.plot(self['time'], self[val], label=label,**kwargs)
+        ax.plot(self['time'], self[val], label=label, **kwargs)
         ax.set_ylabel('{} ($nT$)'.format(val))
         ax.set_xlabel('Time from ' + self['time'][0].isoformat() + ' UTC')
         applySmartTimeTicks(ax, self['time'])
@@ -3761,16 +3779,19 @@ class GeoIndexFile(LogFile):
 
         if plot_obs:
             # Check for label in obs. kwargs:
-            if 'label' not in obs_kwargs: obs_kwargs['label'] = 'Obs. ' + val
+            if 'label' not in obs_kwargs:
+                obs_kwargs['label'] = 'Obs. ' + val
 
             if self.fetch_obs_ae():
                 ax.plot(self.obs_ae['time'], self.obs_ae[val.lower()],
                         **obs_kwargs)
                 applySmartTimeTicks(ax, self['time'])
 
-        if add_legend: ax.legend(loc='best')
+        if add_legend:
+            ax.legend(loc='best')
 
         return fig, ax
+
 
 class VirtSat(LogFile):
     '''
@@ -3792,7 +3813,7 @@ class VirtSat(LogFile):
             name = list(filter(None, a))[0]
         except IndexError:
             name = None
-        self.attrs['name']=name
+        self.attrs['name'] = name
 
         # Create interpolation functions for position.
         self._interp = {}
@@ -3835,12 +3856,12 @@ class VirtSat(LogFile):
         units = units.lower()
 
         # Create dictionary of unit conversions.
-        conv  = {'ev' : 6241.50935,  # nPa/cm^3 --> eV.
-                 'kev': 6.24150935,  # nPa/cm^3 --> KeV.
-                 'k'  : 72429626.47} # nPa/cm^3 --> K.
+        conv = {'ev': 6241.50935,   # nPa/cm^3 --> eV.
+                'kev': 6.24150935,  # nPa/cm^3 --> KeV.
+                'k': 72429626.47}   # nPa/cm^3 --> K.
 
         # Calculate number density if not done already.
-        if not 'N' in self:
+        if 'N' not in self:
             self.calc_ndens()
 
         # Find all number density variables.
@@ -3853,7 +3874,7 @@ class VirtSat(LogFile):
                 continue
             self[key[:-1] + 't'] = dmarray(
                 conv[units] * self[key[:-1] + 'p']/self[key],
-                attrs = {'units':units})
+                attrs={'units': units})
 
     def calc_bmag(self):
         '''
@@ -3862,9 +3883,9 @@ class VirtSat(LogFile):
         '''
 
         if 'b' not in self:
-            self['b']=np.sqrt(self['bx']**2+
-                              self['by']**2+
-                              self['bz']**2)
+            self['b'] = np.sqrt(self['bx']**2 +
+                                self['by']**2 +
+                                self['bz']**2)
 
         return True
 
@@ -3880,14 +3901,15 @@ class VirtSat(LogFile):
         the keyword **units** can be changed to 'rad' to change this.
         '''
 
-        if 'b' not in self: self.calc_bmag()
+        if 'b' not in self:
+            self.calc_bmag()
 
         incl = np.arcsin(self['bz'] / self['b'])
 
         if units == 'deg':
-            self['b_incl'] = dmarray(incl * 180. / np.pi, {'units':'degrees'})
+            self['b_incl'] = dmarray(incl * 180. / np.pi, {'units': 'degrees'})
         elif units == 'rad':
-            self['b_incl'] = dmarray(incl, {'units':'radians'})
+            self['b_incl'] = dmarray(incl, {'units': 'radians'})
         else:
             raise ValueError('Unrecognized units.  Use "deg" or "rad"')
 
@@ -3914,8 +3936,8 @@ class VirtSat(LogFile):
             testval = time
 
         # Test if datetime or not.
-        if type(testval) == type(self['time'][0]):
-            time=date2num(time)
+        if isinstance(testval, type(self['time'][0])):
+            time = date2num(time)
 
         # Interpolate, using "try" as to not pass time limits and extrapolate.
         try:
@@ -3943,20 +3965,23 @@ class VirtSat(LogFile):
 
         plane = plane.lower()
         loc = self.get_position(time)
-        if None in loc: return
+        if None in loc:
+            return
         x = loc['xyz'.index(plane[0])]
         y = loc['xyz'.index(plane[1])]
 
         # Do not label satellite if outside axes bounds.
-        if (x < min(xlim)) or (x > max(xlim))or \
-           (y < min(ylim)) or (y > max(ylim)): dolabel=False
+        if (x < min(xlim)) or (x > max(xlim)) or \
+           (y < min(ylim)) or (y > max(ylim)):
+            dolabel = False
 
         target.plot(x, y, 'o', **kwargs)
         if dolabel:
             xoff = 0.03 * (xlim[1] - xlim[0])
             if dobox:
                 target.text(x + xoff, y, self.attrs['name'],
-                            bbox={'fc':'w', 'ec':'k'}, size=size, va='center')
+                            bbox={'fc': 'w', 'ec': 'k'},
+                            size=size, va='center')
             else:
                 target.text(x + xoff, y, self.attrs['name'],
                             size=size, va='center', color=c)
@@ -3969,7 +3994,7 @@ class VirtSat(LogFile):
     def add_orbit_plot(self, plane='XY', target=None, loc=111, rbody=1.0,
                        title=None, trange=None, add_grid=True, style='g.',
                        adjust_axes=True, add_arrow=True,
-                       arrow_kwargs={'color':'g', 'width':.05, 'ec':'k'},
+                       arrow_kwargs={'color': 'g', 'width': .05, 'ec': 'k'},
                        **kwargs):
         '''
         Create a 2D orbit plot in the given plane (e.g. 'XY' or 'ZY').
@@ -4010,11 +4035,10 @@ class VirtSat(LogFile):
 
         from spacepy.pybats import add_body
         from spacepy.pybats.ram import grid_zeros
-        import matplotlib.pyplot as plt
 
-        fig, ax = set_target(target, figsize=(5,5), loc=loc)
+        fig, ax = set_target(target, figsize=(5, 5), loc=loc)
 
-        plane=plane.upper()
+        plane = plane.upper()
 
         # Set time range of plot.
         if not trange:
@@ -4022,8 +4046,8 @@ class VirtSat(LogFile):
         tloc = (self['time'] >= trange[0]) & (self['time'] <= trange[-1])
 
         # Extract orbit X, Y, or Z.
-        plane=plane.lower()
-        if plane[0] in ['x','y','z']:
+        plane = plane.lower()
+        if plane[0] in ['x', 'y', 'z']:
             x = self[plane[0]][tloc]
         else:
             raise ValueError('Bad dimension specifier: ' + plane[0])
@@ -4051,6 +4075,6 @@ class VirtSat(LogFile):
             if add_grid:
                 ax.grid()
             grid_zeros(ax)
-            add_body(ax, rad=rbody, add_night=('X' in plane.upper()) )
+            add_body(ax, rad=rbody, add_night=('X' in plane.upper()))
 
         return fig, ax

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -1644,7 +1644,8 @@ class Bats2d(IdlFile):
         ax.set_xlabel('GSM %s' % xdim.upper())
         ax.set_ylabel('GSM %s' % ydim.upper())
         ax.set_title(title)
-        self.add_body(ax)
+        if 'rbody' in self.attrs or 'body' in self.attrs:
+            self.add_body(ax)
 
         return fig, ax
 
@@ -1935,7 +1936,8 @@ class Bats2d(IdlFile):
                         compX='bx', compY='bz', narrow=0, arrsize=12,
                         method='rk4', tol=np.pi/720., DoClosed=True,
                         colors=None, linestyles=None, maxPoints=1E6,
-                        nOpen=5, nClosed=15, arrstyle='->', **kwargs):
+                        nOpen=5, nClosed=15, arrstyle='->',
+                        add_body=False, **kwargs):
         '''
         Create an array of field lines closed to the central body in the
         domain.  Add these lines to Matplotlib target object *target*.
@@ -2012,6 +2014,7 @@ class Bats2d(IdlFile):
         linestyles A single line style indicator, defaults to '-';
                    see :class:`~matplotlib.collections.LineCollection` for
                    possible options.
+        add_body   Add an planet/body to the figure. Defaults to False.
         ========== ===========================================================
 
         Extra kwargs are passed to Matplotlib's LineCollection class as
@@ -2044,7 +2047,8 @@ class Bats2d(IdlFile):
         # Set ax and fig based on given target.
         adj_lims = not target  # If no target set, adjust axes limits.
         fig, ax = set_target(target, figsize=(10, 10), loc=111)
-        self.add_body(ax)
+        if add_body:
+            self.add_body(ax)
 
         # Lines, colors, and styles:
         lines = []
@@ -2527,7 +2531,7 @@ class Bats2d(IdlFile):
             ang = 90.0
         else:
             ang = 0.0
-        if add_body:
+        if add_body and 'rbody' in self.attrs:
             self.add_body(ax, ang=ang)
 
         return fig, ax, pcol, cbar
@@ -2668,7 +2672,7 @@ class Bats2d(IdlFile):
             ang = 90.0
         else:
             ang = 0.0
-        if add_body:
+        if add_body and 'rbody' in self.attrs:
             self.add_body(ax, ang=ang)
 
         return fig, ax, cont, cbar

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -623,10 +623,12 @@ class Stream(Extraction):
             if (r[0] < bats.attrs['rbody']) and (r[-1] < bats.attrs['rbody']):
                 self.open = False
                 self.status = 'closed'
-            elif (r[0] > bats.attrs['rbody']) and (r[-1] < bats.attrs['rbody']):
+            elif (r[0] > bats.attrs['rbody']) and \
+                 (r[-1] < bats.attrs['rbody']):
                 self.open = True
                 self.status = 'north lobe'
-            elif (r[0] < bats.attrs['rbody']) and (r[-1] > bats.attrs['rbody']):
+            elif (r[0] < bats.attrs['rbody']) and \
+                 (r[-1] > bats.attrs['rbody']):
                 self.open = True
                 self.status = 'south lobe'
             # Trim the fat!
@@ -1046,11 +1048,14 @@ class Bats2d(IdlFile):
         # Unit conversion (nT, uA, cm^-3 -> nT, A, m^-3) to nN/m^3.
         conv = 1E-6
         # Calculate cross product, convert units.
-        self['jbx'] = dmarray((self['jy']*self['bz']-self['jz']*self['by'])*conv,
+        self['jbx'] = dmarray((self['jy']*self['bz'] -
+                               self['jz']*self['by'])*conv,
                               {'units': 'nN/m^3'})
-        self['jby'] = dmarray((self['jz']*self['bx']-self['jx']*self['bz'])*conv,
+        self['jby'] = dmarray((self['jz']*self['bx'] -
+                               self['jx']*self['bz'])*conv,
                               {'units': 'nN/m^3'})
-        self['jbz'] = dmarray((self['jx']*self['by']-self['jy']*self['bx'])*conv,
+        self['jbz'] = dmarray((self['jx']*self['by'] -
+                               self['jy']*self['bx'])*conv,
                               {'units': 'nN/m^3'})
         self['jb'] = dmarray(np.sqrt(self['jbx']**2 +
                                      self['jby']**2 +
@@ -2057,7 +2062,7 @@ class Bats2d(IdlFile):
         # Try to get line style from "style" string.
         # Default to regular line if not successful.
         if not linestyles:
-            lstyle = re.sub('\w', '', style)
+            lstyle = re.sub(r'\w', '', style)
             if not lstyle:
                 linestyles = '-'
             else:
@@ -2511,7 +2516,8 @@ class Bats2d(IdlFile):
             assert isinstance(xlim[1], numbers.Number)
         except (TypeError, AssertionError):
             if xlim is not None:
-                raise ValueError('add_pcolor: xlim must be list- or array-like and have 2 elements')
+                raise ValueError('add_pcolor: xlim must be list- ' +
+                                 'or array-like and have 2 elements')
         else:
             ax.set_xlim(xlim)
         try:
@@ -2520,7 +2526,8 @@ class Bats2d(IdlFile):
             assert isinstance(ylim[1], numbers.Number)
         except (TypeError, AssertionError):
             if ylim is not None:
-                raise ValueError('add_pcolor: ylim must be list- or array-like and have 2 elements')
+                raise ValueError('add_pcolor: ylim must be list- ' +
+                                 'or array-like and have 2 elements')
         else:
             ax.set_ylim(ylim)
 
@@ -2651,7 +2658,8 @@ class Bats2d(IdlFile):
             assert isinstance(xlim[1], numbers.Number)
         except (TypeError, AssertionError):
             if xlim is not None:
-                raise ValueError('add_contour: xlim must be list- or array-like and have 2 elements')
+                raise ValueError('add_contour: xlim must be list- ' +
+                                 'or array-like and have 2 elements')
         else:
             ax.set_xlim(xlim)
         try:
@@ -2759,7 +2767,7 @@ class ShellSlice(IdlFile):
 
         # Need at least 2D in angle space:
         if self.dphi == 0 or self.dtheta == 0:
-            raise ValueError('Fluence can only be calculated for 2D+ surfaces.')
+            raise ValueError('Fluence can be calculated for >=2D surfaces.')
 
         # Trim flux off of val name:
         if '_rflx' in var:
@@ -2967,9 +2975,9 @@ class Mag(PbData):
 
     def _recalc(self):
         '''
-        Calculate total :math:`\Delta B` from GM and IE; store under object keys
-        *totaln*, *totale*, and *totald* (one for each component of the HEZ
-        coordinate system).
+        Calculate total :math:`\Delta B` from GM and IE; store under object
+        keys *totaln*, *totale*, and *totald* (one for each component of the
+        HEZ coordinate system).
 
         This function should only be called to correct legacy versions of
         magnetometer files.
@@ -3022,7 +3030,7 @@ class Mag(PbData):
             if v[:3] == 'dBn':
                 v_east = v.replace('dBn', 'dBe')
                 self[v.replace('dBn', 'dBh')] = dmarray(
-                    np.sqrt(self[v]**2+self[v_east]**2), {'units':'nT'})
+                    np.sqrt(self[v]**2+self[v_east]**2), {'units': 'nT'})
 
     def calc_dbdt(self):
         '''
@@ -3164,7 +3172,7 @@ class Mag(PbData):
         '''
 
         # Set plot targets.
-        fig, ax = set_target(target, figsize=(10,4), loc=loc)
+        fig, ax = set_target(target, figsize=(10, 4), loc=loc)
 
         prefix = 'dB'+direc
 
@@ -3438,7 +3446,7 @@ class MagGridFile(IdlFile):
 
         # Additional header parsing:
         head = self.attrs['header']
-        match = re.search('\((\w+)\).*\[(\w+)\].*\[(\w+)\]', head)
+        match = re.search(r'\((\w+)\).*\[(\w+)\].*\[(\w+)\]', head)
         coord, unit1, unit2 = match.groups()
 
         self['grid'].attrs['coord'] = coord
@@ -3768,7 +3776,8 @@ class GeoIndexFile(LogFile):
         The target kwarg works like in other PyBats plot functions: it can be
         a figure, an axes, or None, and it determines where the plot is placed.
 
-        Other kwargs customize the line.  Extra kwargs are passed to pyplot.plot
+        Other kwargs customize the line.  Extra kwargs are passed to
+        pyplot.plot
 
         Observed AE can be added via the *plot_obs* kwarg.  AE is automatically
         fetched from the Kyoto World Data Center via the
@@ -3825,7 +3834,8 @@ class VirtSat(LogFile):
         # Attempt to extract the satellite's name and save it.
         try:
             s = self.attrs['file']
-            a = findall('sat_([\-\w]+)_\d+_n\d+\.sat|sat_(\w+)_n\d+\.sat', s)[0]
+            searchstr = r'sat_([\-\w]+)_\d+_n\d+\.sat|sat_(\w+)_n\d+\.sat'
+            a = findall(searchstr, s)[0]
             name = list(filter(None, a))[0]
         except IndexError:
             name = None
@@ -3970,8 +3980,8 @@ class VirtSat(LogFile):
         '''
         For a given axes, *target*, add the location of the satellite at
         time *time* as a circle.  If kwarg *dolabel* is True, the satellite's
-        name will be used to label the dot.  Optional kwargs are any accepted by
-        matplotlib.axes.Axes.plot.  The kwarg *plane* specifies the plane
+        name will be used to label the dot.  Optional kwargs are any accepted
+        by matplotlib.axes.Axes.plot.  The kwarg *plane* specifies the plane
         of the plot, e.g., 'XY', 'YZ', etc.
         '''
 
@@ -4001,7 +4011,6 @@ class VirtSat(LogFile):
             else:
                 target.text(x + xoff, y, self.attrs['name'],
                             size=size, va='center', color=c)
-
 
         # Restore Axes' limits.
         target.set_ylim(ylim)

--- a/spacepy/pybats/qotree.py
+++ b/spacepy/pybats/qotree.py
@@ -76,7 +76,7 @@ class QTree(object):
         '''
         Internal recursive method for populating tree.
         '''
-        from numpy import sqrt, log2, arange, meshgrid, mod
+        from numpy import sqrt, log2, meshgrid, mod, linspace
 
         # Start by limiting locations to within block limits:
         self[i].locs = self.locs[(grid[0, :][self.locs] > self[i].lim[0]) &
@@ -140,8 +140,8 @@ class QTree(object):
                 if dx < self.dx_min:
                     self.dx_min = dx
                 self[i].cells = meshgrid(
-                    arange(self[i].lim[0], self[i].lim[1]+dx, dx),
-                    arange(self[i].lim[2], self[i].lim[3]+dx, dx))
+                    linspace(self[i].lim[0], self[i].lim[1], blksize+1),
+                    linspace(self[i].lim[2], self[i].lim[3], blksize+1))
                 self.nleafs += 1
                 return
         elif (self[i].npts < self.blocksize**2):
@@ -176,8 +176,8 @@ class QTree(object):
             if dx < self.dx_min:
                 self.dx_min = dx
             self[i].cells = meshgrid(
-                arange(self[i].lim[0], self[i].lim[1]+dx, dx),
-                arange(self[i].lim[2], self[i].lim[3]+dx, dx))
+                    linspace(self[i].lim[0], self[i].lim[1], blksize+1),
+                    linspace(self[i].lim[2], self[i].lim[3], blksize+1))
             self.nleafs += 1
             return
 

--- a/spacepy/pybats/qotree.py
+++ b/spacepy/pybats/qotree.py
@@ -1,63 +1,75 @@
 #!/usr/bin/env python
 
 '''
-A class for building QO trees for :class:`~spacepy.pybats.bats.Bats2d` 
+A class for building QO trees for :class:`~spacepy.pybats.bats.Bats2d`
 objects.
 '''
+
 
 class QTree(object):
     '''
     Base class for Quad/Oct tree objects assuming cell-centered grid points
-    in a rectangular non-regular layout.
+    in a rectangular non-regular layout. QTree works for square blocks
+    only (e.g., blocks who have the same number of points in each dimension).
+
+    The `blocksize` kwarg sets the size of the blocks.
+    As BATS-R-US typically uses a block size of 8 (i.e., blocks are 8x8x8
+    points), the default value of `blocksize` is 8.
     '''
-    
-    def __init__(self, grid):
+
+    def __init__(self, grid, blocksize=8):
         '''
         Build QO Tree for input grid.  Grid should be a NxM numpy array where
         N is the number of dimensions and M is the number of points.
         '''
-        from numpy import sqrt, where, arange, lexsort, inf
+
+        from numpy import sqrt, where, lexsort, inf
+
+        # Set size of each block
+
         (self.d, self.npoints) = grid.shape
 
-        if(self.d != 2):
+        if self.d != 2:
             raise NotImplementedError("Sorry, QTrees are for 2D grids only.")
         self.tree = {}
-        
+
         # Find limits of cell-centered grid.
         # Get values and locations of grid max/min
-        minloc, xmin = grid[0,:].argmin(), grid[0,:].min()
-        maxloc, xmax = grid[0,:].argmax(), grid[0,:].max()
+        minloc, xmin = grid[0, :].argmin(), grid[0, :].min()
+        maxloc, xmax = grid[0, :].argmax(), grid[0, :].max()
         # Distance from min X value is grid size at that point.
-        r = sqrt((grid[0,:]-xmin)**2. + (grid[1,:]-grid[1,:][minloc])**2.)
-        ml=(where(r>0, r, 10000)).min()
+        r = sqrt((grid[0, :]-xmin)**2. + (grid[1, :]-grid[1, :][minloc])**2.)
+        ml = (where(r > 0, r, 10000)).min()
         # Actual min is not cell center, but cell boundary.
-        xmin-=ml/2.
+        xmin -= ml/2.
         # Repeat for Xmax.
-        r = sqrt((grid[0,:]-xmax)**2. + 
-                 (grid[1,:]-grid[1,:][maxloc])**2.)
-        ml=(where(r>0, r, 10000)).min()
-        xmax+=ml/2.
-        
-        # Repeat for Ymin/max.
-        minloc, ymin = grid[1,:].argmin(),grid[1,:].min()
-        maxloc, ymax = grid[1,:].argmax(),grid[1,:].max()
+        r = sqrt((grid[0, :]-xmax)**2. +
+                 (grid[1, :]-grid[1, :][maxloc])**2.)
+        ml = (where(r > 0, r, 10000)).min()
+        xmax += ml/2.
 
-        r = sqrt((grid[1,:]-ymin)**2. + (grid[0,:]-grid[0,:][minloc])**2.)
-        ml=(where(r>0, r, 10000)).min(); ymin-=ml/2.
-        r = sqrt((grid[1,:]-ymax)**2. + (grid[0,:]-grid[0,:][maxloc])**2.)
-        ml=(where(r>0, r, 10000)).min(); ymax+=ml/2.
+        # Repeat for Ymin/max.
+        minloc, ymin = grid[1, :].argmin(), grid[1, :].min()
+        maxloc, ymax = grid[1, :].argmax(), grid[1, :].max()
+
+        r = sqrt((grid[1, :]-ymin)**2. + (grid[0, :]-grid[0, :][minloc])**2.)
+        ml = (where(r > 0, r, 10000)).min()
+        ymin -= ml/2.
+        r = sqrt((grid[1, :]-ymax)**2. + (grid[0, :]-grid[0, :][maxloc])**2.)
+        ml = (where(r > 0, r, 10000)).min()
+        ymax += ml/2.
 
         # Some things all trees should know about themselves.
-        self.nleafs=0
+        self.nleafs = 0
         self.aspect_ratio = (xmax-xmin)/(ymax-ymin)
-        self.dx_min = inf # Minimum and maximum spacing
+        self.dx_min = inf  # Minimum and maximum spacing
         self.dx_max = -1  # over all leafs in tree.
 
         # Use spatial range of grid to seed root of QTree.
-        self[1]=[xmin,xmax,ymin,ymax]
-        self.locs = lexsort( (grid[0,:], grid[1,:]) )
+        self[1] = [xmin, xmax, ymin, ymax]
+        self.locs = lexsort((grid[0, :], grid[1, :]))
         self._spawn_kids(grid)
-        self.nbranch=len(list(self.keys()))
+        self.nbranch = len(list(self.keys()))
 
     def _spawn_kids(self, grid, i=1):
         '''
@@ -66,42 +78,48 @@ class QTree(object):
         from numpy import sqrt, max, min, log2, arange, meshgrid, mod
 
         # Start by limiting locations to within block limits:
-        self[i].locs=self.locs[(grid[0,:][self.locs]>self[i].lim[0]) &
-                               (grid[0,:][self.locs]<self[i].lim[1]) &
-                               (grid[1,:][self.locs]>self[i].lim[2]) &
-                               (grid[1,:][self.locs]<self[i].lim[3]) ]
+        self[i].locs = self.locs[(grid[0, :][self.locs] > self[i].lim[0]) &
+                                 (grid[0, :][self.locs] < self[i].lim[1]) &
+                                 (grid[1, :][self.locs] > self[i].lim[2]) &
+                                 (grid[1, :][self.locs] < self[i].lim[3])]
         self[i].npts = self[i].locs.size
-        # Bats blocks are almost always 8x8; 
-        # blocks must have no less than 64 points.
+
+        # Bats blocks are nPoints by nPoints,
+        # blocks must have no less than nPts points.
         # Stop branching as soon as possible (e.g. combine blocks of like dx).
-        a = log2(self[i].npts/64.0) # where a is npts=2^a * 64
-        if (int(a) == a): 
+        # Here, npts=2^a * self.blocksize**2
+        a = log2(self[i].npts/self.blocksize**2)
+        if (int(a) == a):
             # integer 'a' implies correct number of points to be a "leaf".
             # Approximate dx assuming a proper block.
-            xmax=max(grid[0,:][self[i].locs])
-            xmin=min(grid[0,:][self[i].locs])
+            xmax = max(grid[0, :][self[i].locs])
+            xmin = min(grid[0, :][self[i].locs])
             dx = (xmax-xmin) / (sqrt(self[i].npts)-1)
-            # Count points along x=xmax and x= xmin.  These are equal in Leafs. 
-            nxmin=len(grid[0,:][self[i].locs][grid[0,:][self[i].locs]==xmin])
-            nxmax=len(grid[0,:][self[i].locs][grid[0,:][self[i].locs]==xmax])
-            # Define leaf as area of constant dx (using approx above) 
+
+            # Count points along x=xmax and x= xmin.  These are equal in Leafs.
+            nxmin = len(grid[0, :][self[i].locs][grid[0, :][self[i].locs] == xmin])
+            nxmax = len(grid[0, :][self[i].locs][grid[0, :][self[i].locs] == xmax])
+
+            # Define leaf as area of constant dx (using approx above)
             # or npts=64 (min level.)
-            if (a==0) or (nxmax==nxmin==sqrt(self[i].npts)):
+            if (a == 0) or (nxmax == nxmin == sqrt(self[i].npts)):
                 # An NxN block can be considered a "leaf" or stopping point
-                # if above criteria are met.  Leafs must "know" the 
-                # indices of the x,y points located inside of them as a 
+                # if above criteria are met.  Leafs must "know" the
+                # indices of the x,y points located inside of them as a
                 # grid and also know the bounding coords of the grid cells.
                 self[i].isLeaf = True
-                a=int(sqrt(self[i].npts))
+                a = int(sqrt(self[i].npts))
 
-                self[i].locs=self[i].locs.reshape( (a, a) )
+                self[i].locs = self[i].locs.reshape((a, a))
                 self[i].dx = dx
-                if dx>self.dx_max: self.dx_max=dx
-                if dx<self.dx_min: self.dx_min=dx
+                if dx > self.dx_max:
+                    self.dx_max = dx
+                if dx < self.dx_min:
+                    self.dx_min = dx
                 self[i].cells = meshgrid(
                     arange(self[i].lim[0], self[i].lim[1]+dx, dx),
                     arange(self[i].lim[2], self[i].lim[3]+dx, dx))
-                self.nleafs+=1
+                self.nleafs += 1
                 return
         elif (self[i].npts < 64):
             # If we do not reach a true leaf but have few points,
@@ -110,14 +128,15 @@ class QTree(object):
             # different resolution.  Points from **both** resoultions
             # are included in the output file.  Create a leaf that uses the
             # smaller of the two and discards the rest.
-            self[i].isLeaf = True             # Interfaces are considered leafs
-            xmax=max(grid[0,:][self[i].locs]) # These conditions still hold...
-            xmin=min(grid[0,:][self[i].locs])
+            self[i].isLeaf = True  # Interfaces are considered leafs
+            xmax = max(grid[0, :][self[i].locs])  # These conditions still hold
+            xmin = min(grid[0, :][self[i].locs])
 
             # The number of points along each dimension should follow
             # this relationship at interface blocks:
-            a=2*sqrt(self[i].npts/5)
-            if int(a)!=a: raise ValueError(
+            a = 2*sqrt(self[i].npts/5)
+            if int(a) != a:
+                raise ValueError(
                     "Failure to handle interface " +
                     "surface!  Please report to Spacepy devs.")
             a = int(a)
@@ -126,46 +145,55 @@ class QTree(object):
             dx = (xmax-xmin) / (a-1)
 
             # Refine locs so that only multiples of dx are included:
-            subloc = mod(grid[0,:][self[i].locs]-grid[0,:][
+            subloc = mod(grid[0, :][self[i].locs]-grid[0, :][
                 self[i].locs[0]], dx) == 0
-            self[i].locs = self[i].locs[ subloc ]
-            
-            self[i].locs=self[i].locs.reshape( (a, a) )
+            self[i].locs = self[i].locs[subloc]
+
+            self[i].locs = self[i].locs.reshape((a, a))
             self[i].dx = dx
-            if dx>self.dx_max: self.dx_max=dx
-            if dx<self.dx_min: self.dx_min=dx
+            if dx > self.dx_max:
+                self.dx_max = dx
+            if dx < self.dx_min:
+                self.dx_min = dx
             self[i].cells = meshgrid(
                 arange(self[i].lim[0], self[i].lim[1]+dx, dx),
                 arange(self[i].lim[2], self[i].lim[3]+dx, dx))
-            self.nleafs+=1
+            self.nleafs += 1
             return
-            
-        # If above criteria are not met, this block is 
+
+        # If above criteria are not met, this block is
         # not a constant-resolution zone.
         # Subdivide section into four new ones (8 if oct tree)
         dx = (self[i].lim[1] - self[i].lim[0])/2.0
-        x=[self[i].lim[0], self[i].lim[0]+dx, self[i].lim[0]+dx, self[i].lim[0]]
-        y=[self[i].lim[2], self[i].lim[2], self[i].lim[2]+dx, self[i].lim[2]+dx]
-        for j, k in enumerate(range(self.ld(i), self.rd(i)+1)):
-            self[k] = [x[j],x[j]+dx,y[j],y[j]+dx]
-            self._spawn_kids(grid,k)
 
+        x = [self[i].lim[0], self[i].lim[0]+dx,
+             self[i].lim[0]+dx, self[i].lim[0]]
+        y = [self[i].lim[2], self[i].lim[2],
+             self[i].lim[2]+dx, self[i].lim[2]+dx]
+
+        for j, k in enumerate(range(self.ld(i), self.rd(i)+1)):
+            self[k] = [x[j], x[j]+dx, y[j], y[j]+dx]
+            self._spawn_kids(grid, k)
 
     def find_leaf(self, x, y, i=1):
         '''
-        Recursively search for and return the index of the leaf that 
+        Recursively search for and return the index of the leaf that
         contains the input point x, y.
         '''
-        l=self[i].lim
+
+        l = self[i].lim
+
         # if point is in this block...
-        if(l[0]<=x<=l[1])and(l[2]<=y<=l[3]):
+        if (l[0] <= x <= l[1]) and (l[2] <= y <= l[3]):
             # ...and it's a leaf, return this block.
-            if self[i].isLeaf: return i
+            if self[i].isLeaf:
+                return i
             # ...and it's a branch, dig deeper.
             else:
                 for j in range(self.ld(i), self.rd(i)+1):
-                    answer = self.find_leaf(x,y,i=j)
-                    if answer: return answer
+                    answer = self.find_leaf(x, y, i=j)
+                    if answer:
+                        return answer
         else:
             return False
 
@@ -186,48 +214,54 @@ class QTree(object):
 
     def mom(self, k):
         return (k+2**self.d-2)/2**self.d
+
     def leftdaughter(self, k):
-        return k*2**self.d-2**self.d+2
-    def rightdaughter(self,k):
-        return k*2**self.d+1
+        return k*2**self.d - 2**self.d+2
+
+    def rightdaughter(self, k):
+        return k*2**self.d + 1
+
     # convenience:
     rd = rightdaughter
     ld = leftdaughter
 
     def plot_res(self, ax, do_label=True, do_fill=True, tag_leafs=False,
-                 zlim=False,cmap='jet_r'):
+                 zlim=False, cmap='jet_r'):
 
         from matplotlib.pyplot import get_cmap
         from matplotlib import patheffects
         from matplotlib.colors import LogNorm
         from matplotlib.cm import ScalarMappable
-        
+
         # Create a color map using either zlim as given or max/min resolution.
         cNorm = LogNorm(vmin=self.dx_min, vmax=self.dx_max, clip=True)
-        cMap  = ScalarMappable(cmap=get_cmap(cmap), norm=cNorm)
-            
+        cMap = ScalarMappable(cmap=get_cmap(cmap), norm=cNorm)
+
         dx_vals = {}
-        
+
         for key in self.tree:
             if self[key].isLeaf:
                 color = cMap.to_rgba(self[key].dx)
                 dx_vals[self[key].dx] = 1.0
-                self[key].plot_res(ax, fc=color, do_fill=do_fill, label=key*tag_leafs)
+                self[key].plot_res(ax, fc=color, do_fill=do_fill,
+                                   label=key*tag_leafs)
 
         if do_label:
-            
-            ax.annotate('Resolution:', [1.02,0.99], xycoords='axes fraction', 
-                        color='k',size='medium')
-            for i,key in enumerate(sorted(dx_vals.keys())):
-                #dx_int = log2(key)
-                if key<1:
+
+            ax.annotate('Resolution:', [1.02, 0.99], xycoords='axes fraction',
+                        color='k', size='medium')
+            for i, key in enumerate(sorted(dx_vals.keys())):
+                # dx_int = log2(key)
+                if key < 1:
                     label = '1/%i' % (key**-1)
                 else:
                     label = '%i' % key
-                ax.annotate('%s $R_{E}$'%label, [1.02,0.87-i*0.1],
+                ax.annotate(f'{label} $R_{{E}}$', [1.02, 0.87-i*0.1],
                             xycoords='axes fraction', color=cMap.to_rgba(key),
-                            size='x-large',path_effects=[patheffects.withStroke(
-                                linewidth=1,foreground='k')])
+                            size='x-large',
+                            path_effects=[patheffects.withStroke(
+                                linewidth=1, foreground='k')])
+
 
 class Branch(object):
     '''
@@ -240,40 +274,42 @@ class Branch(object):
         '''
         self.isLeaf = False
         self.lim = lim
-    
+
     def plotbox(self, ax, lc='k', **kwargs):
         '''
-        Plot a box encompassing the branch lim onto 
+        Plot a box encompassing the branch lim onto
         axis 'ax'.
         '''
         from matplotlib.collections import LineCollection
         from numpy import array
-        l=self.lim
+        l = self.lim
         segs = (
-            array([ [l[0],l[2] ], [ l[1],l[2]] ]),
-            array([ [l[0],l[3] ], [ l[1],l[3]] ]),
-            array([ [l[0],l[2] ], [ l[0],l[3]] ]),
-            array([ [l[1],l[2] ], [ l[1],l[3]] ]))
-        alpha = 1#max(0, min(.8, -1/40.*l[2]))
-        coll=LineCollection(segs, colors=lc, alpha=alpha, **kwargs)
+            array([[l[0], l[2]], [l[1], l[2]]]),
+            array([[l[0], l[3]], [l[1], l[3]]]),
+            array([[l[0], l[2]], [l[0], l[3]]]),
+            array([[l[1], l[2]], [l[1], l[3]]]))
+        alpha = 1  # max(0, min(.8, -1/40.*l[2]))
+        coll = LineCollection(segs, colors=lc, alpha=alpha, **kwargs)
         ax.add_collection(coll)
-        #ax.plot(l[0:2], [l[2],l[2]], **kwargs)
-        #ax.plot(l[0:2], [l[3],l[3]], **kwargs)
-        #ax.plot([l[0],l[0]], l[2:],  **kwargs)
-        #ax.plot([l[1],l[1]], l[2:],  **kwargs)
+        # ax.plot(l[0:2], [l[2],l[2]], **kwargs)
+        # ax.plot(l[0:2], [l[3],l[3]], **kwargs)
+        # ax.plot([l[0],l[0]], l[2:],  **kwargs)
+        # ax.plot([l[1],l[1]], l[2:],  **kwargs)
 
     def plot_res(self, ax, fc='gray', do_fill=True, label=False):
-        if not self.isLeaf: return
+        if not self.isLeaf:
+            return
         from matplotlib.patches import Polygon
         from numpy import array
-        l=self.lim
+        l = self.lim
         verts = array([
-                [l[0],l[2] ], [ l[1],l[2]],
-                [l[1],l[3] ], [ l[0],l[3]]])
-        alpha = 1#max(0, min(.8, -1/40.*l[2]))
-        poly = Polygon(verts, True, ec=None, fc=fc, fill=do_fill, lw=0.0, alpha=alpha)
+                [l[0], l[2]], [l[1], l[2]],
+                [l[1], l[3]], [l[0], l[3]]])
+        alpha = 1  # max(0, min(.8, -1/40.*l[2]))
+        poly = Polygon(verts, True, ec=None, fc=fc, fill=do_fill,
+                       lw=0.0, alpha=alpha)
         if label:
             x = l[0]+(l[1]-l[0])/2.0
             y = l[2]+(l[3]-l[2])/2.0
-            ax.text(x, y, label) 
+            ax.text(x, y, label)
         ax.add_patch(poly)

--- a/spacepy/pybats/qotree.py
+++ b/spacepy/pybats/qotree.py
@@ -26,6 +26,7 @@ class QTree(object):
         from numpy import sqrt, where, lexsort, inf
 
         # Set size of each block
+        self.blocksize = blocksize
 
         (self.d, self.npoints) = grid.shape
 

--- a/spacepy/pybats/qotree.py
+++ b/spacepy/pybats/qotree.py
@@ -88,21 +88,24 @@ class QTree(object):
         # Bats blocks are nPoints by nPoints,
         # blocks must have no less than nPts points.
         # Stop branching as soon as possible (e.g. combine blocks of like dx).
-        # Here, npts=2^a * self.blocksize**2
+        # Here, npts=self.blocksize**2 * 2^a
+        # 2^a is the number of complete blocks of size blocksize**2 within the
+        # current group of points. If 'a' is non-integer, we include blocks
+        # of different grid spacing.
         a = log2(self[i].npts/self.blocksize**2)
-        if (int(a) == a):
+        if int(a) == a:
             # integer 'a' implies correct number of points to be a "leaf".
             # Approximate dx assuming a proper block.
             xmax = max(grid[0, :][self[i].locs])
             xmin = min(grid[0, :][self[i].locs])
             dx = (xmax-xmin) / (sqrt(self[i].npts)-1)
 
-            # Count points along x=xmax and x= xmin.  These are equal in Leafs.
+            # Count points along x=xmax and x=xmin.  These are equal in Leafs.
             nxmin = len(grid[0, :][self[i].locs][grid[0, :][self[i].locs] == xmin])
             nxmax = len(grid[0, :][self[i].locs][grid[0, :][self[i].locs] == xmax])
 
             # Define leaf as area of constant dx (using approx above)
-            # or npts=64 (min level.)
+            # or npts=blocksize**2 (min level.)
             if (a == 0) or (nxmax == nxmin == sqrt(self[i].npts)):
                 # An NxN block can be considered a "leaf" or stopping point
                 # if above criteria are met.  Leafs must "know" the
@@ -122,7 +125,7 @@ class QTree(object):
                     arange(self[i].lim[2], self[i].lim[3]+dx, dx))
                 self.nleafs += 1
                 return
-        elif (self[i].npts < 64):
+        elif (self[i].npts < self.blocksize**2):
             # If we do not reach a true leaf but have few points,
             # we likely have hit an interface surface.  This is an
             # interface region: the space between two blocks of


### PR DESCRIPTION
This pull request improves `spacepy.pybats.qotree.QTree` logic and functionality. When building the tree, additional checks are now made to ensure uniform resolution within the block. A new keyword has been added to change the default block size of 8x8 points. This argument can be given to `spacepy.pybats.bats.Bats2d` objects, allowing a broader set of output files to be read in successfully. This change closes issue #696 and improves robustness and functionality of pybats.

Beyond this main change, two other items were addressed:

- Heavy linting was performed on all files touched in this PR. Much of this is long overdue.
- Behavior of plot functions that automatically include inner boundary/planet patches has been changed: if 'rbody' is not found in the object attributes, the patches are not generated. Previously, the plotting procedure would throw an exception. This behavior is not desirable for simulations that do not include a body.

Using the edge case that inspired this PR, a new test has been added that requires both the fix and `blocksize` to be set.

## PR Checklist

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

