### PR TITLE
help: take argument to search the documentation

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -8,6 +8,15 @@ This document presents user-visible changes in each release of SpacePy.
    :depth: 2
    :local:
 
+0.7 Series
+==========
+0.7.0 (2024-xx-xx)
+------------------
+
+New features
+************
+`.help` now supports searching the documentation.
+
 0.6 Series
 ==========
 0.6.0 (2024-04-25)

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -64,14 +64,27 @@ import warnings
 import webbrowser
 
 
-def help():
+def help(keyword=None):
     """Launches web browser with SpacePy documentation
 
+    Parameters
+    ----------
+    keyword : str, optional
+
+          .. versionadded:: 0.7.0
+
+      Search for this keyword. If not specified, opens the front page
+      of the documentation.
+
+    Notes
+    -----
     Online help is always for the latest release of SpacePy.
     """
     print('Opening docs for latest release. Installed SpacePy is {}.'.format(
         __version__))
-    webbrowser.open('https://spacepy.github.io/')
+    url = 'https://spacepy.github.io/' if keyword is None\
+        else f'https://spacepy.github.io/search.html?q={keyword}'
+    webbrowser.open(url)
 
 
 # put modules here that you want to be accessible through 'from spacepy import *'

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -79,6 +79,11 @@ def help(keyword=None):
     Notes
     -----
     Online help is always for the latest release of SpacePy.
+
+    Examples
+    --------
+    >>> import spacepy
+    >>> spacepy.help("coordinates")
     """
     print('Opening docs for latest release. Installed SpacePy is {}.'.format(
         __version__))


### PR DESCRIPTION
Inspired by something in pyspedas, this PR adds an optional kwarg to search the documentation.

At the risk of bikeshedding, I'm curious what the kwarg should be called. I'm using `keyword` because it's the keyword you're searching for, but also considered `search`. In practice probably nobody will use it as a kwarg, just positional.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (See below) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

Since this opens a web browser, it's not very testable in CI.