### PR TITLE
Fix CITATION.cff for Zenodo integraion

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -60,7 +60,6 @@ authors:
   - given-names: Amanda
     family-names: Stricklan
 references:
-, Austin, TX, June 28 - July 3 2010.
   - type: conference-paper
     scope: Cite this paper as a general reference for the package and its history.
     year: 2011
@@ -83,7 +82,7 @@ references:
     end: 72
     doi: 10.25080/Majora-92bf1922-012
   - type: article
-    scope: Cite this paper as a general reference, for package scop and specific details of datamodel and coordinates.
+    scope: Cite this paper as a general reference, for package scope and specific details of datamodel and coordinates.
     authors:
       - family-names: Niehof
         given-names: Jonathan T.


### PR DESCRIPTION
The scipy paper has been misformatted in CITATION.cff since it was introduced in 63571812ae81cfa0455a20e4793b711960a5836d, and this is the problem in #736. It bit us again since we don't have that CI implemented. This just fixes the file without implementing the CI, so at least _next_ release the Zenodo might work properly. All this does is remove the location line--it looks like it's superfluous, not like we wanted it to be formatted in properly somewhere else.

Looks like [GitHub is supposed to parse this too](https://citation-file-format.github.io/) so we might have confirmation it's working after the pull.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
