### PR TITLE
Explicit checks for type comparisons to CDF_TIME_TT2000 in istp

### DIFF
--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -492,6 +492,15 @@ class VariableChecks(object):
                     continue
                 if firstdim: #Add pseudo-record dim
                     attrval = numpy.reshape(attrval, (1, -1))
+            if (v.attrs.type(which) in spacepy.pycdf.lib.timetypes) != (v.type() in spacepy.pycdf.lib.timetypes):
+                errs.append(
+                    '{} type {} not comparable to variable type {}.'.format(
+                        which,
+                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
+                        spacepy.pycdf.lib.cdftypenames[v.type()]
+                    )
+                )
+                continue
             # min, max, variable data all same dtype
             if not numpy.can_cast(numpy.asanyarray(attrval),
                                   numpy.asanyarray(minval).dtype):

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -469,8 +469,8 @@ class VariableChecks(object):
         for which in (whichmin, whichmax):
             if not which in v.attrs:
                 continue
-            atype = v.attrs.type(which) # attribute type
-            vtype = v.type() # variable type
+            atype = v.attrs.type(which)
+            vtype = v.type()
             if atype != vtype:
                 errs.append(
                     '{} type {} does not match variable type {}.'.format(

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -469,12 +469,14 @@ class VariableChecks(object):
         for which in (whichmin, whichmax):
             if not which in v.attrs:
                 continue
-            if v.attrs.type(which) != v.type():
+            atype = v.attrs.type(which) # attribute type
+            vtype = v.type() # variable type
+            if atype != vtype:
                 errs.append(
                     '{} type {} does not match variable type {}.'.format(
                         which,
-                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
-                        spacepy.pycdf.lib.cdftypenames[v.type()]))
+                        spacepy.pycdf.lib.cdftypenames[atype],
+                        spacepy.pycdf.lib.cdftypenames[vtype]))
             attrval = v.attrs[which]
             multidim = bool(numpy.shape(attrval)) #multi-dimensional
             if multidim: #Compare shapes, require only 1D var
@@ -492,23 +494,15 @@ class VariableChecks(object):
                     continue
                 if firstdim: #Add pseudo-record dim
                     attrval = numpy.reshape(attrval, (1, -1))
-            if (v.attrs.type(which) in spacepy.pycdf.lib.timetypes) != (v.type() in spacepy.pycdf.lib.timetypes):
-                errs.append(
-                    '{} type {} not comparable to variable type {}.'.format(
-                        which,
-                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
-                        spacepy.pycdf.lib.cdftypenames[v.type()]
-                    )
-                )
-                continue
             # min, max, variable data all same dtype
             if not numpy.can_cast(numpy.asanyarray(attrval),
-                                  numpy.asanyarray(minval).dtype):
+                                  numpy.asanyarray(minval).dtype) or \
+                (atype in spacepy.pycdf.lib.timetypes) != (vtype in spacepy.pycdf.lib.timetypes):
                 errs.append(
                     '{} type {} not comparable to variable type {}.'.format(
                         which,
-                        spacepy.pycdf.lib.cdftypenames[v.attrs.type(which)],
-                        spacepy.pycdf.lib.cdftypenames[v.type()]
+                        spacepy.pycdf.lib.cdftypenames[atype],
+                        spacepy.pycdf.lib.cdftypenames[vtype]
                     ))
                 continue # Cannot do comparisons
             if numpy.any((minval > attrval)) or numpy.any((maxval < attrval)):

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -471,6 +471,7 @@ class VariablesTests(ISTPTestsBase):
     def testValidScale(self):
         """Check scale min and max."""
         v = self.cdf.new('var1', recVary=False, data=[1, 2, 3])
+        tt2000 = self.cdf.new('var2', recVary=False, type=spacepy.pycdf.const.CDF_TIME_TT2000)
         v.attrs['SCALEMIN'] = 1
         v.attrs['SCALEMAX'] = 3
         self.assertEqual(
@@ -521,6 +522,14 @@ class VariablesTests(ISTPTestsBase):
              'SCALEMAX type CDF_INT2 does not match variable type CDF_BYTE.',
              'SCALEMIN (200) outside valid data range (-128,127).',
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
+             ],
+             errs)
+        tt2000.attrs['SCALEMIN'] = 200.42e45 #tt2000 testing
+        errs = spacepy.pycdf.istp.VariableChecks.validscale(tt2000)
+        errs.sort()
+        self.assertEqual(
+            ['SCALEMIN type CDF_DOUBLE does not match variable type CDF_TIME_TT2000.',
+             'SCALEMIN type CDF_DOUBLE not comparable to variable type CDF_TIME_TT2000.',
              ],
              errs)
         

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -524,7 +524,7 @@ class VariablesTests(ISTPTestsBase):
              'SCALEMIN type CDF_INT2 does not match variable type CDF_BYTE.'
              ],
              errs)
-        tt2000.attrs['SCALEMIN'] = 200.42e45 #tt2000 testing
+        tt2000.attrs.new('SCALEMIN', 200.01, type=spacepy.pycdf.const.CDF_DOUBLE)
         errs = spacepy.pycdf.istp.VariableChecks.validscale(tt2000)
         errs.sort()
         self.assertEqual(


### PR DESCRIPTION
Made an explicit check, and an assertion for the validchecks on istp. Check that the system produces an error when a non-timetype is compared against a timetype.

Closes #752 

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] (N/A)Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

