### PR TITLE
test_base: Improve test coverage

### DIFF
--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -266,7 +266,6 @@ def _write_defaults(rcfile, defaults, section='spacepy'):
     """Write configuration defaults out to a file if they aren't there"""
     f = open(rcfile, 'r+t') #Avoid race condition, open for read and write
     try:
-        startpos = f.tell()
         rclines = f.readlines()
         writeme = list(defaults)
         #Places where sections start

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -291,11 +291,11 @@ def _write_defaults(rcfile, defaults, section='spacepy'):
                         writeme.remove(k)
                         break
         #This is what we'll actually write to the file
-        writeme_verb = (f"#SpacePy {__version__} default {k}: {defaults[k]}\n"
+        writeme_verb = [f"#SpacePy {__version__} default {k}: {defaults[k]}\n"
                         f"#{k}: {defaults[k]}\n"
-                        for k in sorted(writeme))
+                        for k in sorted(writeme)]
         #Add writeme to end of this section
-        rclines[:nextsec] += writeme_verb
+        rclines[nextsec:nextsec] = writeme_verb
         #Write the new contents
         f.seek(0)
         f.writelines(rclines)

--- a/spacepy/__init__.py
+++ b/spacepy/__init__.py
@@ -335,8 +335,8 @@ def _read_config(rcfile):
             config = dict(cp.items('spacepy'))
         except configparser.NoSectionError:
             successful = []
-            config = {}
     if not successful:  # Old or bad file structure, wipe it out
+        config = {}
         cp = configparser.ConfigParser()
         cp.add_section('spacepy')
         with open(rcfile, 'w') as cf:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -100,6 +100,19 @@ class SpacepyFuncTests(unittest.TestCase):
                                          DeprecationWarning):
             self.assertEqual(2, testfunc(1))
 
+    def testDeprecationOneParagraph(self):
+        """Test the deprecation decorator, docstring is one paragraph"""
+        @spacepy.deprecated(0.1, 'pithy message')
+        def testfunc(x):
+            """test function"""
+            return x + 1
+        self.assertEqual(
+            "test function\n"
+            "\n"
+            ".. deprecated:: 0.1\n"
+            "   pithy message",
+            testfunc.__doc__)
+
 
 class SpacepyDirTests(unittest.TestCase):
     """Tests on the .spacepy directory and related."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -191,5 +191,28 @@ class SpacepyDirTests(unittest.TestCase):
         spacepy._read_config(spacepy.rcfile)  # Restore the previous config
 
 
+class SpacepyConfigTests(unittest.TestCase):
+    def testWriteDefaultsMultipleSections(self):
+        """Test _write_defaults where the config file has multiple sections"""
+        td = tempfile.mkdtemp()
+        configfile = os.path.join(td, 'spacepy.rc')
+        expected = ['[spacepy]\n',
+                    'some sample text\n',
+                    '#SpacePy UNRELEASED default test entry: value\n',
+                    '#test entry: value\n',
+                    '[test section]\n']
+        try:
+            with open(configfile, 'w') as cf:
+                cf.write('[spacepy]\n')
+                cf.write('some sample text\n')
+                cf.write('[test section]\n')
+            spacepy._write_defaults(configfile, {"test entry": "value"})
+            with open(configfile, 'r') as cf:
+                actual_lines = cf.readlines()
+            self.assertEqual(expected, actual_lines)
+        finally:
+            shutil.rmtree(td)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -214,6 +214,20 @@ class SpacepyConfigTests(unittest.TestCase):
         finally:
             shutil.rmtree(td)
 
+    def testReadConfigError(self):
+        """Test generic error cp for _read_config"""
+        td = tempfile.mkdtemp()
+        configfile = os.path.join(td, 'spacepy.rc')
+        try:
+            with open(configfile, 'w') as cf:
+                cf.write("this text is not in a section\n")
+            spacepy._read_config(configfile)
+            self.assertIn('enable_old_data_warning', spacepy.config)
+        finally:
+            shutil.rmtree(td)
+            spacepy._read_config(spacepy.rcfile)  # Restore the previous config
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -165,6 +165,17 @@ class SpacepyDirTests(unittest.TestCase):
         finally:
             os.chdir(wd)
 
+    def testDotflnTilde(self):
+        """Checks DOT_FLN with no available environment variables"""
+        if 'SPACEPY' in os.environ:
+            del os.environ['SPACEPY']
+        if 'HOME' in os.environ:
+            del os.environ['HOME']
+        if 'HOMEDRIVE' in os.environ:
+            del os.environ['HOMEDRIVE']
+        self.assertEqual(os.path.join(os.path.expanduser('~'), '.spacepy'),
+                         spacepy._find_spacepy_dir())
+
     def testNoDotfln(self):
         """Check creating .spacepy"""
         spdir = os.path.join(self.td, 'spacepy')

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -192,6 +192,7 @@ class SpacepyDirTests(unittest.TestCase):
 
 
 class SpacepyConfigTests(unittest.TestCase):
+    """Tests for _read_config and _write_defaults"""
     def testWriteDefaultsMultipleSections(self):
         """Test _write_defaults where the config file has multiple sections"""
         td = tempfile.mkdtemp()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -167,14 +167,16 @@ class SpacepyDirTests(unittest.TestCase):
 
     def testDotflnTilde(self):
         """Checks DOT_FLN with no available environment variables"""
-        if 'SPACEPY' in os.environ:
-            del os.environ['SPACEPY']
-        if 'HOME' in os.environ:
-            del os.environ['HOME']
-        if 'HOMEDRIVE' in os.environ:
-            del os.environ['HOMEDRIVE']
-        self.assertEqual(os.path.join(os.path.expanduser('~'), '.spacepy'),
-                         spacepy._find_spacepy_dir())
+        keys = ['SPACEPY', 'HOME', 'HOMEDRIVE']
+        backup = {key: os.environ[key] for key in keys if key in os.environ}
+        try:
+            for key in keys:
+                if key in os.environ:
+                    del os.environ[key]
+            self.assertEqual(os.path.join(os.path.expanduser('~'), '.spacepy'),
+                             spacepy._find_spacepy_dir())
+        finally:
+            os.environ.update(backup)
 
     def testNoDotfln(self):
         """Check creating .spacepy"""


### PR DESCRIPTION
This pull request improves the test coverage of `spacepy/__init__.py`, closes #300. The coverage of this file has been improved since this issue was opened (in #376 and #559), up to 85%. This pull request improves this to 89%.

While writing tests, I noticed a bug in `_write_defaults` that produced erroneous output when `spacepy.rc` has more than one section. I rewrote the latter half of `_write_defaults` with a different approach to fix this. Thinking back on it now, I think a more minimal change was possible, although the new code is significantly shorter than the old code.

Also, `_read_config` contained a smaller bug, where if the initial generic configparser read produced an error, the existing `config` would always be used instead of the defaults. Then, when we try to cast `config` with `str2bool`, it fails because it's expecting the values to be strings, but they are not
This was fixed by moving `config = {}` into the `if not successful` block, as this step ensured that the new defaults would be written to `config`.

What's untested are `help`, some Python version/platform workarounds, and OSErrors at the bottom. The OSErrors seem to be avoiding race conditions, which I think are impossible to test, especially in Python.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->