### PR TITLE
Update dictree to allow returning not printing the result

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -76,6 +76,8 @@ and `~.pybats.bats.Bats2d.calc_upar` methods.
 (`~.pybats.qotree.QTree`) now accepts a keyword argument to set the size
 of each block: `blocksize`. Default value is 8.
 
+`~.toolbox.dictree` now supports returning the output instead of printing it.
+
 Deprecations and removals
 *************************
 Since plot styles are no longer applied on import, importing

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -892,14 +892,19 @@ class SpaceData(dict, MetaMixin, ISTPContainer):
 
         Other Parameters
         ----------------
-        verbose : boolean (optional)
+        verbose : bool, default False
             print more info
-        spaces : string (optional)
+        spaces : str (optional)
             string will added for every line
-        levels : integer (optional)
-            number of levels to recurse through (True means all)
-        attrs : boolean (optional)
+        levels : int (optional)
+            number of levels to recurse through (True, the default,  means all)
+        attrs : bool, default False
             display information for attributes
+        print_out : bool, default True
+
+                .. versionadded:: 0.5.0
+
+            Print output (original behavior); if ``False``, return the output.
 
         Examples
         --------
@@ -922,7 +927,7 @@ class SpaceData(dict, MetaMixin, ISTPContainer):
         toolbox.dictree
         '''
         from . import toolbox
-        toolbox.dictree(self, **kwargs)
+        return toolbox.dictree(self, **kwargs)
 
     def flatten(self):
         '''

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -600,7 +600,8 @@ def human_sort( l ):
     return l
 
 
-def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwargs):
+def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False,
+            print_out=True, **kwargs):
     """
     pretty print a dictionary tree
 
@@ -608,14 +609,19 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
     ----------
     in_dict : dict
         a complex dictionary (with substructures)
-    verbose : boolean (optional)
+    verbose : bool, default False
         print more info
-    spaces : string (optional)
+    spaces : str (optional)
         string will added for every line
-    levels : integer (optional)
-        number of levels to recurse through (True means all)
-    attrs : boolean (optional)
+    levels : int (optional)
+        number of levels to recurse through (True, the default,  means all)
+    attrs : bool, default False
         display information for attributes
+    print_out : bool, default True
+
+            .. versionadded:: 0.5.0
+
+        Print output (original behavior); if ``False``, return the output.
 
     Raises
     ------
@@ -653,14 +659,16 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
     """
     if not (hasattr(in_dict, 'keys') or hasattr(in_dict, 'attrs')):
         raise TypeError('dictree: Input must be dictionary-like')
+    res = ''
     if not spaces:
         spaces = ''
-        print('+')
+        res += '+\n'
     toplev = kwargs.get('toplev', True)
     try:
         if toplev and attrs:
-            dictree(in_dict.attrs, spaces=':', verbose=verbose, levels=levels,
-                    attrs=attrs, toplev=True)
+            res += dictree(
+                in_dict.attrs, spaces=':', verbose=verbose, levels=levels,
+                attrs=attrs, toplev=True, print_out=False)
             toplev = False
     except:
         pass
@@ -684,17 +692,23 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
                         dimstr = ' [{}]'.format(len(val))
                     except TypeError:
                         dimstr = ''
-                print(f'{spaces}{bar} ({typestr}{dimstr})')
+                res += f'{spaces}{bar} ({typestr}{dimstr})\n'
             else:
-                print(f'{spaces}{bar}')
+                res += f'{spaces}{bar}\n'
             if hasattr(val, 'attrs') and attrs:
-                dictree(val.attrs, spaces=f'{spaces}    :', verbose=verbose, levels=levels,
-                        attrs=attrs, toplev=False)
+                res += dictree(
+                    val.attrs, spaces=f'{spaces}    :', verbose=verbose,
+                    levels=levels, attrs=attrs, toplev=False, print_out=False)
             if hasattr(val, 'keys') and levels:
-                dictree(val, spaces=f'{spaces}     ', verbose=verbose, levels=levels,
-                        attrs=attrs, toplev=False)
+                res += dictree(
+                    val, spaces=f'{spaces}     ', verbose=verbose,
+                    levels=levels, attrs=attrs, toplev=False, print_out=False)
     except:
         pass
+    if print_out:
+        print(res, end='')
+    else:
+        return res
 
 
 def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True,

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -651,63 +651,50 @@ def dictree(in_dict, verbose=False, spaces=None, levels=True, attrs=False, **kwa
     Attributes of, e.g., a CDF or a datamodel type object (obj.attrs)
     are denoted by a colon.
     """
-    try:
-        assert hasattr(in_dict, 'keys')
-    except AssertionError:
-        try:
-            assert hasattr(in_dict, 'attrs')
-        except:
-            raise TypeError('dictree: Input must be dictionary-like')
-
+    if not (hasattr(in_dict, 'keys') or hasattr(in_dict, 'attrs')):
+        raise TypeError('dictree: Input must be dictionary-like')
     if not spaces:
         spaces = ''
         print('+')
-
-    if 'toplev' in kwargs:
-        toplev = kwargs['toplev']
-    else:
-        toplev = True
+    toplev = kwargs.get('toplev', True)
     try:
         if toplev and attrs:
-            dictree(in_dict.attrs, spaces = ':', verbose = verbose, levels = levels, attrs=attrs, toplev=True)
+            dictree(in_dict.attrs, spaces=':', verbose=verbose, levels=levels,
+                    attrs=attrs, toplev=True)
             toplev = False
     except:
         pass
 
-    # TODO, if levels is True why check again?
-    if levels:
-        try:
-            assert levels is True
-        except AssertionError:
-            levels -= 1
-            if levels == 0:
-                levels = None
+    if levels and levels is not True:  # numerical level count given
+        levels -= 1
+        if levels == 0:
+            levels = None
 
     try:
         for key in sorted(in_dict.keys()):
+            val = in_dict[key]
             bar = '|____' + str(key)
             if verbose:
-                typestr = str(type(in_dict[key])).split("'")[1]
+                typestr = str(type(val)).split("'")[1]
                 #check entry for dict-like OR .attrs dict
                 try:
-                    dimstr = in_dict[key].shape
-                    dimstr = ' ' + str(dimstr)
+                    dimstr = ' {}'.format(val.shape)
                 except AttributeError:
                     try:
-                        dimstr = len(in_dict[key])
-                        dimstr = ' [' + str(dimstr) + ']'
-                    except:
+                        dimstr = ' [{}]'.format(len(val))
+                    except TypeError:
                         dimstr = ''
-                print(spaces + bar + ' ('+ typestr + dimstr + ')')
+                print(f'{spaces}{bar} ({typestr}{dimstr})')
             else:
-                print(spaces + bar)
-            if hasattr(in_dict[key], 'attrs') and attrs:
-                dictree(in_dict[key].attrs, spaces = spaces + '    :', verbose = verbose, levels = levels, attrs=attrs, toplev=False)
-            if hasattr(in_dict[key], 'keys') and levels:
-                dictree(in_dict[key], spaces = spaces + '     ', verbose = verbose, levels = levels, attrs=attrs, toplev=False)
+                print(f'{spaces}{bar}')
+            if hasattr(val, 'attrs') and attrs:
+                dictree(val.attrs, spaces=f'{spaces}    :', verbose=verbose, levels=levels,
+                        attrs=attrs, toplev=False)
+            if hasattr(val, 'keys') and levels:
+                dictree(val, spaces=f'{spaces}     ', verbose=verbose, levels=levels,
+                        attrs=attrs, toplev=False)
     except:
         pass
-    return None
 
 
 def _crawl_yearly(base_url, pattern, datadir, name=None, cached=True,

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -192,6 +192,8 @@ class SpaceDataTests(unittest.TestCase):
         output.close()
         expected = "+\n|____foo\n"
         self.assertEqual(result, expected)
+        result = a.tree(print_out=False)
+        self.assertEqual(result, expected)
 
     def test_fromRecArrayNames(self):
         '''given a known rec array, should get known keys in SpaceData'''

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -690,9 +690,11 @@ class SimpleFunctionTests(unittest.TestCase):
 
     def test_dictree_dmarray(self):
         """dictree with dmarray"""
-        a = {'a': 1, 'b': 2,
+        a = spacepy.SpaceData(
+            {'a': 1, 'b': 2,
              'c': spacepy.dmarray([[1, 2, 3], [4, 5, 6]],
-                                  attrs={'foo': 'bar'})}
+                                  attrs={'foo': 'bar'})},
+            attrs={'test': 99})
         realstdout = sys.stdout
         output = StringIO.StringIO()
         sys.stdout = output
@@ -701,6 +703,7 @@ class SimpleFunctionTests(unittest.TestCase):
         result = output.getvalue()
         output.close()
         expected = """+
+:|____test (int)
 |____a (int)
 |____b (int)
 |____c (spacepy.datamodel.dmarray (2, 3))

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -687,6 +687,8 @@ class SimpleFunctionTests(unittest.TestCase):
      |____cc (dict [2])
 """
         self.assertEqual(expected, result)
+        result = tb.dictree(a, verbose=True, levels=2, print_out=False)
+        self.assertEqual(expected, result)
 
     def test_dictree_dmarray(self):
         """dictree with dmarray"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -667,6 +667,27 @@ class SimpleFunctionTests(unittest.TestCase):
 """
         self.assertEqual(expected, result)
 
+    def test_dictree_levels(self):
+        """dictree with specified max number of levels"""
+        a = {'a': 1, 'b': 2,
+             'c':{'aa': 11, 'bb': 22, 'cc': { 'aaa': 111, 'bbb': 222}}}
+        realstdout = sys.stdout
+        output = StringIO.StringIO()
+        sys.stdout = output
+        self.assertIs(tb.dictree(a, verbose=True, levels=2), None)
+        sys.stdout = realstdout
+        result = output.getvalue()
+        output.close()
+        expected = """+
+|____a (int)
+|____b (int)
+|____c (dict [3])
+     |____aa (int)
+     |____bb (int)
+     |____cc (dict [2])
+"""
+        self.assertEqual(expected, result)
+
     def test_geomspace(self):
         """geomspace should give known output"""
         ans = [1, 10, 100, 1000]

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -688,21 +688,23 @@ class SimpleFunctionTests(unittest.TestCase):
 """
         self.assertEqual(expected, result)
 
-    def test_dictree_np(self):
-        """dictree with numpy array"""
+    def test_dictree_dmarray(self):
+        """dictree with dmarray"""
         a = {'a': 1, 'b': 2,
-             'c': array([[1, 2, 3], [4, 5, 6]])}
+             'c': spacepy.dmarray([[1, 2, 3], [4, 5, 6]],
+                                  attrs={'foo': 'bar'})}
         realstdout = sys.stdout
         output = StringIO.StringIO()
         sys.stdout = output
-        self.assertIs(tb.dictree(a, verbose=True, levels=2), None)
+        self.assertIs(tb.dictree(a, verbose=True, attrs=True), None)
         sys.stdout = realstdout
         result = output.getvalue()
         output.close()
         expected = """+
 |____a (int)
 |____b (int)
-|____c (numpy.ndarray (2, 3))
+|____c (spacepy.datamodel.dmarray (2, 3))
+    :|____foo (str [3])
 """
         self.assertEqual(expected, result)
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -688,6 +688,24 @@ class SimpleFunctionTests(unittest.TestCase):
 """
         self.assertEqual(expected, result)
 
+    def test_dictree_np(self):
+        """dictree with numpy array"""
+        a = {'a': 1, 'b': 2,
+             'c': array([[1, 2, 3], [4, 5, 6]])}
+        realstdout = sys.stdout
+        output = StringIO.StringIO()
+        sys.stdout = output
+        self.assertIs(tb.dictree(a, verbose=True, levels=2), None)
+        sys.stdout = realstdout
+        result = output.getvalue()
+        output.close()
+        expected = """+
+|____a (int)
+|____b (int)
+|____c (numpy.ndarray (2, 3))
+"""
+        self.assertEqual(expected, result)
+
     def test_geomspace(self):
         """geomspace should give known output"""
         ans = [1, 10, 100, 1000]


### PR DESCRIPTION
From discussion in #704, this updates dictree to allow returning (intead of printing) the result. The default remains printing. We could possibly change that (via a deprecation cycle) if we glue on appropriate ipython pretty-print methods. Then ipython would Just Do The Right Thing.

Also extends dictree test coverage and does some refactoring.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
