### PR TITLE
numpy 2.1 pybats fix (CI failure)

### DIFF
--- a/spacepy/pybats/rim.py
+++ b/spacepy/pybats/rim.py
@@ -217,8 +217,8 @@ class Iono(PbData):
         # Create 2-D arrays.
         for key in namevar:
             nkey, skey = 'n_'+key, 's_'+key
-            self[nkey] = reshape(self[nkey], (ntheta, nphi), 'F')
-            self[skey] = reshape(self[skey], (ntheta, nphi), 'F')
+            self[nkey] = reshape(self[nkey], (ntheta, nphi), order='F')
+            self[skey] = reshape(self[skey], (ntheta, nphi), order='F')
 
         # Some extra grid info:
         self.dlon = self['n_psi'  ][0,3]-self['n_psi'  ][0,2]

--- a/spacepy/pybats/rim.py
+++ b/spacepy/pybats/rim.py
@@ -365,7 +365,7 @@ class Iono(PbData):
             that is strictly positive and "Seismic" for diverging data.
             Alternatively, legacy Ridley Ionosphere Model color maps can be
             loaded using "l_wr" (white red) or "l_bwr" (blue-white-red),
-            where the "l\_" prefix indicates legacy and not Matplotlib color maps.
+            where the "l\\_" prefix indicates legacy and not Matplotlib color maps.
         add_cbar : bool
             Add colorbar to plot.  Default is **False** which will
             not add one to the plot.


### PR DESCRIPTION
Quick fix for pybats.rim.Iono.readascii on numpy 2.1, which doesn't allow the order to be a positional arg anymore.

Also found one stray invalid escape in the rim.Ion.add_cont docstring, so that's fixed.

This is why #775 is failing, and why the CI failed yesterday and today. A deprecation warning would have been nice...

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)