### PR TITLE
Fix for issue #752, explicit checks for type comparisons to CDF_TIME_TT2000 in istp

### DIFF
--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -492,6 +492,15 @@ class VariableChecks(object):
                     continue
                 if firstdim: #Add pseudo-record dim
                     attrval = numpy.reshape(attrval, (1, -1))
+            if (v.attrs.type(which) in spacepy.pycdf.lib.timetypes) != (v.type() in spacepy.pycdf.lib.timetypes):
+                errs.append(
+                    '{} type {} not comparable to variable type {}.'.format(
+                        which,
+                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
+                        spacepy.pycdf.lib.cdftypenames[v.type()]
+                    )
+                )
+                continue
             # min, max, variable data all same dtype
             if not numpy.can_cast(numpy.asanyarray(attrval),
                                   numpy.asanyarray(minval).dtype):

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -2,6 +2,8 @@
 
 """Unit testing for istp support"""
 
+from ctypes import cast
+import ctypes
 import datetime
 import inspect
 import os.path
@@ -471,6 +473,7 @@ class VariablesTests(ISTPTestsBase):
     def testValidScale(self):
         """Check scale min and max."""
         v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])
+        tt2000 = self.cdf.new('var2', recVary=False, type=spacepy.pycdf.const.CDF_TIME_TT2000)
         v.attrs['SCALEMIN'] = 1
         v.attrs['SCALEMAX'] = 3
         self.assertEqual(
@@ -523,6 +526,15 @@ class VariablesTests(ISTPTestsBase):
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
              ],
              errs)
+        tt2000.attrs['SCALEMIN'] = 200.42e45 #tt2000 testing
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(tt2000)
+        errs.sort()
+        self.assertEqual(
+            ['SCALEMIN type CDF_DOUBLE does not match variable type CDF_TIME_TT2000.',
+             'SCALEMIN type CDF_DOUBLE not comparable to variable type CDF_TIME_TT2000.',
+             ],
+             errs)
+
         
     def testValidScaleDimensioned(self):
         """Validmin/validmax with multiple elements"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -8,6 +8,7 @@ Copyright 2010-2014 Los Alamos National Security, LLC.
 """
 
 import builtins
+import http.client
 import time, datetime
 import glob, os, sys
 import io


### PR DESCRIPTION
Made an explicit check, and an error for the validchecks on istp, that catches when a non timetype is compared against a timetype.

- [ ] Pull request has descriptive title
- [ ] Pull request gives overview of changes
- [ ] New code has inline comments where necessary
- [ ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ ] Added an entry to release notes if fixing a significant bug or providing a new feature
- [ ] New features and bug fixes should have unit tests
- [ ] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

