### PR TITLE
Fix build on setuptools 70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
       run: |
         # Install (not in build)
         # pip install . does not cache wheel
-        pip install --no-build-isolation --no-deps --log=install_log.txt .
+        pip install --no-build-isolation --no-deps -v -v -v --log=install_log.txt .
         echo "pip log:" && cat install_log.txt && echo "End pip log"
         pushd tests; python -c "import spacepy; print(spacepy.__file__); import os.path; print(os.listdir(os.path.dirname(spacepy.__file__)))"; popd
         ls build/* || true

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,11 @@ try:
 except ModuleNotFoundError:  # Used in older setuptools
     pass
 
-import setuptools.dep_util
+try:
+    import setuptools.modified  # added setuptools 69.0.0
+except ImportError:
+    import setuptools.dep_util  # removed setuptools 70.0.0
+    setuptools.modified = setuptools.dep_util
 import setuptools.extension
 
 import distutils.sysconfig
@@ -423,7 +427,7 @@ class build_ext(_build_ext):
             sources = glob.glob(os.path.join(srcdir, '*.f')) + \
                       glob.glob(os.path.join(srcdir, '*.inc'))
             irbempy = os.path.join(outdir, existing_libfiles[0])
-            if not setuptools.dep_util.newer_group(sources, irbempy):
+            if not setuptools.modified.newer_group(sources, irbempy):
                 return irbempy
 
         if not sys.platform in ('darwin', 'linux2', 'linux', 'win32'):
@@ -657,12 +661,12 @@ class build_ext(_build_ext):
             #Assume every .o file associated with similarly-named .c file,
             #and EVERY header file
             outdated = [s for s, o in zip(sources, objects)
-                        if setuptools.dep_util.newer_group([s] + headers, o)]
+                        if setuptools.modified.newer_group([s] + headers, o)]
             if outdated:
                 comp.compile(outdated, output_dir=self.build_temp)
             libpath = os.path.join(
                 outdir, comp.library_filename('spacepy', lib_type='shared'))
-            if setuptools.dep_util.newer_group(objects, libpath):
+            if setuptools.modified.newer_group(objects, libpath):
                 comp.link_shared_lib(objects, 'spacepy', libraries=['m'],
                                      output_dir=outdir)
             return libpath


### PR DESCRIPTION
CI in #744 failed unrelated to the actual change. setuptools 70 changed the API (pypa/setuptools#4360) so SpacePy build fails. This PR fixes that. It also increases pip's verbosity to help with debugging the issue.

I have confirmed the 0.6.0 binary wheels _install_ fine with 70. #746 documents this until the next release.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
