### PR TITLE
test_plot: improve test coverage

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,6 +8,7 @@ import datetime
 import unittest
 
 import matplotlib.collections
+import matplotlib.pyplot as plt
 import numpy
 import numpy.testing
 
@@ -37,6 +38,15 @@ class PlotFunctionTests(spacepy_testing.TestPlot):
         numpy.testing.assert_allclose(
             pc[2].get_fc(),
             [[0.8627, 0.07843, .235290, 0.75]], rtol=1e-3)
+
+    def test_plot_STT(self):
+        """test STT correctly replaces x tick labels"""
+        time = numpy.array([datetime.datetime(2010, 1, i) for i in range(1, 7)])
+        values = numpy.array([1., 5.1, 2, 3.2, 1, 7])
+        line = spacepy.plot.plot(time, values, smartTimeTicks=True)
+        ax = plt.gca()
+        xticks = ax.get_xticklabels()
+        self.assertEqual('01 Jan', xticks[0].get_text())
 
 
 if __name__ == "__main__":

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -6,6 +6,7 @@ Test suite for plot
 
 import datetime
 import unittest
+import os
 
 import matplotlib.collections
 import matplotlib.pyplot as plt
@@ -53,6 +54,20 @@ class PlotFunctionTests(spacepy_testing.TestPlot):
         expected = ['default', 'spacepy', 'spacepy_altgrid', 'altgrid',
                     'spacepy_polar', 'polar']
         actual = spacepy.plot.available()
+        self.assertEqual(expected, actual)
+
+    def test_available_retvals(self):
+        """test available returns dict of expected plot styles"""
+        from spacepy import __path__ as basepath
+        expected = {
+            'default': os.path.join('{0}'.format(basepath[0]), 'data', 'spacepy.mplstyle'),
+            'spacepy': os.path.join('{0}'.format(basepath[0]), 'data', 'spacepy.mplstyle'),
+            'spacepy_altgrid': os.path.join('{0}'.format(basepath[0]), 'data', 'spacepy_altgrid.mplstyle'),
+            'altgrid': os.path.join('{0}'.format(basepath[0]), 'data', 'spacepy_altgrid.mplstyle'),
+            'spacepy_polar': os.path.join('{0}'.format(basepath[0]), 'data', 'spacepy_polar.mplstyle'),
+            'polar': os.path.join('{0}'.format(basepath[0]), 'data', 'spacepy_polar.mplstyle')
+        }
+        actual = spacepy.plot.available(returnvals=True)
         self.assertEqual(expected, actual)
 
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -78,6 +78,13 @@ class PlotFunctionTests(spacepy_testing.TestPlot):
         # https://stackoverflow.com/questions/44968099/
         self.assertEqual('plasma', mpl.rcParams['image.cmap'])
 
+    def test_revert_style(self):
+        """test revert_style removes new keys in rcParams"""
+        original = mpl.rcParams.get('image.cmap')
+        spacepy.plot.style(look='spacepy')
+        spacepy.plot.revert_style()
+        self.assertEqual(original, mpl.rcParams.get('image.cmap'))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,6 +8,7 @@ import datetime
 import unittest
 import os
 
+import matplotlib as mpl
 import matplotlib.collections
 import matplotlib.pyplot as plt
 import numpy
@@ -69,6 +70,13 @@ class PlotFunctionTests(spacepy_testing.TestPlot):
         }
         actual = spacepy.plot.available(returnvals=True)
         self.assertEqual(expected, actual)
+
+    def test_style(self):
+        """test style updates rcParams"""
+        spacepy.plot.style(look='spacepy')
+        # It seems impossible to test the style:
+        # https://stackoverflow.com/questions/44968099/
+        self.assertEqual('plasma', mpl.rcParams['image.cmap'])
 
 
 if __name__ == "__main__":

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -48,6 +48,13 @@ class PlotFunctionTests(spacepy_testing.TestPlot):
         xticks = ax.get_xticklabels()
         self.assertEqual('01 Jan', xticks[0].get_text())
 
+    def test_available(self):
+        """test available returns the expected plot styles"""
+        expected = ['default', 'spacepy', 'spacepy_altgrid', 'altgrid',
+                    'spacepy_polar', 'polar']
+        actual = spacepy.plot.available()
+        self.assertEqual(expected, actual)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -85,6 +85,14 @@ class PlotFunctionTests(spacepy_testing.TestPlot):
         spacepy.plot.revert_style()
         self.assertEqual(original, mpl.rcParams.get('image.cmap'))
 
+    def test_dual_half_circle(self):
+        """basic test of dual_half_circle execution and output"""
+        wedges = spacepy.plot.dual_half_circle(colors=('y', 'k'))
+        self.assertEqual((0.75, 0.75, 0.0, 1), wedges[0].get_facecolor())
+        self.assertEqual((0.0, 0.0, 0.0, 1), wedges[1].get_facecolor())
+        self.assertEqual(71, len(wedges[0].properties()['verts']))
+        self.assertEqual(71, len(wedges[1].properties()['verts']))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request improves the test coverage of the `spacepy.plot` submodule and closes #309. Currently, `plot/__init__.py` is up to 80% coverage, and all new tests are tests for this file.

Admittedly, this submodule is very difficult to test meaningfully, even outside a lack of understanding of the more technical functions such as `carrington.solarRotationPlot`. Any suggestions on improvements to existing tests or on untested functions are accepted.

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [ ] New code has inline comments where necessary
- [X] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

<!--
Thank you so much for your PR!  The SpacePy community appreciates your
help and feedback.  To help us review your contribution, please
consider the following points:

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "pycdf: Fix dateime to tt2000 on ARM".
  Avoid non-descriptive titles such as "Bug fix" or "Updates".

- The PR summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues. If the PR resolves an issue, please write this in the summary
  so that github will automatically close the issue. E.g. "This PR resolves #1".

We understand that working with PRs can be tricky, even for seasoned contributors.
Please let us know if reviews are unclear or our recommendations seem like excessive work.
If you would like help in addressing a reviewer's comments, or if your PR hasn't been
reviewed in a reasonable timeframe please just comment again.
-->

