### PR TITLE
Fix matplotlib 3.5 and 3.6 deprecations

### DIFF
--- a/spacepy/plot/__init__.py
+++ b/spacepy/plot/__init__.py
@@ -334,10 +334,6 @@ def levelPlot(data, var=None, time=None, levels=(3, 5), target=None, colors=None
         stepsyy = y1.repeat(2)
         y2 = np.zeros_like(stepsyy)
         ax.fill_between(stepsxx, stepsyy, y2, **kwargs)
-        if mpl.__version__<'1.5.0':
-            #pre-v1.5.0, need to manually add an artist for the legend
-            p = plt.Rectangle((0, 0), 0, 0, **kwargs)
-            ax.add_patch(p)
     
     #below threshold 1
     idx = 0

--- a/spacepy/plot/__init__.py
+++ b/spacepy/plot/__init__.py
@@ -287,7 +287,7 @@ def levelPlot(data, var=None, time=None, levels=(3, 5), target=None, colors=None
             raise TypeError('Data appears to be dict-like without a key being given')
     tflag = False
     if time is not None:
-        from scipy.stats import mode
+        import scipy.stats
         try:
             times = data[time]
         except (KeyError, ValueError, IndexError):
@@ -299,7 +299,10 @@ def levelPlot(data, var=None, time=None, levels=(3, 5), target=None, colors=None
             #the x-data are a non-datetime
             times = np.asarray(time)
         #now add the end-point
-        stepsize, dum = mode(np.diff(times), axis=None)
+        try:  # scipy 1.9 and later
+            stepsize, dum = scipy.stats.mode(np.diff(times), keepdims=False)
+        except TypeError:
+            stepsize, dum = scipy.stats.mode(np.diff(times), axis=None)
         times = np.hstack([times, times[-1]+stepsize])
     else:
         times = np.asarray(range(0, len(usearr)+1))

--- a/spacepy/plot/spectrogram.py
+++ b/spacepy/plot/spectrogram.py
@@ -545,11 +545,13 @@ class Spectrogram(dm.SpaceData):
         timeFmt = self.plotSettings['DateFormatter']
         if xy == 'x':
             ticks = axis.get_xticks()
+            axis.set_xticks(ticks)  # Hardcode existing ticks to match labels
             axis.set_xticklabels(matplotlib.dates.num2date(ticks))
             axis.xaxis.set_major_formatter(timeFmt)
             axis.get_figure().autofmt_xdate()
         elif xy == 'y':
             ticks = axis.get_yticks()
+            axis.set_yticks(ticks)
             axis.set_yticklabels(matplotlib.dates.num2date(ticks))
             axis.yaxis.set_major_formatter(timeFmt)
             axis.get_figure().autofmt_ydate()

--- a/spacepy/pybats/qotree.py
+++ b/spacepy/pybats/qotree.py
@@ -254,7 +254,11 @@ class QTree(object):
         from matplotlib.cm import ScalarMappable
 
         # Create a color map using either zlim as given or max/min resolution.
-        cNorm = LogNorm(vmin=self.dx_min, vmax=self.dx_max, clip=True)
+        vmin, vmax = self.dx_min, self.dx_max
+        if vmin == vmax:
+            vmin *= 0.9
+            vmax *= 1.1
+        cNorm = LogNorm(vmin=vmin, vmax=vmax, clip=True)
         cMap = ScalarMappable(cmap=get_cmap(cmap), norm=cNorm)
 
         dx_vals = {}
@@ -326,7 +330,7 @@ class Branch(object):
                 [l[0], l[2]], [l[1], l[2]],
                 [l[1], l[3]], [l[0], l[3]]])
         alpha = 1  # max(0, min(.8, -1/40.*l[2]))
-        poly = Polygon(verts, True, ec=None, fc=fc, fill=do_fill,
+        poly = Polygon(verts, closed=True, ec=None, fc=fc, fill=do_fill,
                        lw=0.0, alpha=alpha)
         if label:
             x = l[0]+(l[1]-l[0])/2.0

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -35,6 +35,7 @@ from test_irbempy import *
 from test_datamanager import *
 from test_datamodel import *
 from test_base import *
+from test_plot import *
 from test_plot_utils import *
 from test_rst import *
 from test_lib import *

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+"""
+Test suite for plot
+"""
+
+import datetime
+import unittest
+
+import matplotlib.collections
+import numpy
+import numpy.testing
+
+import spacepy_testing
+import spacepy.plot
+
+
+class PlotFunctionTests(spacepy_testing.TestPlot):
+    """Tests for plot functions"""
+
+    def test_levelPlot(self):
+        """basic test of levelPlot execution and output"""
+        time = numpy.array([datetime.datetime(2010, 1, i) for i in range(1, 7)])
+        values = numpy.array([1., 5.1, 2, 3.2, 1, 7])
+        ax = spacepy.plot.levelPlot(values, time=time)
+        pc = [c for c in ax.get_children()
+              if isinstance(c, matplotlib.collections.PolyCollection)]
+        self.assertEqual(3, len(pc[0].get_paths()))  # green
+        self.assertEqual(1, len(pc[1].get_paths()))  # yellow
+        self.assertEqual(2, len(pc[2].get_paths()))  # red, one bar two patches
+        numpy.testing.assert_array_equal(
+            pc[0].get_fc(),
+            [[0., 1., 0., 0.75]])
+        numpy.testing.assert_array_equal(
+            pc[1].get_fc(),
+            [[1., 1., 0., 0.75]])
+        numpy.testing.assert_allclose(
+            pc[2].get_fc(),
+            [[0.8627, 0.07843, .235290, 0.75]], rtol=1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -550,11 +550,10 @@ class TestRim(unittest.TestCase):
         self.assertFalse(out[3])  # No color bar.
 
 
-class TestBats2d(unittest.TestCase):
+class TestBats2d(spacepy_testing.TestPlot):
     '''
     Test functionality of Bats2d objects.
     '''
-
     knownMax1 = {'jx':1.4496836229227483e-05, 'jbz':7.309692051649108e-08,
                  'wy':0.0, 'u':1285.6114501953125}
     knownMax2 = {'jx': 1.680669083725661e-05, 'jbz': 8.276679608343329e-08,
@@ -566,6 +565,7 @@ class TestBats2d(unittest.TestCase):
                  'u_perp', 'u_par', 'E', 'beta', 'jb', 'alfven']
 
     def setUp(self):
+        super().setUp()
         self.mhd = pbs.Bats2d(os.path.join(spacepy_testing.datadir,
                                            'pybats_test', 'y0_ascii.out'))
         self.outs = pbs.Bats2d(os.path.join(spacepy_testing.datadir,
@@ -662,6 +662,27 @@ class TestBats2d(unittest.TestCase):
         self.assertEqual(
             'Start value 150 out of range for variable z.',
             str(cm.exception))
+
+    def testPlotOuts(self):
+        '''
+        Create plot from binary outs
+
+        Make grid resolution and contour plot
+        '''
+        fig, ax = self.outs.add_grid_plot()
+        fig, ax, cont, cbar = self.outs.add_contour(
+            'x', 'z', 'p', 21, dolog=True, target=ax, filled=False)
+        self.assertTrue(isinstance(fig, plt.Figure))
+        children = ax.get_children()
+        import matplotlib.patches
+        polys = [c for c in children
+                 if isinstance(c, matplotlib.patches.Polygon)]
+        self.assertEqual(1, len(polys))
+        p = polys[0]
+        numpy.testing.assert_array_equal(
+            p.get_xy(),
+            [[-32, -32], [32, -32], [32, 32], [-32, 32], [-32, -32]]
+            )
 
 
 class TestMagGrid(unittest.TestCase):


### PR DESCRIPTION
Fixes a few deprecations from matplotlib 3.5 and 3.6 in pybats and spectrogram. This also improves test coverage, since it tests the pieces of code which were deprecated. Fixes the case where trying to make a pybats grid resolution plot when there was only one resolution.

EDIT: Added a fix for a deprecation in scipy 1.10 and tested levelPlot to catch it.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)