### PR TITLE
Bump Pandas minimum version for Python 3.9 in CI and test_all.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             os: ubuntu-22.04
             build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
             numpy-version: "~=1.18.0"
-            piplist: "python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.25.0"
+            piplist: "python-dateutil~=2.6.1 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.25.0"
             cflags: "-Wno-error=format-security"
             cdf-version: "3.5.1"
             cdf-munged-version: "35_1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
             os: ubuntu-22.04
             build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
             numpy-version: "~=1.18.0"
-            piplist: "python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.24.0"
+            piplist: "python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.25.0"
             cflags: "-Wno-error=format-security"
             cdf-version: "3.5.1"
             cdf-munged-version: "35_1"

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -23,7 +23,7 @@ TESTS=(
        "3.7|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.8|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy~=1.18.0|python-dateutil~=2.5.0 scipy~=1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.24.0|old"
        "3.8|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
-       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.18.0,<1.19.0|python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.25.0|old"
+       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.18.0,<1.19.0|python-dateutil~=2.6.1 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.25.0|old"
        "3.9|pip setuptools wheel|numpy>=1.21.0 cython|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.10|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.21.0,<1.22.0|python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1 pandas~=1.2.0|old"
        "3.10|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -23,7 +23,7 @@ TESTS=(
        "3.7|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.8|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy~=1.18.0|python-dateutil~=2.5.0 scipy~=1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.24.0|old"
        "3.8|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
-       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.18.0,<1.19.0|python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.24.0|old"
+       "3.9|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.18.0,<1.19.0|python-dateutil~=2.5.0 scipy>=1.5.0,<1.6.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.25.0|old"
        "3.9|pip setuptools wheel|numpy>=1.21.0 cython|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.10|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.21.0,<1.22.0|python-dateutil~=2.7.0 scipy>=1.7.2,<1.8.0 matplotlib~=3.1.0 h5py>=3.6,<3.7 astropy>=4.0,<4.1 pandas~=1.2.0|old"
        "3.10|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"


### PR DESCRIPTION
This pull request resolves #765, drastically improving the time it takes to install dependencies for Python 3.9 on the CI. The fix was to simply increase the Pandas version for the "oldest" dependency strategy to >=1.1.3, which is the earliest version of Pandas that supports binary wheels for Python 3.9 ([source](https://pandas.pydata.org/docs/whatsnew/v1.1.3.html)).

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

