### PR TITLE
Continuous integration fix for users with scipy>=1.14.0

### DIFF
--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -672,7 +672,7 @@ def omniFromDirectionalFlux(fluxarr, alphas, norm=True):
        fac = 2*np.pi
        denomina = 1
     alphrad = np.deg2rad(alphas)
-    numera = integ.simpson(fluxarr*np.sin(alphrad), alphrad)
+    numera = integ.simpson(y=fluxarr*np.sin(alphrad), x=alphrad)
     omniflux = fac*numera/denomina
     return omniflux
 

--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -17,6 +17,8 @@ import warnings
 from functools import partial
 import numpy as np
 import scipy.integrate as integ
+if not hasattr(integ, "simpson"):  # scipy<1.7.0
+    integ.simpson = integ.simps 
 
 from spacepy import help
 import spacepy.datamodel as dm
@@ -670,7 +672,7 @@ def omniFromDirectionalFlux(fluxarr, alphas, norm=True):
        fac = 2*np.pi
        denomina = 1
     alphrad = np.deg2rad(alphas)
-    numera = integ.simps(fluxarr*np.sin(alphrad), alphrad)
+    numera = integ.simpson(fluxarr*np.sin(alphrad), alphrad)
     omniflux = fac*numera/denomina
     return omniflux
 


### PR DESCRIPTION
Scipy 1.14 updated the integration.simps() function to integration.simpson(), this is a fix to maintain continuous integration with users who have scipy<1.14

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [x] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [x] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [x] (N/A) New features and bug fixes should have unit tests
- [x] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
