### PR TITLE
Update citation/acknowledgement information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,7 @@ message: >-
   and other relevant papers as described in the documentation
   of the features used.
 type: software
+url: https://spacepy.github.io
 authors:
   - given-names: Steven K.
     family-names: Morley
@@ -50,9 +51,50 @@ authors:
     family-names: Koller
   - given-names: Asher
     family-names: Merrill
+  - given-names: Lutz
+    family-names: Rastatter
   - given-names: Ashton
     family-names: Reimer
   - given-names: Albert Y.
     family-names: Shih
   - given-names: Amanda
     family-names: Stricklan
+references:
+, Austin, TX, June 28 - July 3 2010. 
+  - type: conference-paper
+    scope: Cite this paper for as a general reference for the package and its history.
+    year: 2011
+    title: "Spacepy - a python-based library of tools for the space sciences"
+    collection-title: "Proceedings of the 9th Python in science conference (SciPy 2010)"
+    authors:
+      - family-names: Morley
+        given-names: Steven K.
+      - family-names: Koller
+        given-names: Josef
+      - family-names: Welling
+        given-names: Daniel T.
+      - family-names: Larsen
+        given-names: Brian A.
+      - family-names: Henderson
+        given-names: Michael G.
+      - family-names: Niehof
+        given-names: Jonathan T.
+    start: 67
+    end: 72
+    doi: 10.25080/Majora-92bf1922-012
+  - type: article
+    scope: Cite this paper as a general reference, for package scop and specific details of datamodel and coordinates.
+    authors:
+      - family-names: Niehof
+        given-names: Jonathan T.
+      - family-names: Morley
+        given-names: Steven K.
+      - family-names: Welling
+        given-names: Daniel T.
+      - family-names: Larsen
+        given-names: Brian A.
+    title: "The SpacePy space science package at 12 years"
+    year: 2022
+    journal: Frontiers in Astronomy and Space Sciences
+    volume: 9
+    doi: 10.3389/fspas.2022.1023612

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,9 +60,9 @@ authors:
   - given-names: Amanda
     family-names: Stricklan
 references:
-, Austin, TX, June 28 - July 3 2010. 
+, Austin, TX, June 28 - July 3 2010.
   - type: conference-paper
-    scope: Cite this paper for as a general reference for the package and its history.
+    scope: Cite this paper as a general reference for the package and its history.
     year: 2011
     title: "Spacepy - a python-based library of tools for the space sciences"
     collection-title: "Proceedings of the 9th Python in science conference (SciPy 2010)"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message: >-
   If you use this software, please cite it using the
   metadata from this file. Please also cite the papers
   by Morley et al. (2011; https://conference.scipy.org/proceedings/scipy2010/morley.html)
-  and Burrell et al. (2018;  doi:10.1029/2018JA025877)
+  and Niehof et al. (2022; https://doi.org/10.3389/fspas.2022.1023612)
   and other relevant papers as described in the documentation
   of the features used.
 type: software

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -41,37 +41,28 @@ To cite SpacePy in publications, use (BibTeX code):
     publisher={Frontiers}
     }
 
-and
-
-    @INPROCEEDINGS{spacepy11,
-    author = {{Morley}, S.~K. and {Koller}, J. and {Welling}, D.~T. and {Larsen}, B.~A. and {Henderson}, M.~G. and {Niehof}, J.~T.},
-    title = "{Spacepy - A Python-based library of tools for the space sciences}",
-    booktitle = "{Proceedings of the 9th Python in science conference (SciPy 2010)}",
-    year = 2011,
-    address = {Austin, TX}
-    }
-
 To cite the code itself:
     @software{spacepy_code,
     author       = {Morley, Steven K. and Niehof, Jonathan T. and
-                    Welling, Daniel T. and Larsen, Brian A. and
-                    Brunet, Antoine and Engel, Miles A. and
-                    Gieseler, Jan and Haiducek, John and
-                    Henderson, Michael and Hendry, Aaron and
-                    Hirsch, Michael and Killick, Peter and
-                    Koller, Josef and Merrill, Asher and
-                    Rastatter, Lutz and Reimer, Ashton and
-                    Shih, Albert Y. and Stricklan, Amanda},
+    Welling, Daniel T. and Larsen, Brian A. and
+    Brunet, Antoine and Engel, Miles A. and
+    Gieseler, Jan and Haiducek, John and
+    Henderson, Michael and Hendry, Aaron and
+    Hirsch, Michael and Killick, Peter and
+    Koller, Josef and Merrill, Asher and
+    Rastatter, Lutz and Reimer, Ashton and
+    Shih, Albert Y. and Stricklan, Amanda},
     title        = {SpacePy},
     publisher    = {Zenodo},
     doi          = {10.5281/zenodo.3252523},
     url          = {https://doi.org/10.5281/zenodo.3252523}
     }
-                                                                                                                                                                                                                                                                                                                                                                                                                                    }
+
+
 Certain modules may provide additional citations in the ``__citation__``
-attribute. Contact a module's author (details in the ``__citation__`` attribute) 
-before publication or public presentation of analysis performed by that 
-module, or in case of questions about the module. This allows the author to 
+attribute. Contact a module's author (details in the ``__citation__`` attribute)
+before publication or public presentation of analysis performed by that
+module, or in case of questions about the module. This allows the author to
 validate the analysis and receive appropriate credit for his or her
 work.
 

--- a/Doc/source/index.rst
+++ b/Doc/source/index.rst
@@ -31,6 +31,18 @@ When publishing research which used SpacePy, please provide appropriate
 credit to the SpacePy team via citation or acknowledgment.
 
 To cite SpacePy in publications, use (BibTeX code):
+    @article{niehof2022spacepy,
+    title={The SpacePy space science package at 12 years},
+    author={Niehof, Jonathan T and Morley, Steven K and Welling, Daniel T and Larsen, Brian A},
+    journal={Frontiers in Astronomy and Space Sciences},
+    volume={9},
+    year={2022},
+    doi={10.3389/fspas.2022.1023612},
+    publisher={Frontiers}
+    }
+
+and
+
     @INPROCEEDINGS{spacepy11,
     author = {{Morley}, S.~K. and {Koller}, J. and {Welling}, D.~T. and {Larsen}, B.~A. and {Henderson}, M.~G. and {Niehof}, J.~T.},
     title = "{Spacepy - A Python-based library of tools for the space sciences}",
@@ -39,15 +51,23 @@ To cite SpacePy in publications, use (BibTeX code):
     address = {Austin, TX}
     }
 
-Or to cite the code itself:
-    @software{SpacePy,
-    author       = {{Larsen}, B.~A. and {Morley}, S.~K. and {Niehof}, J.~T. and {Welling}, D.~T.},
+To cite the code itself:
+    @software{spacepy_code,
+    author       = {Morley, Steven K. and Niehof, Jonathan T. and
+                    Welling, Daniel T. and Larsen, Brian A. and
+                    Brunet, Antoine and Engel, Miles A. and
+                    Gieseler, Jan and Haiducek, John and
+                    Henderson, Michael and Hendry, Aaron and
+                    Hirsch, Michael and Killick, Peter and
+                    Koller, Josef and Merrill, Asher and
+                    Rastatter, Lutz and Reimer, Ashton and
+                    Shih, Albert Y. and Stricklan, Amanda},
     title        = {SpacePy},
     publisher    = {Zenodo},
     doi          = {10.5281/zenodo.3252523},
     url          = {https://doi.org/10.5281/zenodo.3252523}
     }
-
+                                                                                                                                                                                                                                                                                                                                                                                                                                    }
 Certain modules may provide additional citations in the ``__citation__``
 attribute. Contact a module's author (details in the ``__citation__`` attribute) 
 before publication or public presentation of analysis performed by that 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,21 @@ If you wish to use CDF files, download and install the NASA CDF library. The def
 
 When publishing research which used SpacePy, please provide appropriate credit to the SpacePy team via citation or acknowledgement.
 
-To cite SpacePy in publications, use (BibTeX code):
+To cite SpacePy in publications, please cite both the code (DOI: 10.5281/zenodo.3252523) and the papers describing the package (BibTeX code):
+
+```
+@article{niehof2022spacepy,
+  title={The SpacePy space science package at 12 years},
+  author={Niehof, Jonathan T and Morley, Steven K and Welling, Daniel T and Larsen, Brian A},
+  journal={Frontiers in Astronomy and Space Sciences},
+  volume={9},
+  year={2022},
+  doi={10.3389/fspas.2022.1023612},
+  publisher={Frontiers}
+}
+```
+
+and/or
 
 ```
 @INPROCEEDINGS{spacepy11,
@@ -71,6 +85,7 @@ address = {Austin, TX}
 }
 ```
 
+For additional information, see the [CITATION.cff](https://github.com/spacepy/spacepy/blob/main/CITATION.cff) file.
 Certain modules may provide additional citations in the ```__citation__``` attribute. Contact a module's author before publication or public presentation of analysis performed by that module. This allows the author to validate the analysis and receive appropriate credit for his or her work.
 
 For acknowledging SpacePy, please provide the URL to our github repository. [github.com/spacepy/spacepy](https://github.com/spacepy/spacepy)


### PR DESCRIPTION
Our `CITATION.cff` doesn't refer folks to the Niehof et al., 2022 (Spacepy at 12) paper.
This PR changes the file to point to the 2010 conference proceedings and the 2022 update paper.
The change will be visible in two places:
1. When folks click the "cite this repository" link on the github page, and
2. When we tag a new release the metadata gets used by Zenodo, so the citation info will be there.

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [N/A] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [N/A] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

