### PR TITLE
Two new IMF Calculations: clock angle and epsilon

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -25,6 +25,12 @@ pandas 0.18.0, which is not installed by default with SpacePy.
 (`~.datamodel.ISTPArray.fromQuantity`). This support requires Astropy
 1.0, which is not installed by default with SpacePy.
 
+`~.pybats.ImfInput` now has two new methods:
+:meth:`~.pybats.ImfInput.calc_clock` which, calculates and stores the IMF
+clock angle defined as the angle of the interplanetary magnetic field (IMF) in
+the GSM Y-Z plane; and :meth:`~.pybats.ImfInput.calc_epsilon`, which calculates
+the epsilon parameter, an approximation of power input into the magnetosphere.
+
 0.5 Series
 ==========
 0.5.0 (2024-03-11)

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1960,7 +1960,8 @@ class ImfInput(PbData):
         '''
 
         self['clock'] = dmarray(180/np.pi * np.arctan2(self['by'], self['bz']),
-                                attrs={'units': r'^{\circ}'})
+                                attrs={'units': r'$^{\circ}$',
+                                       'label': 'Clock Angle'})
 
     def calc_epsilon(self):
         '''

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1956,7 +1956,6 @@ class ImfInput(PbData):
         purely southward configuration.
 
         The resulting value is stored as `self['cloc']` in units of degrees.
-
         '''
 
         self['clock'] = dmarray(180/np.pi * np.arctan2(self['by'], self['bz']),

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1974,7 +1974,6 @@ class ImfInput(PbData):
 
         For full details, see Perreault and Akasofu(1978),
         https://doi.org/10.1111/j.1365-246X.1978.tb05494.x.
-
         '''
 
         if 'b' not in self:

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1928,7 +1928,7 @@ class ImfInput(PbData):
         # Const: nT->T, m->km, mu_0, proton mass, cm-3->m-3.
         const = 1E-12/np.sqrt(4.*np.pi*10**-7*1.67E-27*100**3)
 
-        self['vAlf'] = dmarray(const*self['b']/np.sqrt(self['rho']),
+        self['vAlf'] = dmarray(const*self['b']/np.sqrt(self[self._denvar]),
                                {'units': '$km/s$', 'label': r'V$_{Alf}'})
 
         return True

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -1955,7 +1955,11 @@ class ImfInput(PbData):
         angle of zero represents purely northward IMF while 180 represents
         purely southward configuration.
 
-        The resulting value is stored as `self['cloc']` in units of degrees.
+        The resulting value is stored as `self['clock']` in units of degrees.
+
+        Notes
+        -----
+        .. versionadded:: 0.6.0
         '''
 
         self['clock'] = dmarray(180/np.pi * np.arctan2(self['by'], self['bz']),
@@ -1974,6 +1978,10 @@ class ImfInput(PbData):
 
         For full details, see Perreault and Akasofu(1978),
         https://doi.org/10.1111/j.1365-246X.1978.tb05494.x.
+
+        Notes
+        -----
+        .. versionadded:: 0.6.0
         '''
 
         if 'b' not in self:

--- a/spacepy/pybats/ram.py
+++ b/spacepy/pybats/ram.py
@@ -1392,10 +1392,6 @@ class PressureFile(PbData):
 
         '''
         from matplotlib.colors import LogNorm
-        try:
-            from matplotlib.colors import get_cmap
-        except ImportError:
-            from matplotlib.cm import get_cmap
         from matplotlib.pyplot import colorbar
         from matplotlib.ticker import LogLocator, LogFormatterMathtext
 
@@ -1414,7 +1410,7 @@ class PressureFile(PbData):
         p = np.reshape(self[var], [self.attrs['nL'], self.attrs['nTheta']])
         ax.grid(False)  # as of mpl 3.5 grid must be turned off before calling pcolormesh
         pcol = ax.pcolormesh(T, R, p[:, :-1], norm=LogNorm(vmin=minz, vmax=maxz),
-                             cmap=get_cmap('inferno'))
+                             cmap='inferno')
         _adjust_dialplot(ax, R, title=title, labelsize=15)
         if add_cbar:
             cbar = colorbar(pcol, pad=0.1, ticks=LogLocator(), ax=ax,

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -125,11 +125,11 @@ class TestQTree(unittest.TestCase):
 class TestCalcNdens(unittest.TestCase):
     '''Test the pybats.bats _calc_ndens function'''
     # Recognized species:
-    mass = {'hp':1.0, 'op':16.0, 'he':4.0,
-            'sw':1.0, 'o':16.0, 'h':1.0, 'iono':1.0, '':1.0}
+    mass = {'hp': 1.0, 'op': 16.0, 'he': 4.0,
+            'sw': 1.0, 'o': 16.0, 'h': 1.0, 'iono': 1.0, '': 1.0}
 
-    case1 = {'rho':np.array([42.]), 'oprho':np.array([32.]),
-             'hprho':np.array([2.]), 'herho':np.array([8.])}
+    case1 = {'rho': np.array([42.]), 'oprho': np.array([32.]),
+             'hprho': np.array([2.]), 'herho': np.array([8.])}
 
     def testCalcNdens(self):
         pbs._calc_ndens(self.case1)
@@ -145,17 +145,19 @@ class TestParsers(unittest.TestCase):
     '''
 
     # For variable names to latex conversion (from a 3 fluid run.)
-    knownTex = {'grid':'grid', 'x':'x', 'y':'y',
-                'rho':'$\rho_{}$', 'ux':'$U_{x}$', 'uy':'$U_{y}$',
-                'uz':'$U_{z}$', 'bx':'$B_{x}$', 'by':'$B_{y}$', 'bz':'$B_{z}$',
-                'pe':'pe', 'p':'$P_{}$', 'swrho':'$\rho_{sw}$',
-                'swux':'$U_{x, sw}$', 'swuy':'$U_{y, sw}$',
-                'swuz':'$U_{z, sw}$', 'swp':'$P_{sw}$',
-                'hprho':'$\rho_{hp}$', 'hpux':'$U_{x, hp}$',
-                'hpuy':'$U_{y, hp}$', 'hpuz':'$U_{z, hp}$', 'hpp':'$P_{hp}$',
-                'oprho':'$\rho_{op}$', 'opux':'$U_{x, op}$',
-                'opuy':'$U_{y, op}$', 'opuz':'$U_{z, op}$', 'opp':'$P_{op}$',
-                'jx':'$J_{x}$', 'jy':'$J_{y}$', 'jz':'$J_{z}$'}
+    knownTex = {'grid': 'grid', 'x': 'x', 'y': 'y',
+                'rho': '$\rho_{}$', 'ux': '$U_{x}$', 'uy': '$U_{y}$',
+                'uz': '$U_{z}$', 'bx': '$B_{x}$', 'by': '$B_{y}$',
+                'bz': '$B_{z}$', 'pe': 'pe', 'p': '$P_{}$',
+                'swrho': '$\rho_{sw}$', 'swux': '$U_{x, sw}$',
+                'swuy': '$U_{y, sw}$', 'swuz': '$U_{z, sw}$',
+                'swp': '$P_{sw}$', 'hprho': '$\rho_{hp}$',
+                'hpux': '$U_{x, hp}$', 'hpuy': '$U_{y, hp}$',
+                'hpuz': '$U_{z, hp}$', 'hpp': '$P_{hp}$',
+                'oprho': '$\rho_{op}$', 'opux': '$U_{x, op}$',
+                'opuy': '$U_{y, op}$', 'opuz': '$U_{z, op}$',
+                'opp': '$P_{op}$', 'jx': '$J_{x}$', 'jy': '$J_{y}$',
+                'jz': '$J_{z}$'}
 
     # For parsing TecPlot variable names:
     tecText = 'VARIABLES ="X [R]", "Y [R]", "Z [R]", "Rho [amu/cm^3]", ' + \
@@ -301,7 +303,9 @@ class TestIdlFile(unittest.TestCase):
     knownMhdXmin = -220.0
     knownMhdZlim = 124.0
     knownMhdTime = dt.datetime(2014, 4, 10, 0, 0, 50)
-    knownMhdX_unsorted = [-220., -212., -204., -196., -188., -180., -172., -164.] # first 8 X positions in the y0_ascii.out file
+    # first 8 X positions in the y0_ascii.out file:
+    knownMhdX_unsorted = [-220., -212., -204., -196.,
+                          -188., -180., -172., -164.]
 
     # Known values for multi-frame *.outs files:
     # Time/iteration range covered by files:
@@ -351,7 +355,8 @@ class TestIdlFile(unittest.TestCase):
 
         # Test units are loaded correctly:
         for v in mhd:
-            if v not in self.varnames: continue
+            if v not in self.varnames:
+                continue
             self.assertEqual(self.knownMhdUnits[v], mhd[v].attrs['units'])
 
         # Test values inside of mhd:
@@ -452,8 +457,8 @@ class TestBatsLog(unittest.TestCase):
 
         # Fake some observed data:
         time = np.array([log['time'][0], log['time'][-1]])
-        log.obs_dst = {'time':time, 'dst':[-1, 1]}
-        log.obs_sym = {'time':time, 'sym-h':[1, -1]}
+        log.obs_dst = {'time': time, 'dst': [-1, 1]}
+        log.obs_sym = {'time': time, 'sym-h': [1, -1]}
 
         # Create plot with default style:
         fig, ax = log.add_dst_quicklook(plot_obs=True, plot_sym=True,
@@ -464,8 +469,8 @@ class TestBatsLog(unittest.TestCase):
         # Create plot with custom style:
         fig, ax = log.add_dst_quicklook(plot_obs=True, plot_sym=True,
                                         epoch=log['time'][5], dstvar='dst_sm',
-                                        obs_kwargs={'ls':'--', 'c':'k'},
-                                        sym_kwargs={'ls':':', 'c':'orange'},
+                                        obs_kwargs={'ls': '--', 'c': 'k'},
+                                        sym_kwargs={'ls': ':', 'c': 'orange'},
                                         lw=5)
         self.assertTrue(isinstance(fig, plt.Figure))
         self.assertTrue(isinstance(ax,  plt.Axes))
@@ -554,13 +559,13 @@ class TestBats2d(spacepy_testing.TestPlot):
     '''
     Test functionality of Bats2d objects.
     '''
-    knownMax1 = {'jx':1.4496836229227483e-05, 'jbz':7.309692051649108e-08,
-                 'wy':0.0, 'u':1285.6114501953125}
+    knownMax1 = {'jx': 1.4496836229227483e-05, 'jbz': 7.309692051649108e-08,
+                 'wy': 0.0, 'u': 1285.6114501953125}
     knownMax2 = {'jx': 1.680669083725661e-05, 'jbz': 8.276679608343329e-08,
                  'wy': 0.0, 'u': 1285.6114501953125}
     knownCalcSingle = [8.6176513671875, 9.724967e-11, 1.0006003, 400.0,
-                       0.0067278803, 0.009994, 0.99992746, 399.99097, -2.691152,
-                       0.4002311, 8.664787, 9.730319e-17, 9.760558]
+                       0.0067278803, 0.009994, 0.99992746, 399.99097,
+                       -2.691152, 0.4002311, 8.664787, 9.730319e-17, 9.760558]
     calcnames = ['t', 'j', 'b', 'u', 'bx_hat', 'by_hat', 'bz_hat',
                  'u_perp', 'u_par', 'E', 'beta', 'jb', 'alfven']
 
@@ -717,7 +722,8 @@ class TestMagGrid(unittest.TestCase):
         m1 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
                                           'pybats_test', 'mag_grid_ascii.out'))
         m2 = pbs.MagGridFile(os.path.join(spacepy_testing.datadir,
-                                          'pybats_test', 'mag_grid_binary.out'))
+                                          'pybats_test',
+                                          'mag_grid_binary.out'))
 
         self.assertAlmostEqual(self.knownDbnMax, m1['dBn'].max())
         self.assertAlmostEqual(self.knownPedMax, m1['dBnPed'].max())
@@ -939,7 +945,8 @@ class TestImfInput(unittest.TestCase):
         f3 = self.sing.quicklook(plotvars=[['bx', 'by', 'bz'], 'n', 'v'],
                                  colors=[])
         # Custom vars, nested but incomplete colors:
-        f4 = self.mult.quicklook([['bx', 'by', 'bz'], ['SwRho', 'IonoRho'], 'v'],
+        f4 = self.mult.quicklook([['bx', 'by', 'bz'], ['SwRho', 'IonoRho'],
+                                  'v'],
                                  colors=[['r', 'g', 'b'], ['orange', 'cyan']])
         # Custom vars, custom colors/shape mismatch, blank axes:
         f5 = self.mult.quicklook([['bx', 'by', 'bz'], ['ux', 'uy'], 'blah'],
@@ -1083,15 +1090,18 @@ class RamTests(unittest.TestCase):
         rmkeys = [key for key in data if key.lower().startswith('omni')]
         for rmk in rmkeys:
             del data[rmk]
-        regrH = np.array([0.0000000e+00, 1.4857327e+07, 1.4904620e+07, 1.4523555e+07,
-                          1.3417377e+07, 1.1787100e+07, 9.8903560e+06, 8.0948140e+06,
-                          6.6876425e+06, 5.7112065e+06, 5.0520345e+06, 4.5785050e+06,
-                          4.2270450e+06, 3.9780850e+06, 3.8351362e+06, 3.7873392e+06,
-                          3.9363230e+06, 4.0524422e+06, 2.9526408e+06, 9.0399219e+05,
-                          5.2025672e+05, 2.4965306e+05, 9.1892180e+04, 3.0133383e+04,
-                          1.6105718e+04, 1.4831358e+04, 1.7809768e+04, 2.2456926e+04,
-                          2.5075262e+04, 2.3687787e+04, 1.8142951e+04, 1.0017233e+04,
-                          3.8184448e+03, 1.1123656e+03, 2.2883945e+02],
+        regrH = np.array([0.0000000e+00, 1.4857327e+07, 1.4904620e+07,
+                          1.4523555e+07, 1.3417377e+07, 1.1787100e+07,
+                          9.8903560e+06, 8.0948140e+06, 6.6876425e+06,
+                          5.7112065e+06, 5.0520345e+06, 4.5785050e+06,
+                          4.2270450e+06, 3.9780850e+06, 3.8351362e+06,
+                          3.7873392e+06, 3.9363230e+06, 4.0524422e+06,
+                          2.9526408e+06, 9.0399219e+05, 5.2025672e+05,
+                          2.4965306e+05, 9.1892180e+04, 3.0133383e+04,
+                          1.6105718e+04, 1.4831358e+04, 1.7809768e+04,
+                          2.2456926e+04, 2.5075262e+04, 2.3687787e+04,
+                          1.8142951e+04, 1.0017233e+04, 3.8184448e+03,
+                          1.1123656e+03, 2.2883945e+02],
                          dtype=np.float32)
         data.create_omniflux(check=False)
         testarr = np.array(data['omniH'][0].data)

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -866,6 +866,15 @@ class TestImfInput(unittest.TestCase):
     knownImfIono = [4.99, 0.01]
     knownSubMilli = dt.datetime(2017, 9, 6, 16, 42, 37, 0)
 
+    # Known calculated values
+    knownCalcB = [3., 10.]
+    knownCalcU = [406.201920231798, 703.5623639735]
+    knownCalcP = [1.340968, 12.3201435]
+    knownCalcAlf = [29.28687846, 56.36262388]
+    knownCalcMa = [13.86975811, 12.4827823]
+    knownCalcClock = [0.0, 180.0]
+    knownCalcEps = [0.0, 5.5987714e-05]
+
     def tearDown(self):
         # Remove temporary files.
         for f in glob.glob('*.tmp'):
@@ -933,6 +942,30 @@ class TestImfInput(unittest.TestCase):
         self.assertEqual(self.knownImfTemp[-1], self.mult['t'][-1])
         self.assertEqual(self.knownImfIono[0], self.mult['IonoRho'][0])
         self.assertEqual(self.knownImfIono[-1], self.mult['IonoRho'][-1])
+
+    def testCalcs(self):
+        '''Test calculations'''
+
+        # Perform calculations:
+        self.sing.calc_pram()     # Ram pressure.
+        self.sing.calc_alfmach()  # Alven mach number (includes calc_alf, _u)
+        self.sing.calc_epsilon()  # Epsilon/Poynting flux (includes _b, _clock)
+
+        # Check'em:
+        self.assertEqual(self.knownCalcB[0], self.sing['b'][0])
+        self.assertEqual(self.knownCalcB[1], self.sing['b'][-1])
+        self.assertAlmostEqual(self.knownCalcU[0], self.sing['u'][0])
+        self.assertAlmostEqual(self.knownCalcU[-1], self.sing['u'][-1])
+        self.assertAlmostEqual(self.knownCalcP[0], self.sing['pram'][0])
+        self.assertAlmostEqual(self.knownCalcP[-1], self.sing['pram'][-1])
+        self.assertAlmostEqual(self.knownCalcAlf[0], self.sing['vAlf'][0])
+        self.assertAlmostEqual(self.knownCalcAlf[-1], self.sing['vAlf'][-1])
+        self.assertAlmostEqual(self.knownCalcMa[0], self.sing['machA'][0])
+        self.assertAlmostEqual(self.knownCalcMa[-1], self.sing['machA'][-1])
+        self.assertAlmostEqual(self.knownCalcClock[0], self.sing['clock'][0])
+        self.assertAlmostEqual(self.knownCalcClock[-1], self.sing['clock'][-1])
+        self.assertAlmostEqual(self.knownCalcEps[0], self.sing['epsilon'][0])
+        self.assertAlmostEqual(self.knownCalcEps[-1], self.sing['epsilon'][-1])
 
     def testPlot(self):
         import matplotlib.pyplot as plt


### PR DESCRIPTION
This PR adds two new calculations to the Pybats ImfInput object: clock angle and epsilon (solar wind poynting flux scaled by clock angle). It also adds a new test for **all** calculations in the object class.

Unrelated: the use of Matplotlibs `get_cmap` has been removed from `ram.py`. This was throwing deprecation warnings dating back to MPL 3.7 and is not necessary. Tests still pass.

## PR Checklist

- [ x] Pull request has descriptive title
- [x ] Pull request gives overview of changes
- [x ] New code has inline comments where necessary
- [ x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to release notes if fixing a significant bug or providing a new feature
- [x ] New features and bug fixes should have unit tests
- [ ] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)



