### PR TITLE
Improve toolbox test coverage

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -22,6 +22,11 @@ Dependency requirements
 Sphinx 4.0 is now required to build the documentation; this is not
 a concern for most users.
 
+Deprecations and removals
+*************************
+`~spacepy.toolbox.timeout_check_call` is deprecated as redundant to using
+`subprocess.check_call` with the ``timeout`` argument.
+
 0.6 Series
 ==========
 0.6.0 (2024-04-25)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -518,7 +518,10 @@ def assemble(fln_pattern, outfln, sortkey='ticks', verbose=True):
             idx = np.argsort(dcomb[sortkey])
         TAIcount = len(dcomb[sortkey])
         for key in dcomb: # iterates over keys by default
-            dim = np.array(np.shape(dcomb[key]))
+            if isinstance(dcomb[key], spt.Ticktock):
+                dim = np.array(dcomb[key].data.shape)
+            else:
+                dim = np.array(np.shape(dcomb[key]))
             ax = np.where(dim==TAIcount)[0]
             if len(ax) == 1: # then match with length of TAI
                 dcomb[key] = dcomb[key][idx] # resort

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -2492,10 +2492,7 @@ def bin_edges_to_center(edges):
     [0.5, 1.5, 2.5, 3.5]
     """
     df = np.diff(edges)
-    if isinstance(df[0], datetime.timedelta) and sys.version_info[0:2]<=(3,2):
-        return edges[:-1] + df//2
-    else:
-        return edges[:-1] + df/2
+    return edges[:-1] + df/2
 
 def thread_job(job_size, thread_count, target, *args, **kwargs):
     """

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -2859,6 +2859,10 @@ def timeout_check_call(timeout, *args, **kwargs):
     """
     Call a subprocess with a timeout.
 
+    .. deprecated:: 0.7.0
+        Use ``timeout`` argument of :func:`subprocess.check_call`, added
+        in Python 3.3.
+
     Like :func:`subprocess.check_call`, but will terminate the process and
     raise :exc:`TimeoutError` if it runs for too long.
 
@@ -2892,6 +2896,9 @@ def timeout_check_call(timeout, *args, **kwargs):
     out : int
         0 on successful completion
     """
+    warnings.warn("timeout_check_call was deprecated in 0.7.0"
+                  " and will be removed.",
+                  DeprecationWarning)
     resolution = 0.1
     pro = subprocess.Popen(*args, **kwargs)
     starttime = time.time()

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -2179,10 +2179,7 @@ def query_yes_no(question, default="yes"):
         raise ValueError("invalid default answer: {}".format(default))
     while 1:
         sys.stdout.write(question + prompt)
-        if sys.version_info[0]==2:
-            choice = raw_input().lower()
-        elif sys.version_info[0]>2:
-            choice = input().lower()
+        choice = input().lower()
         if default is not None and choice == '':
             return default
         elif choice in valid:

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -498,8 +498,10 @@ def assemble(fln_pattern, outfln, sortkey='ticks', verbose=True):
         else:
             TAIcount = len(d[fln][ list(d[fln].keys())[0] ])
         for key in d[fln]:
-            #print fln, key
-            dim = np.array(np.shape(d[fln][key]))
+            if isinstance(dcomb[key], spt.Ticktock):
+                dim = np.array(d[fln][key].data.shape)
+            else:
+                dim = np.array(np.shape(d[fln][key]))
             ax = np.where(dim==TAIcount)[0]
             if len(ax) == 1: # then match with TAI length is given (jump over otherwise like for 'parameters')
                 if isinstance(dcomb[key], spt.Ticktock):

--- a/tests/integration_toolbox.py
+++ b/tests/integration_toolbox.py
@@ -187,5 +187,21 @@ class WebGettingIntegration(unittest.TestCase):
         self.assertEqual('Cannot specify connection without keepalive',
                          str(cm.exception))
 
+    def testGetUrlReport(self):
+        """Call get_url, use report hook"""
+        hook_record = []
+        def hook(count, bs, size):
+            hook_record.append((count, bs, size))
+        with open(os.path.join(self.td, 'foo.txt'), 'wb') as f:
+            f.write(b'1' * 1536)
+        data = spacepy.toolbox.get_url(
+            'http://localhost:{}/foo.txt'.format(self.port), reporthook=hook)
+        self.assertEqual(
+            b"1" * 1536, data)
+        self.assertEqual(
+            [(1, 1024, 1536), (2, 1024, 1536)],
+            hook_record)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -1247,6 +1247,23 @@ class TBTimeFunctionTests(unittest.TestCase):
         anst = [ 1.,  3.,  5.,  7.]
         numpy.testing.assert_almost_equal(anst, out[1])
 
+    def test_windowMeanNotDatetime(self):
+        """windowMean should give known results, with non-datetime time"""
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', r'windowmean\:', UserWarning, 'spacepy.toolbox$')
+            # same setup as windowMean3, but 'time' is in fractional days
+            wsize = 1.
+            olap = .5
+            data = [10, 20] * 50
+            time = [(n + .5) / 24 for n in range(100)]
+            time[50:] = [val + 2 for val in time[50:]]
+            outdata, outtime = tb.windowMean(data, time, winsize=wsize, overlap=olap, st_time=0.)
+            od_ans = [ 15.,  15.,  15.,  15.,  15.,  numpy.nan,  numpy.nan,  15.,  15.,  15.,  15., 15., 15.]
+            ot_ans = [.5 * n for n in range(1, 14)]
+            numpy.testing.assert_almost_equal(od_ans, outdata)
+            self.assertEqual(ot_ans, outtime)
+
     def test_link_extracter(self):
         """Get links from sample html"""
         indata = """

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -860,13 +860,19 @@ class SimpleFunctionTests(unittest.TestCase):
         self.assertRaises(IndexError, tb.do_with_timeout,
                           0.5, testfunc, 5)
 
+    #This test definitely doesn't work on Windows, and the function
+    #itself probably doesn't, either
+    @unittest.skipIf(sys.platform == 'win32', 'Not supported on Windows.')
     def test_timeout_check_call(self):
         """Make sure check_call replacement handles timeout"""
-        #This test definitely doesn't work on Windows, and the function
-        #itself probably doesn't, either
-        if sys.platform != 'win32':
+        with spacepy_testing.assertWarns(
+                self, message='timeout_check_call was deprecated',
+                category=DeprecationWarning):
             self.assertEqual(0, tb.timeout_check_call(10.0, 'sleep 2',
                                                       shell=True))
+        with spacepy_testing.assertWarns(
+                self, message='timeout_check_call was deprecated',
+                category=DeprecationWarning):
             self.assertRaises(tb.TimeoutError, tb.timeout_check_call,
                               1.0, 'sleep 5', shell=True)
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -604,10 +604,13 @@ class SimpleFunctionTests(unittest.TestCase):
                   [lambda x: x / 2, 4, 0, 100],
                   [lambda x: numpy.exp(-(x ** 2) / (2 * 5 ** 2)) / \
                           (5 * numpy.sqrt(2 * numpy.pi)), 0.6, -inf, inf],
+                  [lambda x: numpy.exp(-(x ** 2) / (2 * 5 ** 2)) / \
+                          (5 * numpy.sqrt(2 * numpy.pi)), 0.6],
                   ]
         outputs = [3.0 ** (1.0 / 3),
                    4,
-                   1.266735515678999
+                   1.266735515678999,
+                   1.266735515678999,
                    ]
         for (input, output) in zip(inputs, outputs):
             self.assertAlmostEqual(output,

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -32,7 +32,7 @@ import spacepy.time
 import spacepy.toolbox as tb
 
 __all__ = ['PickleAssembleTests', 'SimpleFunctionTests', 'TBTimeFunctionTests',
-           'ArrayBinTests']
+           'ArrayBinTests', 'TBPlotTests']
 
 @contextmanager
 def mockRawInput(mock):
@@ -1307,6 +1307,23 @@ class ArrayBinTests(unittest.TestCase):
             self.assertEqual(output,
                              tb.arraybin(*input))
 
+class TBPlotTests(spacepy_testing.TestPlot):
+    """Toolbox tests that make plots"""
+
+    def testBootHistoPlot(self):
+        """Bootstrap histogram makes a plot"""
+        numpy.random.seed(28420)
+        data = numpy.random.randn(1000)
+        bin_edges, ci_low, ci_high, sample, bars = spacepy.toolbox.bootHisto(
+            data, n=1000, seed=28420, plot=True)
+        # Return values checked in testBootHisto, checking plot only.
+        self.assertEqual(10, len(bars))  # len(bin_edges) - 1
+        self.assertEqual(7, bars[0].get_height())  # sample[0]
+        self.assertAlmostEqual(0.766784192,  # bin_edges[1] - bin_edges[0]
+                               bars[0].get_width())
+        self.assertAlmostEqual(-3.173718043,  # bin_edges[0]
+                               bars[0].get_x())
+        self.assertEqual(10, len(bars.errorbar[2][0].get_segments()))
 
 
 if __name__ == "__main__":

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -545,6 +545,16 @@ class SimpleFunctionTests(unittest.TestCase):
             for i, val in enumerate(real_ans):
                 self.assertEqual(val, tb.pmm(data[i]))
 
+    def test_pmm_list_str(self):
+        """Test pmm with list of str input"""
+        data = ['foo', 'bar', 'qux']
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore', 'pmm: Unable to exclude non-finite',
+                RuntimeWarning, 'spacepy.toolbox$')
+            ans = tb.pmm(data)
+        self.assertEqual([['bar', 'qux']], ans)
+
     def test_rad2mlt(self):
         """rad2mlt should give known answers (regression)"""
         real_ans = array([ -6.        ,  -4.10526316,  -2.21052632,  -0.31578947,

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -1247,6 +1247,31 @@ class TBTimeFunctionTests(unittest.TestCase):
         anst = [ 1.,  3.,  5.,  7.]
         numpy.testing.assert_almost_equal(anst, out[1])
 
+    def test_link_extracter(self):
+        """Get links from sample html"""
+        indata = """
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>SpacePy 0.6.0 documentation &#8212; SpacePy v0.6.0 Manual</title>
+  </head><body>
+  <section id="spacepy-version-documentation">
+<h1>SpacePy 0.6.0 documentation<a class="headerlink" href="#spacepy-version-documentation" title="Permalink to this heading"></a></h1>
+<dl class="simple">
+<dt>To cite the code itself:</dt><dd><p>&#64;software{spacepy_code,
+doi          = {10.5281/zenodo.3252523},
+url          = {<a class="reference external" href="https://doi.org/10.5281/zenodo.3252523">https://doi.org/10.5281/zenodo.3252523</a>}
+}</p></dd></dl>
+</section></body></html>
+        """
+        p = tb.LinkExtracter()
+        p.feed(indata)
+        p.close()
+        self.assertEqual(
+            ['#spacepy-version-documentation', 'https://doi.org/10.5281/zenodo'
+             '.3252523'], p.links)
+
 
 class ArrayBinTests(unittest.TestCase):
     """Tests for arraybin function"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -617,6 +617,14 @@ class SimpleFunctionTests(unittest.TestCase):
                                    tb.intsolve(*input),
                                    places=6)
 
+    def testIntSolveWarning(self):
+        """intsolve warns when it doesn't converge"""
+        with spacepy_testing.assertWarns(
+                self, message='Difference between desired value and actual',
+                category=UserWarning):
+            ans = tb.intsolve(lambda x: x**2, 1, 0, 5, maxit=10)
+        self.assertAlmostEqual(3.0 ** (1.0 / 3), ans, places=2)
+
     def testDistToList(self):
         """Convert probability distribution to list of values"""
         inputs = [[lambda x: x, 10, 0, 10],

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -277,22 +277,49 @@ class SimpleFunctionTests(unittest.TestCase):
         )
 
     def test_query_yes_no(self):
-        '''query_yes_no should return known strings for known input'''
+        """query_yes_no should return known strings for known input"""
         realstdout = sys.stdout
         output = io.StringIO()
         sys.stdout = output
-        with mockRawInput('y'):
-            self.assertEqual(tb.query_yes_no('yes?'), 'yes')
-        with mockRawInput('n'):
-            self.assertEqual(tb.query_yes_no('no?'), 'no')
-        with mockRawInput(''):
-            self.assertEqual(tb.query_yes_no('no?', default='no'), 'no')
-        output.close()
-        sys.stdout = realstdout
+        try:
+            with mockRawInput('y'):
+                self.assertEqual(tb.query_yes_no('yes?'), 'yes')
+            with mockRawInput('n'):
+                self.assertEqual(tb.query_yes_no('no?'), 'no')
+            with mockRawInput(''):
+                self.assertEqual(tb.query_yes_no('no?', default='no'), 'no')
+        finally:
+            result = output.getvalue()
+            output.close()
+            sys.stdout = realstdout
+        self.assertEqual(
+            "yes? [Y/n] no? [Y/n] no? [y/N] ",
+            result)
 
     def test_query_yes_no_badDefault(self):
-        '''query_yes_no should return error for bad args'''
+        """query_yes_no should return error for bad args"""
         self.assertRaises(ValueError, tb.query_yes_no, '', default='bad')
+
+    def test_query_yes_no_bad_choice(self):
+        """query_yes_no with an invalid choice"""
+        realstdout = sys.stdout
+        output = io.StringIO()
+        realstdin = sys.stdin
+        input_ = io.StringIO("z\ny\n")
+        sys.stdout = output
+        sys.stdin = input_
+        try:
+            self.assertEqual(tb.query_yes_no('no?', default='no'), 'yes')
+        finally:
+            result = output.getvalue()
+            output.close()
+            input_.close()
+            sys.stdout = realstdout
+            sys.stdin = realstdin
+        self.assertEqual(
+            "no? [y/N] Please respond with 'yes' or 'no' (or 'y' or 'n').\n"
+            "no? [y/N] ",
+            result)
 
     def test_mlt2rad(self):
         """mlt2rad should have known output for known input"""

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -156,6 +156,30 @@ class PickleAssembleTests(unittest.TestCase):
             result[key] = result[key].tolist()
         self.assertEqual(expected, result)
 
+    def test_assemble_sorted_time(self):
+        """Test assemble with a ticktock as sort key"""
+        D1 = {
+            'time': spacepy.time.Ticktock(['2020-01-03', '2020-01-02'],
+                                          dtype='ISO'),
+            'val': numpy.array([1, 2]),
+        }
+        D2 = {
+            'time': spacepy.time.Ticktock(['2020-01-04', '2020-01-01'],
+                                          dtype='ISO'),
+            'val': numpy.array([3, 4]),
+        }
+        tb.savepickle(os.path.join(self.tempdir, 'test_pickle_1.pkl'), D1)
+        tb.savepickle(os.path.join(self.tempdir, 'test_pickle_2.pkl'), D2)
+        result = tb.assemble(
+            os.path.join(self.tempdir, 'test_pickle_[1-2].pkl'),
+            os.path.join(self.tempdir, 'test_all.pkl'),
+            sortkey='time', verbose=False)
+        numpy.testing.assert_array_equal(
+            result['val'], [4, 2, 1, 3])
+        numpy.testing.assert_array_equal(
+            result['time'].ISO,
+            [f'2020-01-0{d}T00:00:00' for d in range(1, 5)])
+
 
 class SimpleFunctionTests(unittest.TestCase):
 


### PR DESCRIPTION
This PR does pretty much everything I can reasonably think of to increase the coverage of toolbox. With this, the combined coverage of unit + integration test is 75%, so I'm going to say closes #313.

In addition to just testing (and removing some Python 2-isms), this PR:

- Fixes assemble with Ticktock data
- Fixes windowMean if times are given as numerical rather than datetimes. This needed two fixes: one is not forcing the window and overlap to be timedelta, the other was removing floor division (which was required for timedeltas in 3.2 and earlier)
- Deprecates timeout_check_call, as check_call has supported timeouts since 3.3.


## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
