### PR TITLE
Improve Toolbox Test Coverage

### DIFF
--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -386,8 +386,6 @@ def loadpickle(fln):
                 return pickle.load(fh, encoding='latin1')
         except pickle.UnpicklingError: #maybe it's a gzip?
             gzip = True
-        else:
-            gzip = False
     if gzip:
         try:
             import zlib

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -520,9 +520,6 @@ def assemble(fln_pattern, outfln, sortkey='ticks', verbose=True):
             ax = np.where(dim==TAIcount)[0]
             if len(ax) == 1: # then match with length of TAI
                 dcomb[key] = dcomb[key][idx] # resort
-    else:
-        # do nothing
-        pass
 
     if verbose: print('\n writing: ', outfln)
     savepickle(outfln, dcomb)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -378,27 +378,27 @@ def loadpickle(fln):
     >>> d = loadpickle('test.pbin')
     """
     if not os.path.exists(fln) and os.path.exists(fln + '.gz'):
-        gzip = True
+        # It's a gzip
         fln += '.gz'
     else:
         try:
             with open(fln, 'rb') as fh:
                 return pickle.load(fh, encoding='latin1')
         except pickle.UnpicklingError: #maybe it's a gzip?
-            gzip = True
-    if gzip:
-        try:
-            import zlib
-            with open(fln, 'rb') as fh:
-                stream = zlib.decompress(fh.read(), 16 + zlib.MAX_WBITS) 
-                return pickle.loads(stream, encoding='latin1')
-        except MemoryError:
-            import gzip
-            with open(fln) as fh:
-                gzh = gzip.GzipFile(fileobj=fh)
-                contents = pickle.load(gzh, encoding='latin1')
-                gzh.close()
-            return contents
+            pass
+    # Try to resolve as a gzip
+    try:
+        import zlib
+        with open(fln, 'rb') as fh:
+            stream = zlib.decompress(fh.read(), 16 + zlib.MAX_WBITS)
+            return pickle.loads(stream, encoding='latin1')
+    except MemoryError:
+        import gzip
+        with open(fln) as fh:
+            gzh = gzip.GzipFile(fileobj=fh)
+            contents = pickle.load(gzh, encoding='latin1')
+            gzh.close()
+        return contents
 
 
 # -----------------------------------------------

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -39,14 +39,8 @@ import pickle
 
 import numpy as np
 
-try:
-    from spacepy import help
-except ImportError:
-    pass
-except:
-    pass
-
 import spacepy
+from spacepy import help
 from spacepy import time as spt
 
 #Try to pull in the C version. Assumption is that if you import this module,

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -100,6 +100,18 @@ class PickleAssembleTests(unittest.TestCase):
             result[key] = result[key].tolist()
         self.assertEqual(expected, result)
 
+    def test_assemble_sorted(self):
+        tb.savepickle(os.path.join(self.tempdir, 'test_pickle_1.pkl'), self.D1)
+        tb.savepickle(os.path.join(self.tempdir, 'test_pickle_2.pkl'), self.D2)
+        tb.savepickle(os.path.join(self.tempdir, 'test_pickle_3.pkl'), self.D3)
+        # Manually sort expected by 'names'
+        expected = {'names': sorted(self.all['names']),
+                    'TAI': [val for _, val in sorted(zip(self.all['names'], self.all['TAI']))]}
+        result = tb.assemble(os.path.join(self.tempdir, 'test_pickle_[1-3].pkl'), os.path.join(self.tempdir, 'test_all.pkl'), sortkey="names", verbose=False)
+        for key in result:
+            result[key] = result[key].tolist()
+        self.assertEqual(expected, result)
+
 
 class SimpleFunctionTests(unittest.TestCase):
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -106,8 +106,13 @@ class PickleAssembleTests(unittest.TestCase):
         tb.savepickle(os.path.join(self.tempdir, 'test_pickle_3.pkl'), self.D3)
         # Manually sort expected by 'names'
         expected = {'names': sorted(self.all['names']),
-                    'TAI': [val for _, val in sorted(zip(self.all['names'], self.all['TAI']))]}
-        result = tb.assemble(os.path.join(self.tempdir, 'test_pickle_[1-3].pkl'), os.path.join(self.tempdir, 'test_all.pkl'), sortkey="names", verbose=False)
+                    'TAI': [val for _, val in
+                            sorted(zip(self.all['names'], self.all['TAI']))]}
+        result = tb.assemble(
+            os.path.join(self.tempdir,'test_pickle_[1-3].pkl'),
+            os.path.join(self.tempdir, 'test_all.pkl'),
+            sortkey="names", verbose=False
+        )
         for key in result:
             result[key] = result[key].tolist()
         self.assertEqual(expected, result)


### PR DESCRIPTION
This pull request slightly improves the test coverage of `spacepy.toolbox`. Removed some unreachable or redundant lines, and added a test for `assemble` with a `sortkey`. See issue #313.
## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to release notes if fixing a significant bug or providing a new feature
- [ ] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

