### PR TITLE
Support editable installs

### DIFF
--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -21,17 +21,6 @@ import sysconfig
 sys.path.append(sys.path.pop(0))
 # Put in the unit test directory path, so spacepy_testing can be documented.
 sys.path.append(os.path.abspath(os.path.join('..', '..', 'tests')))
-# Add build directory to the path, preferring version-specific.
-buildbase = os.path.abspath(os.path.join(
-    os.path.dirname(__file__), '..', '..', 'build'))
-for pth in ('lib', # Prepending, so add low-priority paths first.
-            'lib.{0}-{1}.{2}'.format(sysconfig.get_platform(),
-                                     *sys.version_info[:2]),
-            ):
-    buildpath = os.path.join(buildbase, pth)
-    if os.path.isdir(buildpath):
-        if not buildpath in sys.path:
-            sys.path.insert(0, buildpath)
 
 # -- General configuration -----------------------------------------------------
 

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -81,6 +81,11 @@ Deprecations and removals
 Since plot styles are no longer applied on import, importing
 ``spacepy.plot.apionly`` has no effect and is deprecated.
 
+The new pip-based install method does not support a separate ``build``
+step so `~spacepy_testing.add_build_to_path` is deprecated. Alternatives
+include using an :ref:`editable install <install_--editable>` or installing
+in a custom location using :ref:`\\\\\\-\\\\\\-prefix <install_--prefix>` and manually editing :envvar:`PYTHONPATH`.
+
 Major bugfixes
 **************
 :func:`~.datamodel.toCDF` handling of time types other than TT2000 has

--- a/Doc/source/tests.rst
+++ b/Doc/source/tests.rst
@@ -6,6 +6,19 @@ Unit tests
 .. contents::
    :local:
 
+Unit tests are in the ``tests`` directory. Individual scripts can be
+run from this directory, or ``test_all.py`` will run all tests in all
+scripts.
+
+spacepy must be installed before running the tests. To avoid affecting an
+installed version while testing, use a separate :mod:`venv` or conda
+environment, or install in a custom location using
+:ref:`\\\\\\-\\\\\\-prefix <install_--prefix>` and manually edit
+:envvar:`PYTHONPATH`.
+
+Using an :ref:`editable install <install_--editable>` may be useful to save
+time with repeated installs while editing.
+
 The spacepy_testing module
 ==========================
 
@@ -14,20 +27,7 @@ The spacepy_testing module
 The ``spacepy_testing`` module contains utilities for assistance with
 testing SpacePy. It is not installed as part of SpacePy and is thus
 only importable from the unit test scripts themselves (which are in the
-same directory). All unit test scripts import this module, and should
-do so before importing any spacepy modules to ensure pathing is correct.
-
-On import, :func:`~spacepy_testing.add_build_to_path` is run so that
-the ``build`` directory is added to the Python search path. This means
-the tests run against the latest build, not the installed version. Remove
-the build directory to run against the installed version instead. The build
-directory does not completely separate out Python versions, so removing
-the build directory (and rebuilding) is recommended when switching Python
-versions.
-
-Build the package before running the tests::
-
-  python setup.py build
+same directory). All unit test scripts import this module.
 
 .. contents::
    :local:

--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -20,7 +20,7 @@ set PYVER="%2"
 CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate" py%2_%1
 pushd %~dp0\..\..\
 rmdir /s /q build 2> nul
-CALL python setup.py bdist_wheel
+CALL pyproject-build -w -n -x
 popd
 ::This turns off echo!
 CALL conda deactivate

--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -47,36 +47,27 @@ IF "%ACTION%"=="BUILD" (
     set NUMPY="numpy"
     :: Build with the minimum version for each Python version
     IF "%2"=="310" (
-        set NUMPY="numpy>=1.21.0,<1.22.0"
+        set NUMPY="numpy~=1.21.0"
     )
     IF "%2"=="39" (
     :: 1.18 works on 3.9, but there's no Windows binary wheel.
     :: 1.19.4 has Win10 2004 bug on 64-bit, but
     :: we'll avoid it on 32-bit as well, no point getting picky...
-        set NUMPY="numpy>=1.19.5,<1.20.0"
+        set NUMPY="numpy~=1.19.5"
     )
     IF "%2"=="38" (
-        set NUMPY="numpy>=1.17.0,<1.19.0"
+        set NUMPY="numpy~=1.17.0"
     )
     IF "%2"=="37" (
-        set NUMPY="numpy>=1.15.1,<1.16.0"
+        set NUMPY="numpy~=1.15.1"
     )
     IF "%2"=="36" (
-    :: 1.12 works on 3.6, but f2py fails on Windows
-        set NUMPY="numpy>=1.13.0,<1.14.0"
+        set NUMPY="numpy~=1.15.1"
     )
-    IF "%2"=="35" (
-        set NUMPY="numpy>=1.10.0,<1.11.0"
-    )
-    CALL pip install !NUMPY!
+    CALL pip install !NUMPY! build wheel
 ) ELSE (
     :: Testing. Get the latest of everything
-    IF "%2"=="310" (
-        CALL pip install numpy
-        CALL pip install numpy scipy matplotlib h5py astropy
-    ) ELSE (
-        CALL conda install -y numpy scipy matplotlib h5py astropy
-    )
+    CALL conda install -y numpy scipy matplotlib h5py astropy
 )
 CALL conda deactivate
 ::This turns off echo!

--- a/setup.py
+++ b/setup.py
@@ -258,9 +258,6 @@ def finalize_compiler_options(cmd):
         return
     if sys.platform == 'win32' and isinstance(cmd.f2py, str) \
        and not is_win_exec(cmd.f2py):
-        if egginfo_only: #Punt, we're not going to call it
-            cmd.f2py = [cmd.f2py]
-            return
         f2py = cmd.f2py
         if not os.path.isfile(f2py): #Not a file, and didn't exec
             f2pydir = next((d for d in os.environ['PATH'].split(os.pathsep)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,11 @@ import copy
 import os, shutil, getopt, glob, re
 import platform
 import subprocess
-import sysconfig
+if sys.platform == 'win32' and sys.version_info < (3, 8):
+    # https://github.com/python/cpython/issues/84006
+    from distutils import sysconfig
+else:
+    import sysconfig
 import warnings
 
 import distutils.ccompiler

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -28,8 +28,13 @@ def add_build_to_path():
     module search path, so the unit tests can be run against the built
     instead of installed version.
 
-    This is run on import of this module.
+    .. deprecated:: 0.5.0
+        The new pip-based installation method does not support a separate
+        "build" step, so this function is no longer useful. When developing,
+        either install to a custom location and manually set the path, or
+        use an editable install.
     """
+    warnings.warn('add_build_to_path deprecated in 0.5.0', DeprecationWarning)
     # Prioritize version-specific path; py2 tends to be version-specific
     # and py3 tends to use just "lib". But only use first-matching.
     for pth in ('lib',  # Prepending, so add low-priority paths first.
@@ -202,6 +207,3 @@ class TestPlot(unittest.TestCase):
             matplotlib.pyplot.savefig(fname)
             matplotlib.pyplot.close()
         matplotlib.use(self.old_backend)
-
-
-add_build_to_path()


### PR DESCRIPTION
This PR builds on #681. Primarily it supports "editable mode" for installs, which is really just a pathing/symlink trick but compiled code needs special handling (the compiled version of the library gets dumped in the source tree, ick)

One of the big changes here is that instead of compiling irbem and libspacepy as part of the "build" command it's now in the "build_ext" (extension) subcommand. So that means defining some extensions but basically bypassing the normal setuptools extension building code with our own (since it doesn't support Fortran extensions and assumes raw C libraries are only used by Python extensions).

Editable installs basically supplant the "use the build directory" approach, so this removes that handling in unit tests and documentation, and documents that.

Finally there are some fixes to Windows breakage from #681 (since I didn't test everything on Windows that time).

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
