### PR TITLE
Update test_toolbox to fix failing CI: import inf from numpy not scipy

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -2353,7 +2353,7 @@ def intsolve(func, value, start=None, stop=None, maxit=1000):
     **Note:** Assumes func is everywhere positive, otherwise solution may
            be multi-valued.
     """
-    from scipy import inf
+    from numpy import inf
     from scipy.integrate import quad
     from warnings import warn
     if start is None:
@@ -2432,7 +2432,7 @@ def dist_to_list(func, length, min=None, max=None):
     >>> p2 = matplotlib.pyplot.plot(x, [gauss(i) * 1000 for i in x], 'red')
     >>> matplotlib.pyplot.draw()
     """
-    from scipy import inf
+    from numpy import inf
     from scipy.integrate import quad
     if min is None:
         min = -inf

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 
 import numpy
 from numpy import array
-from scipy import inf
+from numpy import inf
 from scipy.stats import poisson
 
 import spacepy_testing


### PR DESCRIPTION
It appears that inf was removed from the scipy base namespace at some point, so this is now failing to import. Numpy still provides this and the objects are the same in older versions of both libraries.

CI is currently failing because of this, so the change (which is backward compatible) should enable the testing to run on all supported versions.

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [N/A] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [N/A] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
