### PR TITLE
pybats.IdlFile: never sort binary inputs

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -63,11 +63,6 @@ with temperature and density naming.
 perpendicular velocities with new `~.pybats.bats.Bats2d.calc_uperp`
 and `~.pybats.bats.Bats2d.calc_upar` methods.
 
-`~.pybats.IdlFile` supports reading binary files without sorting
-unstructured data (and adds support for sorting in reading ASCII
-files). Unsorted is now the default for all except `~.pybats.bats.Bats2d`.
-Thanks Lutz Rastaetter.
-
 Deprecations and removals
 *************************
 Since plot styles are no longer applied on import, importing
@@ -80,6 +75,9 @@ been fixed.
 
 Other changes
 *************
+`~.pybats.IdlFile` no longer sorts unstructured data from binary files; see
+that documentation for details. Thanks Lutz Rastaetter.
+
 :func:`~.datamodel.toCDF` now only accepts valid keyword arguments.
 
 Plot styles are not automatically applied on import of :mod:`.plot`. Use

--- a/spacepy/pybats/bats.py
+++ b/spacepy/pybats/bats.py
@@ -753,16 +753,19 @@ class Bats2d(IdlFile):
     see how to handle multi-frame files (*.outs) and for a list of critical
     attributes.
 
+    .. versionchanged:: 0.5.0
+
+       Unstructured data are now presented as in the files. See
+       `~pybats.IdlFile` for details.
     '''
     # Init by calling IdlFile init and then building qotree, etc.
-    def __init__(self, filename, *args, sort_unstructured=True, **kwargs):
+    def __init__(self, filename, *args, **kwargs):
 
         # Create quad tree object attribute:
         self._qtree = None
 
         # Read file.
         IdlFile.__init__(self, filename, keep_case=False, *args,
-                         sort_unstructured=sort_unstructured,
                          **kwargs)
 
         # Behavior of output files changed Jan. 2017:

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -244,7 +244,6 @@ class TestIdlFile(unittest.TestCase):
     knownMhdZlim = 124.0
     knownMhdTime = dt.datetime(2014, 4, 10, 0, 0, 50)
     knownMhdX_unsorted = [-220., -212., -204., -196., -188., -180., -172., -164.] # first 8 X positions in the y0_ascii.out file
-    knownMhdX_sorted = [-220., -212., -220., -204., -220., -212., -212., -204.] # first 8 X positions in the binary y=0_mhd_1_e20140410-000050.out file after sorting of positions
 
     # Known values for multi-frame *.outs files:
     # Time/iteration range covered by files:
@@ -286,12 +285,6 @@ class TestIdlFile(unittest.TestCase):
         self.assertEqual(self.knownMhdZlim*-1, mhd['z'].min())
         for v in range(len(self.knownMhdX_unsorted)):
             self.assertEqual(self.knownMhdX_unsorted[v], (mhd['x'])[v])
-        mhd = pb.IdlFile(os.path.join(spacepy_testing.datadir,
-                                      'pybats_test',
-                                      'y=0_mhd_1_e20140410-000050.out'),
-                         sort_unstructured=True)
-        for v in range(len(self.knownMhdX_sorted)):
-            self.assertEqual(self.knownMhdX_sorted[v], (mhd['x'])[v])
 
     def testAscii(self):
         # Open file:


### PR DESCRIPTION
This PR removes the sorting of unstructured binary data in pybats. It appears this didn't work properly anyhow. Closes #705.

#584 added the ability to leave binary data unsorted (it was sorted by default) and to sort ASCII data (was unsorted by default). As detailed in #705, the sorting was nondeterministic and probably didn't give a desired/useful answer anyway. The qotree code provides a better way of working with adjacent grid points (the goal of the sorting).

So this PR just rips out the sorting altogether. Because the optional sorting was never released, the release notes and such are updated as if that kwarg never happened.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
