### PR TITLE
ci: fix typo in cython version for python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
             dep-strategy: "newest"
           - python-version: "3.9"
             os: ubuntu-22.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0<3.0"
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
             numpy-version: "~=1.18.0"
             piplist: "python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.24.0"
             cflags: "-Wno-error=format-security"


### PR DESCRIPTION
This fixes a bizarre typo in the CI definition, where for Python 3.9 it was requiring "cython<3.0<3.0". I'm wondering if this is part of why 3.9 is one of the things that always takes forever in the CI. Introduced in #684, 1abb533c87d319dbfbf3aedcc54cf9d5a9f06431

I have no idea why this worked _at all_.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
