### PR TITLE
Minor test cleanup

### DIFF
--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -202,8 +202,9 @@ class TestPlot(unittest.TestCase):
         super().tearDown()
         import matplotlib
         import matplotlib.pyplot
-        if self.save_plots and matplotlib.pyplot.get_fignums():
-            fname = 'output_{}.png'.format('_'.join(self.id().split('.')[1:]))
-            matplotlib.pyplot.savefig(fname)
+        if matplotlib.pyplot.get_fignums():
+            if self.save_plots:
+                fname = 'output_{}.png'.format('_'.join(self.id().split('.')[1:]))
+                matplotlib.pyplot.savefig(fname)
             matplotlib.pyplot.close()
         matplotlib.use(self.old_backend)

--- a/tests/test_pycdf_istp.py
+++ b/tests/test_pycdf_istp.py
@@ -649,10 +649,11 @@ class VariablesTestsNew(ISTPTestsBase):
             'FILLVAL', (1.0, 2.0),
             type=spacepy.pycdf.const.CDF_EPOCH16)
         errs = spacepy.pycdf.istp.VariableChecks.fillval(v)
-        self.assertEqual(
-            'FILLVAL [1. 2.] (9999-12-13 23:59:59.999999),'  
-            ' should be (-1e+31, -1e+31) (9999-12-31 23:59:59.999999)' 
-            ' for variable type CDF_EPOCH16.', errs[0])
+        self.assertRegex(
+            errs[0],
+            'FILLVAL \\[\\s?1.\\s+2.\\] \\(9999-12-13 23:59:59.999999\\),'
+            ' should be \\(-1e\\+31, -1e\\+31\\)'
+            ' \\(9999-12-31 23:59:59.999999\\) for variable type CDF_EPOCH16.')
         self.assertEqual(1, len(errs), '\n'.join(errs))
 
     def testFillvalTT2000(self):


### PR DESCRIPTION
This PR makes two quick changes to the tests:

- The test for #757 was failing on Python 3.6, x86 Mac, numpy 1.12, with different spacing and signs. So this PR loosens the test a bit by making it a regex.
- Any plotting tests that did not save the plot weren't closing the plot object, which eventually issued a warning. This was fixed.

No functional changes.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
