### PR TITLE
test_spectrogram: remove superfluous saving of output on one test

### DIFF
--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -236,7 +236,6 @@ class SimpleSpectrogramTests(spacepy_testing.TestPlot):
 
     def testFillAndLow(self):
         """Distinguish between fill and below range cutoff"""
-        self.save_plots = True
         z = np.tile(np.arange(1., 6), (10, 1))
         z[0, :2] = .5
         z[1, :2] = .1


### PR DESCRIPTION
This is a one-liner. One of the test_spectrogram tests was explicitly saving the output and we don't need that...it was basically debugging code that was left in. I tracked it down to #661.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)