### PR TITLE
datamodel plot routines: fix all-blank UNITS

### DIFF
--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -534,7 +534,7 @@ class ISTPContainer(collections.abc.Mapping):
                 ax.plot(numpy.array(x), data[:, dim], **plot_kwargs)
         ylabel = v.attrs.get('LABLAXIS', '')
         u = v.units(fmt='latex')
-        if u:
+        if u.strip():
             ylabel = '{}{}(${}$)'.format(ylabel, ' ' if ylabel else '', u)
         if ylabel:
             ax.set_ylabel(ylabel)
@@ -680,7 +680,7 @@ class ISTPContainer(collections.abc.Mapping):
         y = self[v.attrs['DEPEND_1']]
         zlabel = v.attrs.get('LABLAXIS', '')
         u = v.units(fmt='latex')
-        if u:
+        if u.strip():
             zlabel = '{}{}(${}$)'.format(
                 zlabel, ' ' if zlabel else '', u)
         zlabel = zlabel if zlabel else None
@@ -699,7 +699,7 @@ class ISTPContainer(collections.abc.Mapping):
                                             ax=ax, zero_valid=True, cmap=cmap)
         ylabel = y.attrs.get('LABLAXIS', '')
         u = y.units(fmt='latex')
-        if u:
+        if u.strip():
             ylabel = '{}{}(${}$)'.format(
                 ylabel, ' ' if ylabel else '', u)
         if ylabel:

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1445,6 +1445,18 @@ class ISTPPlotTests(spacepy_testing.TestPlot):
         self.assertEqual('UT', ax.get_xlabel())
         self.assertIs(None, ax.get_legend())
 
+    def test_lineplot_timeseries_1D_blank_units(self):
+        """Plot a timeseries with a single line, empty units"""
+        self.sd['B_mag'].attrs['UNITS'] = ' '
+        ax = self.sd.lineplot('B_mag')
+        lines = ax.get_lines()
+        self.assertEqual(1, len(lines))
+        np.testing.assert_array_equal(lines[0].get_xdata(), self.sd['Epoch'])
+        np.testing.assert_array_equal(lines[0].get_ydata(), self.sd['B_mag'])
+        self.assertEqual('B', ax.get_ylabel())
+        self.assertEqual('UT', ax.get_xlabel())
+        self.assertIs(None, ax.get_legend())
+
     def test_lineplot_timeseries_target_fig(self):
         """Plot a timeseries, specify a figure"""
         import matplotlib.pyplot


### PR DESCRIPTION
Quick fix for the datamodel plot routines when UNITS is blank, i.e. not empty but all spaces. This is the preferred way of showing dimensionless values in ISTP CDF, and most notably it showed up in Kp from MMS MEC. We use LaTeX to render the units, and matplotlib chokes on `$ $`.

This was a regression from 0.5.0 to 0.6.0, where 8c2f42ba0f57d3012051992b3b034b6a90d254ea switched to using LaTeX in the plots.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (NA) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
