### PR TITLE
Fix numpy 2.0 deprecations

### DIFF
--- a/Doc/source/configuration.rst
+++ b/Doc/source/configuration.rst
@@ -58,14 +58,6 @@ data, which can be updated with :func:`~spacepy.toolbox.update`.
 
 Available configuration options
 ===============================
-enable_deprecation_warning
-  SpacePy raises :py:exc:`~exceptions.DeprecationWarning` when deprecated functions
-  are called. Starting in Python 2.7, these are ignored. SpacePy adds a warnings
-  filter to force display of deprecation warnings from SpacePy the first time a
-  deprecated function is called. Set this option to False to retain the default
-  Python behavior. (See :py:mod:`warnings` module for details on custom warning
-  filters.)
-
 enable_old_data_warning
   SpacePy maintains certain databases from external sources, notably the
   leapsecond database used by :py:mod:`~spacepy.time`. By default

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -39,6 +39,12 @@ The ``spacepy.irbempy.irbempylib`` module has been removed. This was
 the old internal interface to the IRBEM library and was not intended
 for public use.
 
+Other changes
+*************
+Operations on `~spacepy.datamodel.dmarray` which return a scalar value
+will now return a numpy :std:term:`array scalar` rather than the base
+Python type. This is consistent with the behavior of `~numpy.ndarray`.
+
 0.6 Series
 ==========
 0.6.0 (2024-04-25)

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -48,6 +48,9 @@ Operations on `~spacepy.datamodel.dmarray` which return a scalar value
 will now return a numpy :std:term:`array scalar` rather than the base
 Python type. This is consistent with the behavior of `~numpy.ndarray`.
 
+Warnings issued by SpacePy are now associated with the line of the
+calling code, not with the SpacePy code itself.
+
 0.6 Series
 ==========
 0.6.0 (2024-04-25)

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -49,7 +49,14 @@ will now return a numpy :std:term:`array scalar` rather than the base
 Python type. This is consistent with the behavior of `~numpy.ndarray`.
 
 Warnings issued by SpacePy are now associated with the line of the
-calling code, not with the SpacePy code itself.
+calling code, not with the SpacePy code itself. The
+``enable_deprecation_warning`` :doc:`configuration option <configuration>`
+has been removed and SpacePy does not force display of deprecation
+warnings, as warnings issued by SpacePy cannot be distinguished from
+other warnings. It is recommended to occasionally run Python code with
+the :option:`-Wd <-W>` option to enable deprecation warnings. See
+:py:mod:`warnings` for more details.
+
 
 0.6 Series
 ==========

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -22,6 +22,9 @@ New features
 
 Dependency requirements
 ***********************
+Numpy 2.0 is now fully supported. Several deprecations and errors
+using 2.0 were fixed.
+
 Numpy and f2py are no longer required to build SpacePy. This change
 will not be noticable to most users. Binary wheels are no longer tied
 to numpy or Python version. SpacePy will now build on numpy 1.26 and

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -47,6 +47,11 @@ Other changes
 Operations on `~spacepy.datamodel.dmarray` which return a scalar value
 will now return a numpy :std:term:`array scalar` rather than the base
 Python type. This is consistent with the behavior of `~numpy.ndarray`.
+`~spacepy.datamodel.dmarray` also supports assigning to its ``dtype``
+and ``shape``. Together these changes should make ``dmarray`` a much
+closer drop-in replacement for `~numpy.ndarray`; in particular, these
+address known issues with conversion to masked arrays and passing to
+`~matplotlib.pyplot.pcolormesh`.
 
 Warnings issued by SpacePy are now associated with the line of the
 calling code, not with the SpacePy code itself. The

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -348,8 +348,7 @@ def _write_defaults(rcfile, defaults, section='spacepy'):
 def _read_config(rcfile):
     """Read configuration information from a file"""
     global config
-    defaults = {'enable_deprecation_warning': str(True),
-                'keepalive': str(True),
+    defaults = {'keepalive': str(True),
                 'ncpus': str(multiprocessing.cpu_count()),
                 'qindenton_url': 'http://virbo.org/ftp/QinDenton/hour/merged/latest/WGhour-latest.d.zip',
                 'qd_daily_url': 'https://rbsp-ect.newmexicoconsortium.org/data_pub/QinDenton/',
@@ -361,8 +360,7 @@ def _read_config(rcfile):
                 }
     #Functions to cast a config value; if not specified, value is a string
     str2bool = lambda x: x.lower() in ('1', 'yes', 'true', 'on')
-    caster = {'enable_deprecation_warning': str2bool,
-              'keepalive': str2bool,
+    caster = {'keepalive': str2bool,
               'ncpus': int,
               'support_notice': str2bool,
               'enable_old_data_warning': str2bool,
@@ -460,7 +458,3 @@ _read_config(rcfile)
 if __version__ == 'UNRELEASED' and config['support_notice']:
     print('This unreleased version of SpacePy is not supported '
           'by the SpacePy team.')
-# Set up a filter to always warn on deprecation
-if config['enable_deprecation_warning']:
-    warnings.filterwarnings('default', '', DeprecationWarning,
-                            '^spacepy', 0, False)

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -115,7 +115,7 @@ def _deprecator(version, message, docstring, func):
     #this is the actual, deprecated function
     @functools.wraps(func)
     def _deprecated(*args, **kwargs):
-        warnings.warn(message, DeprecationWarning)
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
         return func(*args, **kwargs)
     if func.__doc__ is None:
         doclines = []

--- a/spacepy/ae9ap9.py
+++ b/spacepy/ae9ap9.py
@@ -540,7 +540,7 @@ def _parseInfo(header):
             if match:  # But old has propagator on this line; process and warn
                 warnings.warn(
                     "Support for orbit files from AE9AP9 model <1.5 is deprecated; please update to model 1.5 or later.",
-                    DeprecationWarning)
+                    DeprecationWarning, stacklevel=2)
                 ans['propagator'] = match.group(1).strip()
     return ans
 

--- a/spacepy/ctrans/__init__.py
+++ b/spacepy/ctrans/__init__.py
@@ -470,7 +470,8 @@ class CTrans(dm.SpaceData):
         if not pnmodel == 'IAU82':
             import warnings
             warnings.warn('Only the IAU1980 nutation model is currently implemented. '
-                          + 'This will be used with the selected precession model.')
+                          + 'This will be used with the selected precession model.',
+                          stacklevel=2)
         else:
             from . import iau80n
             dPsi, dEps = iau80n.nutation(self['TT_JC'], self['constants'], nTerms)
@@ -935,7 +936,8 @@ class CTrans(dm.SpaceData):
             error = np.abs(ecc_anom - ecc_anom_old)
         if count >= maxiter:
             import warnings
-            warnings.warn('Estimation of eccentric anomaly failed to converge')
+            warnings.warn('Estimation of eccentric anomaly failed to converge',
+                          stacklevel=2)
         return ecc_anom
 
 

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -953,12 +953,17 @@ class dmarray(numpy.ndarray, MetaMixin, ISTPArray):
         for val in self.Allowed_Attributes:
             self.__setattr__(val, copy.deepcopy(getattr(obj, val, {})))
 
-    def __array_wrap__(self, out_arr, context=None):
+    def __array_wrap__(self, out_arr, context=None, return_scalar=None):
         #check for zero-dims (numpy bug means subclass behaviour isn't consistent with ndarray
         #this traps most of the bad behaviour ( std() and var() still problems)
-        if out_arr.ndim > 0:
-            return numpy.ndarray.__array_wrap__(self, out_arr, context)
-        return numpy.ndarray.__array_wrap__(self, out_arr, context)[()]
+        if return_scalar:
+            return super().__array_wrap__(out_arr, context, True)[()]
+        if return_scalar is False:
+            return super().__array_wrap__(out_arr, context, False)
+        # Pre numpy 2.0, so guess if scalar
+        if out_arr.ndim:
+            return super().__array_wrap__(out_arr, context)
+        return super().__array_wrap__(out_arr, context)[()]
 
     def __reduce__(self):
         """This is called when pickling, see:

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -895,7 +895,8 @@ class dmarray(numpy.ndarray, MetaMixin, ISTPArray):
     .. versionchanged:: 0.7.0
        Operations on a ``dmarray`` which return a scalar value return a numpy
        :std:term:`array scalar`. Previously they would return the base
-       Python type.
+       Python type. Assignment to ``dtype`` and ``shape`` are also now
+       supported; previously this raised :exc:`TypeError`.
 
     Raises
     ------
@@ -994,8 +995,8 @@ class dmarray(numpy.ndarray, MetaMixin, ISTPArray):
         dmarray_assert took 16.025478 s
         It looks like != is the fastest, but not by much over 10000000 __setattr__
         """
-        #meta is special-handled because it should NOT be pickled
-        if name in ('Allowed_Attributes', 'meta'):
+        # Several attrs special-cased because should NOT be pickled
+        if name in ('Allowed_Attributes', 'dtype', 'meta', 'shape'):
             pass
         elif not name in self.Allowed_Attributes:
             raise TypeError("Only attribute listed in Allowed_Attributes can be set")

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -1687,14 +1687,15 @@ def fromHDF5(fname, **kwargs):
                 try:
                     value = hfile[path].attrs[key]
                 except TypeError:
-                    warnings.warn('Unsupported datatype in dataset {}.attrs[{}]'.format(path, key))
+                    warnings.warn('Unsupported datatype in dataset {}.attrs[{}]'.format(path, key), stacklevel=2)
                     continue
                 try:
                     SDobject.attrs[key] = value
                 except:
                     warnings.warn('The following key:value pair is not permitted\n' +
                                   'key = {0} ({1})\n'.format(key, type(key)) +
-                                  'value = {0} ({1})'.format(value, type(value)), DMWarning)
+                                  'value = {0} ({1})'.format(value, type(value)),
+                                  DMWarning, stacklevel=2)
 
     try:
         import h5py
@@ -1805,7 +1806,7 @@ def toHDF5(fname, SDobject, **kwargs):
                                 'key, value, type = {0}, {1}, {2})\n'.format(
                                     key, value, type(value)) +
                                 'value has been converted to a string for output',
-                                DMWarning)
+                                DMWarning, stacklevel=2)
                     else:
                         hfile[path].attrs[dumkey] = ''
                 elif isinstance(value, datetime.datetime):
@@ -1816,7 +1817,7 @@ def toHDF5(fname, SDobject, **kwargs):
                     warnings.warn('The following key:value pair is not permitted\n' +
                                   'key = {0} ({1})\n'.format(key, type(key)) +
                                   'value type {0} is not in the allowed attribute list'.format(type(value)),
-                                  DMWarning)
+                                  DMWarning, stacklevel=2)
 
     try:
         import h5py
@@ -1896,7 +1897,7 @@ def toHDF5(fname, SDobject, **kwargs):
                 warnings.warn('The following data is not being written as is not of an allowed type\n' +
                               'key = {0} ({1})\n'.format(key, type(key)) +
                               'value type {} is not in the allowed data type list'.format(
-                                  type(value)), DMWarning)
+                                  type(value)), DMWarning, stacklevel=2)
     finally:
         if must_close:
             hfile.close()
@@ -2211,7 +2212,8 @@ def readJSONheadedASCII(fname, mdata=None, comment='#', convert=False, restrict=
             try:
                 name = keys.pop(keys.index(conkey)) #remove from keylist
             except ValueError:
-                warnings.warn('Key {} for conversion not found in file'.format(conkey), UserWarning)
+                warnings.warn('Key {} for conversion not found in file'.format(conkey),
+                              UserWarning, stacklevel=2)
                 continue
             for i, element in numpy.ndenumerate(mdata[name]):
                 mdata[name][i] = conversions[name](element)
@@ -2324,7 +2326,7 @@ def writeJSONMetadata(fname, insd, depend0=None, order=None, verbose=False, retu
                          ' as it has too high a rank\n'
                     l2 = 'key = {0} ({1})\n'.format(key, insd[key].shape)
                     l3 = 'Maximum allowed number of dimensions is 2\n'
-                    warnings.warn(''.join([l1, l2, l3]), DMWarning)
+                    warnings.warn(''.join([l1, l2, l3]), DMWarning, stacklevel=2)
             except AttributeError: #AttrErr if just metadata
                 #js_out[key]['DIMENSION'] = insd[key].attrs['DIMENSION']
                 pass

--- a/spacepy/datamodel.py
+++ b/spacepy/datamodel.py
@@ -892,6 +892,11 @@ class dmarray(numpy.ndarray, MetaMixin, ISTPArray):
     Although the format of attributes is not enforced, using ISTP metadata
     enables the use of methods from `ISTPArray`.
 
+    .. versionchanged:: 0.7.0
+       Operations on a ``dmarray`` which return a scalar value return a numpy
+       :std:term:`array scalar`. Previously they would return the base
+       Python type.
+
     Raises
     ------
     NameError
@@ -953,7 +958,7 @@ class dmarray(numpy.ndarray, MetaMixin, ISTPArray):
         #this traps most of the bad behaviour ( std() and var() still problems)
         if out_arr.ndim > 0:
             return numpy.ndarray.__array_wrap__(self, out_arr, context)
-        return numpy.ndarray.__array_wrap__(self, out_arr, context).tolist()
+        return numpy.ndarray.__array_wrap__(self, out_arr, context)[()]
 
     def __reduce__(self):
         """This is called when pickling, see:

--- a/spacepy/empiricals.py
+++ b/spacepy/empiricals.py
@@ -129,7 +129,8 @@ def getPlasmaPause(ticks, model='M2002', LT='all', omnivals=None):
 
     if model == 'CA1992':
         if LT != 'all':
-            warnings.warn('No LT dependence currently supported for CA1992 model', RuntimeWarning)
+            warnings.warn('No LT dependence currently supported for CA1992 model',
+                          RuntimeWarning, stacklevel=2)
     if model not in model_list:
         raise ValueError("Please specify a valid model:\n{0}".format(' or '.join(model_list)))
 

--- a/spacepy/igrf.py
+++ b/spacepy/igrf.py
@@ -164,7 +164,7 @@ class IGRF():
         if time < igrfcoeffs.datelow or time > igrfcoeffs.datehigh:
             if limits.lower() == 'warn':
                 errmsg += '\nProceeding using effective date {0}'.format(igrfcoeffs.datehigh)
-                warnings.warn(errmsg)
+                warnings.warn(errmsg, stacklevel=2)
                 self.time = igrfcoeffs.datehigh
             else:
                 errmsg += '''\nUse "limits='warn'" to force out-of-range times '''
@@ -186,7 +186,8 @@ class IGRF():
         if self.__status['time_set']:
             return
         if not self.__status['init']:
-            warnings.warn('IGRF: Initialize for a time before invoking this method.')
+            warnings.warn('IGRF: Initialize for a time before invoking this method.',
+                          stacklevel=2)
             return
 
         # Find the indices for the epochs surrounding input time

--- a/spacepy/irbempy/__init__.py
+++ b/spacepy/irbempy/__init__.py
@@ -123,7 +123,8 @@ if 'TS07_DATA_PATH' not in os.environ:
             # https://discuss.python.org/t/importlib-resources-access-whole-directories-as-resources/15618/5
             td = tempfile.mkdtemp()
             warnings.warn(
-                f"Writing TS07 data to {td}; will not automatically clean.")
+                f"Writing TS07 data to {td}; will not automatically clean.",
+                stacklevel=2)
             td = os.path.join(td, 'TAIL_PAR')
             os.mkdir(td)
             files = list(spdatapath.joinpath('TAIL_PAR').iterdir())
@@ -1728,7 +1729,7 @@ class Shieldose2:
             cfac = fl_convert.get(fluence.lower(), fl_convert['nasa'])
             if fluence.lower() not in fl_convert:
                 wstr = f'{fluence} not a supported fluence model. Defaulting to NASA.'
-                warnings.warn(wstr)
+                warnings.warn(wstr, stacklevel=2)
             outdict['fluence_electron'] = dm.dmarray(outdict['dose_electron']
                                                      * cfac)
             ftext = f'Fluence calculated from Dose-Si using {fluence} model'

--- a/spacepy/omni.py
+++ b/spacepy/omni.py
@@ -418,4 +418,5 @@ if not (presentQD and presentO2):
     warnings.warn(
         "Qin-Denton/OMNI2 data not found in current format."
         " This module has limited functionality."
-        " Run spacepy.toolbox.update(QDomni=True) to download data.")
+        " Run spacepy.toolbox.update(QDomni=True) to download data.",
+        stacklevel=2)

--- a/spacepy/plot/apionly.py
+++ b/spacepy/plot/apionly.py
@@ -7,4 +7,4 @@ Formerly used to import spacepy.plot without changing styles.
 import warnings
 
 warnings.warn('Plot styles no longer applied on import, apionly deprecated'
-              ' in SpacePy 0.5.0', DeprecationWarning)
+              ' in SpacePy 0.5.0', DeprecationWarning, stacklevel=2)

--- a/spacepy/pycdf/__init__.py
+++ b/spacepy/pycdf/__init__.py
@@ -328,7 +328,7 @@ class Library(object):
             if ctypes.sizeof(ctypes.c_longlong) != \
                ctypes.sizeof(ctypes.c_double):
                 warnings.warn('ARM with unknown type sizes; '
-                              'TT2000 functions will not work.')
+                              'TT2000 functions will not work.', stacklevel=2)
             else:
                 if self._library.computeTT2000(
                         _cast_ll(2010), _cast_ll(1), _cast_ll(1),
@@ -336,7 +336,8 @@ class Library(object):
                         _cast_ll(0), _cast_ll(0), _cast_ll(0)
                 ) != 315576066184000000:
                     warnings.warn('ARM with unknown calling convention; '
-                                  'TT2000 functions will not work.')
+                                  'TT2000 functions will not work.',
+                                  stacklevel=2)
                 self.datetime_to_tt2000 = self._datetime_to_tt2000_typepunned
         if self.epoch_to_datetime(63113903999999.984).year != 1999:
             self.epoch_to_datetime = self._epoch_to_datetime_bad_rounding
@@ -1361,7 +1362,7 @@ class CDFError(CDFException):
 class CDFWarning(CDFException, UserWarning):
     """Used for a warning in the CDF library."""
 
-    def warn(self, level=4):
+    def warn(self, level=5):
         """
         Issues a warning based on the information stored in my exception
 
@@ -1370,7 +1371,7 @@ class CDFWarning(CDFException, UserWarning):
         Other Parameters
         ================
         level : int
-            optional (default 3), how far up the stack the warning should
+            optional (default 5), how far up the stack the warning should
             be reported. Passed directly to `warnings.warn`.
         """
         warnings.warn(self, self.__class__, level)
@@ -2000,7 +2001,7 @@ class CDF(MutableMapping, spacepy.datamodel.MetaMixin):
         if self.encoding not in ('ascii', 'utf-8'):
             warnings.warn(
                 'Opening CDF for write with nonstandard encoding {}'.format(
-                    self.encoding))
+                    self.encoding), stacklevel=2)
 
     @classmethod
     def from_data(cls, filename, sd):

--- a/spacepy/seapy.py
+++ b/spacepy/seapy.py
@@ -81,9 +81,10 @@ class SeaBase(object):
         if nonmon or noncontig:
             warnings.warn('Input time not {}; results are unlikely to be valid.'.format(
                           ('monotonic or contiguous' if nonmon else 'contiguous')
-                          if noncontig else 'monotonic'))
+                          if noncontig else 'monotonic'), stacklevel=2)
         if len(epochs) > len(times) / 2:
-            warnings.warn('Too many epochs; results are unlikely to be valid.')
+            warnings.warn('Too many epochs; results are unlikely to be valid.',
+                          stacklevel=2)
         if isinstance(epochs, spt.Ticktock):
             self.epochs = epochs.UTC
         else:
@@ -102,7 +103,7 @@ class SeaBase(object):
         if kwargs['window'] != self.window:
             warnings.warn(
                 'Window size changed to {0} (points) to fit resolution ({1})'.format(
-                self.window, self.delta))
+                    self.window, self.delta), stacklevel=2)
         self.bound_type = None
 
     def __str__(self):

--- a/spacepy/time.py
+++ b/spacepy/time.py
@@ -1793,7 +1793,7 @@ class Ticktock(MutableSequence):
 
         """
         warnings.warn('today() returns UTC day as of 0.2.2.',
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         try:
             dt = datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
         except AttributeError:
@@ -2078,7 +2078,7 @@ def sec2hms(sec, rounding=True, days=False, dtobj=False):
     if not days:
         if sec > 86400:
             warnings.warn("Number of seconds > seconds in day. "
-                          "Try days keyword.")
+                          "Try days keyword.", stacklevel=2)
     else:
         sec %= 86400
     if dtobj:  # no need to do the computation
@@ -2290,7 +2290,7 @@ def _read_leaps(oldstyle=False):
         mtime = datetime.datetime(*time.gmtime(os.path.getmtime(fname))[:6])
     except IOError:
         warnings.warn('Cannot read leapsecond file. Use'
-                      ' spacepy.toolbox.update(leapsecs=True).')
+                      ' spacepy.toolbox.update(leapsecs=True).', stacklevel=2)
         text = [] # Use built-in pre-1972 leaps
         mtime = None
     # Some files have a "last checked" line at the top
@@ -2339,7 +2339,8 @@ def _read_leaps(oldstyle=False):
            utcnow, mtime,
            datetime.datetime(int(year[-1]), int(mon[-1]), int(day[-1]))):
             warnings.warn('Leapseconds may be out of date.'
-                          ' Use spacepy.toolbox.update(leapsecs=True)')
+                          ' Use spacepy.toolbox.update(leapsecs=True)',
+                          stacklevel=2)
 
     TAIleaps = np.zeros(len(secs))
     TAItup = [''] * len(secs)

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -317,9 +317,9 @@ def tCommon(ts1, ts2, mask_only=True):
 
     tn1, tn2 = date2num(ts1), date2num(ts2)
 
-    el1in2 = np.in1d(tn1, tn2, assume_unique=True)  #makes mask of present/absent
-    el1in2 = np.in1d(tn1, tn2, assume_unique=True)  #makes mask of present/absent
-    el2in1 = np.in1d(tn2, tn1, assume_unique=True)
+    el1in2 = np.isin(tn1, tn2, assume_unique=True)  #makes mask of present/absent
+    el1in2 = np.isin(tn1, tn2, assume_unique=True)  #makes mask of present/absent
+    el2in1 = np.isin(tn2, tn1, assume_unique=True)
 
     if mask_only:
         return el1in2, el2in1

--- a/spacepy/toolbox/__init__.py
+++ b/spacepy/toolbox/__init__.py
@@ -1545,14 +1545,15 @@ def windowMean(data, time=[], winsize=0, overlap=0, st_time=None, op=np.mean):
         if not isinstance(winsize, int):
             winsize = int(round(winsize))
             warnings.warn('windowmean: non-integer windowsize, rounding to %d' \
-            % winsize)
+                          % winsize, stacklevel=2)
         if winsize < 1:
             winsize = 1
-            warnings.warn('windowmean: window length < 1, defaulting to 1')
+            warnings.warn('windowmean: window length < 1, defaulting to 1',
+                          stacklevel=2)
         if overlap >= winsize:
             overlap = winsize - 1
             warnings.warn('''windowmean: overlap longer than window, truncated to
-            %d''' % overlap)
+            %d''' % overlap, stacklevel=2)
         lastpt = winsize-1 #set last point to end of window size
         while lastpt < len(data):
             datwin = np.ma.masked_where(np.isnan(data[startpt:startpt+winsize]), \
@@ -2098,7 +2099,8 @@ def pmm(*args):
         except TypeError:
             ind = np.arange(len(a)).astype(int)
             import warnings
-            warnings.warn('pmm: Unable to exclude non-finite values, results may be incorrect', RuntimeWarning)
+            warnings.warn('pmm: Unable to exclude non-finite values, results may be incorrect',
+                          RuntimeWarning, stacklevel=2)
         try:
             ans.append([np.min(a[ind]), np.max(a[ind])])
         except TypeError:
@@ -2898,7 +2900,7 @@ def timeout_check_call(timeout, *args, **kwargs):
     """
     warnings.warn("timeout_check_call was deprecated in 0.7.0"
                   " and will be removed.",
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
     resolution = 0.1
     pro = subprocess.Popen(*args, **kwargs)
     starttime = time.time()

--- a/tests/spacepy_testing.py
+++ b/tests/spacepy_testing.py
@@ -196,6 +196,7 @@ class TestPlot(unittest.TestCase):
         import matplotlib
         import matplotlib.pyplot
         self.old_backend = matplotlib.get_backend()
+        matplotlib.pyplot.close('all')
         matplotlib.use('agg')
 
     def tearDown(self):
@@ -207,4 +208,5 @@ class TestPlot(unittest.TestCase):
                 fname = 'output_{}.png'.format('_'.join(self.id().split('.')[1:]))
                 matplotlib.pyplot.savefig(fname)
             matplotlib.pyplot.close()
+        matplotlib.pyplot.close('all')
         matplotlib.use(self.old_backend)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -8,6 +8,9 @@ Copyright 2010-2014 Triad National Security, LLC.
 Copyright 2015-2020 the contributors
 """
 
+import glob
+import importlib
+import os.path
 import sys
 try:
     import unittest_pretty as ut
@@ -24,32 +27,17 @@ if spacepy.config['enable_deprecation_warning']:
 
 import spacepy_testing
 
-from test_pybats import *
-from test_time import *
-from test_empiricals import *
-from test_toolbox import *
-from test_omni import *
-from test_coordinates import *
-from test_ctrans import *
-from test_igrf import *
-from test_seapy import *
-from test_poppy import *
-from test_pycdf import *
-from test_pycdf_istp import *
-from test_data_assimilation import *
-from test_spectrogram import *
-from test_irbempy import *
-from test_datamanager import *
-from test_datamodel import *
-from test_base import *
-from test_plot import *
-from test_plot_utils import *
-from test_rst import *
-from test_lib import *
-from test_ae9ap9 import *
-from test_testing import *
-from test_lanlstar import *
-# add others here as they are written
+# Duplicative of test discovery, but avoids pulling the integration tests
+for testfile in glob.glob(os.path.join(os.path.dirname(__file__), 'test_*.py')):
+    modname = os.path.basename(testfile)[:-3]
+    if modname == 'test_all':
+        continue
+    mod = importlib.import_module(modname)
+    for name in dir(mod):
+        cls = getattr(mod, name)
+        if isinstance(cls, type) and issubclass(cls, ut.TestCase):
+            globals()[name] = cls
+
 
 if __name__ == '__main__':
     ut.main(warnings=False)  # do not reset warning filter

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -18,8 +18,12 @@ except ImportError:
     import unittest as ut
 import warnings
 
+# Warnings attributed to SpacePy code should be errors
 warnings.filterwarnings("error", module=r"spacepy\.")
 warnings.filterwarnings("error", module="spacepy_testing$")
+# omni is imported from spacepy and may not have this data in testing
+warnings.filterwarnings("default", "Qin-Denton/OMNI2 data not found",
+                        UserWarning, r"spacepy\.")
 
 import spacepy_testing
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -20,10 +20,6 @@ import warnings
 
 warnings.filterwarnings("error", module=r"spacepy\.")
 warnings.filterwarnings("error", module="spacepy_testing$")
-import spacepy
-if spacepy.config['enable_deprecation_warning']:
-    # Remove "default" deprecation, which overrides the error filter
-    del warnings.filters[0]
 
 import spacepy_testing
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -9,11 +9,18 @@ Copyright 2015-2020 the contributors
 """
 
 import sys
-
 try:
     import unittest_pretty as ut
 except ImportError:
     import unittest as ut
+import warnings
+
+warnings.filterwarnings("error", module=r"spacepy\.")
+warnings.filterwarnings("error", module="spacepy_testing$")
+import spacepy
+if spacepy.config['enable_deprecation_warning']:
+    # Remove "default" deprecation, which overrides the error filter
+    del warnings.filters[0]
 
 import spacepy_testing
 
@@ -45,4 +52,4 @@ from test_lanlstar import *
 # add others here as they are written
 
 if __name__ == '__main__':
-    ut.main()
+    ut.main(warnings=False)  # do not reset warning filter

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -40,8 +40,8 @@ class SpacepyFuncTests(unittest.TestCase):
             "            this will test things\n"
             "            ",
             testfunc.__doc__)
-        with spacepy_testing.assertWarns(self, 'always', r'pithy message$',
-                                         DeprecationWarning, r'spacepy$'):
+        with spacepy_testing.assertWarns(self, 'always', r'.*pithy message$',
+                                         DeprecationWarning):
             self.assertEqual(2, testfunc(1))
 
     def testDeprecationNone(self):
@@ -55,7 +55,7 @@ class SpacepyFuncTests(unittest.TestCase):
             "       pithy message",
             testfunc.__doc__)
         with spacepy_testing.assertWarns(self, 'always', r'pithy message$',
-                                         DeprecationWarning, r'spacepy$'):
+                                         DeprecationWarning):
             self.assertEqual(2, testfunc(1))
 
     def testDeprecationDifferentIndent(self):
@@ -97,7 +97,7 @@ class SpacepyFuncTests(unittest.TestCase):
             "            ",
             testfunc.__doc__)
         with spacepy_testing.assertWarns(self, 'always', r'pithy message$',
-                                         DeprecationWarning, r'spacepy$'):
+                                         DeprecationWarning):
             self.assertEqual(2, testfunc(1))
 
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -593,6 +593,19 @@ class dmarrayTests(unittest.TestCase):
         res = d.max(axis=1)
         self.assertIsInstance(res, dm.dmarray)
 
+    def test_empty_median(self):
+        """median of empty array is nan"""
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', '^(Mean of empty slice|invalid value encountered)',
+                                    RuntimeWarning, '^numpy.*')
+            ans = np.median(dm.dmarray([]))
+        self.assertTrue(np.isnan(ans))
+
+    def test_ufunc_of_ma(self):
+        """Convert dmarray to ma and call scalar ufunc"""
+        ans = np.ma.masked_array(self.dat).min()
+        self.assertEqual(1., ans)
+
         
 class converterTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -583,6 +583,16 @@ class dmarrayTests(unittest.TestCase):
         expected = [sd[key].dtype for key in sd]
         got = [ra.dtype[name] for name in ra.dtype.names]
         self.assertEqual(expected, got)
+
+    def test_scalar_output(self):
+        """ufuncs should return numpy scalar not 0D array"""
+        d = dm.dmarray([1, 2, 3], dtype=np.int32)
+        res = d.max()
+        self.assertIsInstance(res, np.int32)
+        d = dm.dmarray([[1, 2, 3], [4, 5, 6]])
+        res = d.max(axis=1)
+        self.assertIsInstance(res, dm.dmarray)
+
         
 class converterTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_empiricals.py
+++ b/tests/test_empiricals.py
@@ -83,7 +83,7 @@ class empFunctionTests(unittest.TestCase):
         with spacepy_testing.assertWarns(
                 self, 'always',
                 r'No LT dependence currently supported for CA1992 model',
-                RuntimeWarning, r'spacepy\.empiricals$'):
+                RuntimeWarning):
             em.getPlasmaPause(self.ticks, model='CA1992', LT=12, omnivals=self.omnivals)
 
     def test_getLmax(self):

--- a/tests/test_pycdf.py
+++ b/tests/test_pycdf.py
@@ -2669,11 +2669,10 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual(zVar.sparse(), const.NO_SPARSERECORDS)
         zVar.sparse(const.PREV_SPARSERECORDS)
         self.assertEqual(zVar.sparse(), const.PREV_SPARSERECORDS)
-        zVar[0] = 1;
-        zVar[3] = 2;
-        # Arguments to use for assertWarngs, since used a lot....
-        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                   r'spacepy\.pycdf$')
+        zVar[0] = 1
+        zVar[3] = 2
+        # Arguments to use for assertWarnings, since used a lot....
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[1], 1);
         with spacepy_testing.assertWarns(*aw_args):
@@ -2686,8 +2685,7 @@ class ChangeCDF(ChangeCDFBase):
         zVar[0] = [1, 2];
         zVar[3] = [3, 4];
         # Arguments to use for assertWarngs, since used a lot....
-        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                   r'spacepy\.pycdf$')
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         with spacepy_testing.assertWarns(*aw_args):
             numpy.testing.assert_array_equal(
                 [[1, 2], [1, 2], [1, 2], [3, 4]],
@@ -2701,8 +2699,7 @@ class ChangeCDF(ChangeCDFBase):
         zVar[3] = 2;
         self.assertEqual(4, len(zVar))
         # Arguments to use for assertWarngs, since used a lot....
-        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                   r'spacepy\.pycdf$')
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         with spacepy_testing.assertWarns(*aw_args):
             numpy.testing.assert_array_equal(zVar[...],
                                              [1, 1, 1, 2]);
@@ -2717,8 +2714,7 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual([0], hs.starts)
         self.assertEqual([4], hs.counts)
         with spacepy_testing.assertWarns(
-                self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                r'spacepy\.pycdf$'):
+                self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning):
             numpy.testing.assert_array_equal(zVar[:4],
                                              [1, 2, 3, 3]);
 
@@ -2731,8 +2727,7 @@ class ChangeCDF(ChangeCDFBase):
         zVar[3] = 2;
         pad = zVar.pad()
         # Arguments to use for assertWarngs, since used a lot....
-        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                   r'spacepy\.pycdf$')
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         with spacepy_testing.assertWarns(*aw_args):
             self.assertEqual(zVar[1], pad);
         with spacepy_testing.assertWarns(*aw_args):
@@ -2751,8 +2746,7 @@ class ChangeCDF(ChangeCDFBase):
         zVar[3] = [3, 4];
         pad = zVar.pad(20)
         # Arguments to use for assertWarngs, since used a lot....
-        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                   r'spacepy\.pycdf$')
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         with spacepy_testing.assertWarns(*aw_args):
             numpy.testing.assert_array_equal(
                 [[1, 2], [20, 20], [20, 20], [3, 4]],
@@ -2770,8 +2764,7 @@ class ChangeCDF(ChangeCDFBase):
                          str(cm.exception))
         # Following is test for if this did work
         # Arguments to use for assertWarngs, since used a lot....
-        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-        #           r'spacepy\.pycdf$')
+        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         #with spacepy_testing.assertWarns(*aw_args):
         #    numpy.testing.assert_array_equal(zVar[0:5],
         #                                     [1, 1, 99, 99, 2])
@@ -2785,8 +2778,7 @@ class ChangeCDF(ChangeCDFBase):
         zVar[5] = 3;
         del zVar[3]
         # Arguments to use for assertWarngs, since used a lot....
-        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-                   r'spacepy\.pycdf$')
+        aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         with spacepy_testing.assertWarns(*aw_args):
             numpy.testing.assert_array_equal(zVar[0:6],
                                              [1, 1, 1, 1, 1, 3])
@@ -2804,8 +2796,7 @@ class ChangeCDF(ChangeCDFBase):
                          str(cm.exception))
         # Following is test for if this did work
         # Arguments to use for assertWarngs, since used a lot....
-        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-        #           r'spacepy\.pycdf$')
+        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         #with spacepy_testing.assertWarns(*aw_args):
         #    numpy.testing.assert_array_equal(zVar[0:4],
         #                                     [1, 1, 1, 3])
@@ -2823,8 +2814,7 @@ class ChangeCDF(ChangeCDFBase):
                          str(cm.exception))
         # Following is test for if this did work
         # Arguments to use for assertWarngs, since used a lot....
-        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning,
-        #           r'spacepy\.pycdf$')
+        #aw_args = (self, 'always', r'VIRTUAL_RECORD_DATA', cdf.CDFWarning)
         #with spacepy_testing.assertWarns(*aw_args):
         #    numpy.testing.assert_array_equal(zVar[0:4],
         #                                     [1000, 101, 102, 3])
@@ -2836,7 +2826,7 @@ class ChangeCDF(ChangeCDFBase):
         self.assertEqual(const.PAD_SPARSERECORDS, zVar.sparse())
         self.assertEqual(99, zVar.pad())
         with spacepy_testing.assertWarns(self, 'always', r'VIRTUAL_RECORD_DATA',
-                                         cdf.CDFWarning, r'spacepy\.pycdf$'):
+                                         cdf.CDFWarning):
             numpy.testing.assert_array_equal(zVar[0:5], [1, 2, 3, 4, 99])
 
     def testSparseCopy(self):
@@ -2914,7 +2904,7 @@ class ChangeCDF(ChangeCDFBase):
         if not str is bytes:
             msg = msg.encode('ascii')
         with spacepy_testing.assertWarns(self, 'always', r'ATTR_NAME_TRUNC',
-                                         cdf.CDFWarning, r'spacepy\.pycdf$'):
+                                         cdf.CDFWarning):
             self.cdf._call(cdf.const.CREATE_, cdf.const.ATTR_, msg,
                            cdf.const.GLOBAL_SCOPE, ctypes.byref(attrnum))
 

--- a/tests/test_spectrogram.py
+++ b/tests/test_spectrogram.py
@@ -233,6 +233,21 @@ class SimpleSpectrogramTests(spacepy_testing.TestPlot):
         self.assertGreater(ylim[1], y[-1])
         self.assertLess(ylim[1], 250)
 
+    def testSimpleXYZDatesdmarray(self):
+        """Simple, three dmarray inputs, inputs, x is time"""
+        x = dm.dmarray(np.linspace(0, np.pi, 12))
+        y = dm.dmarray(np.logspace(0, 2, 6))
+        # Power-law in energy, sin in time
+        z = 1e4 * np.sin(x)[:, None] * (y ** -2)[None, :] + 1
+        dt = dm.dmarray(np.vectorize(lambda d: datetime.datetime(2010, 1, 1)
+                                     + datetime.timedelta(days=d))(x))
+        ax = simpleSpectrogram(dt, y, z)
+        mesh =  [c for c in ax.get_children() if isinstance(c, matplotlib.collections.QuadMesh)]
+        self.assertEqual(1, len(mesh))
+        mesh = mesh[0]
+        np.testing.assert_array_almost_equal(
+            z, mesh.get_array().reshape(z.shape[::-1]).transpose())  # mesh swaps row/column
+
     def testLinearZ(self):
         """Linear Z axis"""
         z = np.arange(72).reshape((12, 6))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -126,7 +126,7 @@ class TimeFunctionTests(unittest.TestCase):
         with spacepy_testing.assertWarns(
                 self, 'always',
                 r'Number of seconds > seconds in day\. Try days keyword\.$',
-                UserWarning, r'spacepy\.time$'):
+                UserWarning):
             for i, val in enumerate(inval):
                 ans = t.sec2hms(*val)
                 self.assertEqual(real_ans[i], ans)
@@ -1424,7 +1424,7 @@ class TimeClassTests(unittest.TestCase):
         with spacepy_testing.assertWarns(
                 self, 'always',
                 r'today\(\) returns UTC day as of 0\.2\.2\.$',
-                DeprecationWarning, r'spacepy\.time$'):
+                DeprecationWarning):
             v1 = t.Ticktock.today()
         self.assertEqual(v1.UTC[0].hour, 0)
         self.assertEqual(v1.UTC[0].minute, 0)

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -560,7 +560,7 @@ class SimpleFunctionTests(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 'ignore', 'pmm: Unable to exclude non-finite',
-                RuntimeWarning, 'spacepy.toolbox$')
+                RuntimeWarning)
             data = [array([5,9,23,24,6]).astype(object),
                     [datetime.datetime(2000, 3, 1, 0, 1), datetime.datetime(2000, 2, 28), datetime.datetime(2000, 3, 1)],
                     numpy.array(['foo', 'bar', 'baz'], dtype=object),
@@ -578,7 +578,7 @@ class SimpleFunctionTests(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 'ignore', 'pmm: Unable to exclude non-finite',
-                RuntimeWarning, 'spacepy.toolbox$')
+                RuntimeWarning)
             ans = tb.pmm(data)
         self.assertEqual([['bar', 'qux']], ans)
 
@@ -1214,7 +1214,7 @@ class TBTimeFunctionTests(unittest.TestCase):
         """windowMean should give known results 5(regression)"""
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                'ignore', r'windowmean\:', UserWarning, 'spacepy.toolbox$')
+                'ignore', r'windowmean\:', UserWarning)
             wsize = datetime.timedelta(days=1)
             olap = datetime.timedelta(hours=12)
             data = [10, 20]*50
@@ -1305,7 +1305,7 @@ class TBTimeFunctionTests(unittest.TestCase):
         """windowMean should give known results, with non-datetime time"""
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                'ignore', r'windowmean\:', UserWarning, 'spacepy.toolbox$')
+                'ignore', r'windowmean\:', UserWarning)
             # same setup as windowMean3, but 'time' is in fractional days
             wsize = 1.
             olap = .5


### PR DESCRIPTION
This PR fixes deprecations in numpy 2.0 (and one matplotlib deprecation that was found in the process). Closes #764.

One of these fixes changes the `__array_wrap__` handling so that it's closer to numpy, returning an array scalar (not zero-shape array) for scalar results instead of a Python object. This gets us some bug fixes for free, and tests are added to catch the regressions: closes #12 (SF65 is fixed by this, SF71 was already working in current `main`), closes #528 (looks like it's also working in `main`, but tested now). It then only took a little extra work to fix the incompatibility with pcolormesh; closes #258.

It also makes warnings attributed to spacepy fatal to the test_all process, so the CI will now fail if we have warnings. It's a bit of hack that should be revisited in the future, but works and gets us earlier warnings. To make this work, warnings issued *by* SpacePy now have their stacklevel changed (closes #721, see #527) so they are attributed to the calling code. This also means the enable deprecation warnings functionality goes away--we can't enable deprecation warnings just for deprecations *from* SpacePy, so the best we can do is encourage our users to run with `-Wd` occasionally.

Running the unit tests still issues a _lot_ of deprecation warnings, but they are not in spacepy. There's a few from matplotlib and many from numpy--numpy itself is not deprecation-clean in using its own API. That's part of the reason for the "error on spacepy warnings" change, to help distinguish between those cases.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
