### PR TITLE
Handling for incorrect CDF fillval on epoch16 variables

### DIFF
--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -378,14 +378,17 @@ class VariableChecks(object):
             else numpy.all(actual == expected)
         if not match:
             if timetype:
-                converted_expected = {
-                    spacepy.pycdf.const.CDF_EPOCH.value:
-                    spacepy.pycdf.lib.v_epoch_to_datetime,
-                    spacepy.pycdf.const.CDF_EPOCH16.value:
-                    spacepy.pycdf.lib.v_epoch16_to_datetime,
-                    spacepy.pycdf.const.CDF_TIME_TT2000.value:
-                    spacepy.pycdf.lib.v_tt2000_to_datetime
-                }[v.type()](expected)
+                if v.type() == spacepy.pycdf.const.CDF_EPOCH16.value:
+                    converted_expected = spacepy.pycdf.lib.v_epoch16_to_datetime(
+                        numpy.asanyarray(expected))
+                    actual = tuple(actual)
+                else:
+                    converted_expected = {
+                        spacepy.pycdf.const.CDF_EPOCH.value:
+                        spacepy.pycdf.lib.v_epoch_to_datetime,
+                        spacepy.pycdf.const.CDF_TIME_TT2000.value:
+                        spacepy.pycdf.lib.v_tt2000_to_datetime
+                    }[v.type()](expected)
                 errs.append(
                     'FILLVAL {} ({}), should be {} ({}) for variable type {}.'
                     .format(

--- a/spacepy/pycdf/istp.py
+++ b/spacepy/pycdf/istp.py
@@ -381,7 +381,6 @@ class VariableChecks(object):
                 if v.type() == spacepy.pycdf.const.CDF_EPOCH16.value:
                     converted_expected = spacepy.pycdf.lib.v_epoch16_to_datetime(
                         numpy.asanyarray(expected))
-                    actual = tuple(actual)
                 else:
                     converted_expected = {
                         spacepy.pycdf.const.CDF_EPOCH.value:

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -632,6 +632,17 @@ class VariablesTestsNew(ISTPTestsBase):
             type=spacepy.pycdf.const.CDF_EPOCH16)
         errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
         self.assertEqual(0, len(errs), '\n'.join(errs))
+    
+    def testFillvalEpoch16NoDefaultFill(self):
+        """Test for fillval throwing error for incorrect default fill"""
+        v = self.cdf.new('Epoch', type=spacepy.pycdf.const.CDF_EPOCH16)
+        v.attrs.new(
+            'FILLVAL', (0.1, 2.0),
+            type=spacepy.pycdf.const.CDF_EPOCH16)
+        errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
+        self.assertEqual(
+            'FILLVAL (0.1, 2.0) (9999-12-13 23:59:59.999999), should be (-1e+31, -1e+31) (9999-12-31 23:59:59.999999) for variable type CDF_EPOCH16.', errs[0])
+        self.assertEqual(1, len(errs), '\n'.join(errs))
 
     def testFillvalTT2000(self):
         """Test for fillval being okay with TT2000"""

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -637,11 +637,13 @@ class VariablesTestsNew(ISTPTestsBase):
         """Test for fillval throwing error for incorrect default fill"""
         v = self.cdf.new('Epoch', type=spacepy.pycdf.const.CDF_EPOCH16)
         v.attrs.new(
-            'FILLVAL', (0.1, 2.0),
+            'FILLVAL', (1.0, 2.0),
             type=spacepy.pycdf.const.CDF_EPOCH16)
         errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
         self.assertEqual(
-            'FILLVAL (0.1, 2.0) (9999-12-13 23:59:59.999999), should be (-1e+31, -1e+31) (9999-12-31 23:59:59.999999) for variable type CDF_EPOCH16.', errs[0])
+            'FILLVAL [1. 2.] (9999-12-13 23:59:59.999999),'  
+            ' should be (-1e+31, -1e+31) (9999-12-31 23:59:59.999999)' 
+            ' for variable type CDF_EPOCH16.', errs[0])
         self.assertEqual(1, len(errs), '\n'.join(errs))
 
     def testFillvalTT2000(self):


### PR DESCRIPTION
Added an explicit check for the incorrect fillval being used on an epoch16 type variable, as well as the accompanying unit tests.

Closes #399 

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] New features and bug fixes should have unit tests
- [x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

