### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
             dep-strategy: "newest"
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get Week
@@ -148,7 +148,7 @@ jobs:
         echo "week=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         # Force-expire the pip cache weekly
@@ -157,7 +157,7 @@ jobs:
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
     - name: Cache cdf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/cdf
         # Force-expire the CDF cache weekly
@@ -189,7 +189,7 @@ jobs:
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install and run tests
       working-directory: ${{ github.workspace }}
       run: |
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unicode check
         run: (! file irbem-lib-*/*.f irbem-lib-*/source/*.f | grep -q Unicode )
         working-directory: ${{ github.workspace }}/spacepy/irbempy/
@@ -239,7 +239,7 @@ jobs:
             dep-strategy: "newest"
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get Week
@@ -248,7 +248,7 @@ jobs:
         echo "week=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         # Different pip cache for docs (includes numpydoc, sphinx)
@@ -260,7 +260,7 @@ jobs:
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-${{ matrix.python-version }}-
           pip-v${{ env.pip-cache-version}}-${{ steps.get-week.outputs.week }}-${{ matrix.os }}-
     - name: Cache cdf
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/cdf
         # Force-expire the CDF cache weekly
@@ -292,7 +292,7 @@ jobs:
 # Per https://github.com/actions/checkout/issues/15, this gets the MERGE
 # commit of the PR, not just the tip of the PR.
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build spacepy and docs
       working-directory: ${{ github.workspace }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,24 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.6"
-            os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
-            numpy-version: "~=1.15.1"
-            piplist: "python-dateutil~=2.5.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 pandas~=0.18.0"
-            cflags: "-Wno-error=format-security"
-            cdf-version: "3.5.1"
-            cdf-munged-version: "35_1"
-            dep-strategy: "oldest"
-          - python-version: "3.6"
-            os: ubuntu-20.04
-            build-deps: "pip setuptools wheel cython"
-            numpy-version: ">=1.19.0,<1.20.0"
-            piplist: "python-dateutil scipy matplotlib h5py astropy pandas"
-            cflags: ""
-            cdf-version: "3.9.1"
-            cdf-munged-version: "39_1"
-            dep-strategy: "newest"
           - python-version: "3.7"
             os: ubuntu-22.04
             build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
@@ -196,7 +178,7 @@ jobs:
         python -m pip install --no-build-isolation ${BUILD_DEPS}
         pip install --no-build-isolation --force-reinstall "numpy${NUMPY_VERSION}"
         # Make sure new packages don't override numpy version
-        if [ "$DEPSTRAT" = "oldest" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
+        if [ "$DEPSTRAT" = "oldest" -a \( ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
             # scipy < 1.5 doesn't build on gcc 10+ without this argument
             FOPT="-fallow-argument-mismatch" pip install --no-build-isolation --log=install_log.txt numpy${NUMPY_VERSION} ${PIPLIST}
         else
@@ -237,11 +219,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.6"
-            os: ubuntu-20.04
-            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython"
+          - python-version: "3.7"
+            os: ubuntu-22.04
+            build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
             numpy-version: "~=1.15.1"
-            piplist: "python-dateutil~=2.5.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 sphinx~=4.0.0 numpydoc"
+            piplist: "python-dateutil~=2.5.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 sphinx~=4.0.0 numpydoc"
             cflags: "-Wno-error=format-security"
             cdf-version: "3.5.1"
             cdf-munged-version: "35_1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
             os: ubuntu-22.04
             build-deps: "pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0"
             numpy-version: "~=1.15.1"
-            piplist: "python-dateutil~=2.5.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 sphinx~=4.0.0 numpydoc"
+            piplist: "python-dateutil~=2.5.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 sphinx~=4.0.0 numpydoc~=0.8.0"
             cflags: "-Wno-error=format-security"
             cdf-version: "3.5.1"
             cdf-munged-version: "35_1"

--- a/Doc/source/conf.py
+++ b/Doc/source/conf.py
@@ -39,6 +39,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
 
 # Not actually Python modules, or so beta that we don't want them in docs
 autodoc_mock_imports = ["spacepy.irbempy.libirbem",
+                        "spacepy.libcdf",
                         "spacepy.libspacepy",
                         "spacepy.sandbox",
                         ]

--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -39,7 +39,7 @@ principles:
        which have binary wheels available. Numpy may be tested with earlier
        versions that do not conflict with other dependencies. For this reason,
        the CI configuration is not a reasonable guide of the minimum supported
-       versoin.
+       version.
 
  #. No support will be provided for conflicting versions of
     dependencies. E.g. SciPy 1.9 requires NumPy 1.18. Although SpacePy
@@ -178,3 +178,11 @@ history. The oldest version supported according to this policy is in
      - 0.9.0 (2022/10/27)
      - 1.0.0 (2023/9/1)
      - tested with 0.4.0
+   * - `numpydoc <https://pypi.org/project/numpydoc/#history>`_
+       (only needed for developers to build documentation)
+     - 1.8.0 (2024/8/9)
+     - 1.6.0 (2023/9/25)
+     - **1.2.0** (2022/1/24)
+     - 1.5.0 (2022/10/8)
+     - 1.6.0 (2023/9/25)
+     - 0.8.0 (2018/3/30)

--- a/Doc/source/dep_versions.rst
+++ b/Doc/source/dep_versions.rst
@@ -84,14 +84,14 @@ history. The oldest version supported according to this policy is in
      - 3.10.4 (2022/3/24)
      - **3.10.0** (2021/10/4)
      - 3.11.0 (2022/10/24)
-     - 3.6.0 (2016/12/23)
+     - 3.7.0 (2018/6/27)
    * - `AstroPy <https://docs.astropy.org/en/stable/changelog.html#changelog>`_
      - 6.1.1 (2024/6/14)
      - 6.0.0 (2023/11/25)
      - **5.0.2** (2022/3/10)
      - 5.2 (2022/12/12)
      - 5.3 (2023/5/22)
-     - 1.0 (2015/2/18)
+     - 2.0 (2017/7/7)
    * - `CDF <https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/latest-release/unix/CHANGES.txt>`_
      - 3.9.0 (2023/1/22)
      - N/A

--- a/Doc/source/dependencies.rst
+++ b/Doc/source/dependencies.rst
@@ -19,7 +19,7 @@ Without these packages installed, SpacePy will not
 function. Installing via ``pip`` will normally install Python-based
 dependencies automatically.
 
-Python 3.6+
+Python 3.7+
 -----------
 
 `Python <http://www.python.org/>`_ is the core language for SpacePy.
@@ -135,7 +135,7 @@ the ``use_irbem`` option.
 
 .. _dependencies_astropy:
 
-Astropy 1.0+
+Astropy 2.0+
 ------------
 :mod:`~spacepy.time` requires Astropy if conversion to/from
 Astropy :class:`~astropy.time.Time` is desired.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -33,6 +33,10 @@ later on Python 3.12. Numpy is still required to run SpacePy.
 Sphinx 4.0 is now required to build the documentation; this is not
 a concern for most users.
 
+Support for Python 3.6 has been removed due to inability to
+test. Python 3.7 is the oldest supported Python; as a result, Astropy
+2.0 is the oldest supported Astropy (if using Astropy).
+
 Deprecations and removals
 *************************
 `~spacepy.toolbox.timeout_check_call` is deprecated as redundant to using

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The latest "bleeding-edge" source code is available from our github repository a
 
 Further installation documentation, including building from source and OS-specific information, can be found [here](https://spacepy.github.io/install.html). Full documentation is at [https://spacepy.github.io](https://spacepy.github.io).
 
-SpacePy supports Python 3.6 and later.
+SpacePy supports Python 3.7 and later.
 
 ### Dependencies
 

--- a/developer/scripts/build_win.cmd
+++ b/developer/scripts/build_win.cmd
@@ -16,11 +16,8 @@ GOTO :EOF
 CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate" py%1
 pushd %~dp0\..\..\
 rmdir /s /q build 2> nul
-IF "%1"=="36" (
-    CALL pyproject-build -w -n -x
-) ELSE (
-    CALL python-build -w -n -x
-)
+CALL python-build -w -n -x
+
 popd
 ::This turns off echo!
 CALL conda deactivate

--- a/developer/scripts/linux_wheels.sh
+++ b/developer/scripts/linux_wheels.sh
@@ -5,7 +5,6 @@
 #wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 #bash ./Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda
 VERSIONS=(
-    "3.6"
     "3.7"
     "3.8"
     "3.9"
@@ -18,11 +17,7 @@ do
     ENVNAME=spacepy${PYVER//.}
     ~/miniconda/bin/conda create -y -n ${ENVNAME} python=${PYVER}
     source ~/miniconda/bin/activate ${ENVNAME}
-    if [ ${PYVER} = "3.6" ]; then
-	conda install -y wheel
-	pip install build
-	BUILD=pyproject-build
-    elif [ ${PYVER} = "3.9" ]; then
+    if [ ${PYVER} = "3.9" ]; then
 	conda install -y python-build wheel
 	BUILD=python-build
     elif [ ${PYVER} = "3.12" ]; then

--- a/developer/scripts/mac_x86_wheels.sh
+++ b/developer/scripts/mac_x86_wheels.sh
@@ -11,11 +11,7 @@ do
     ENVNAME=spacepy${PYVER//.}
     ~/opt/miniconda/bin/conda create -y -n ${ENVNAME} python=${PYVER}
     source ~/opt/miniconda/bin/activate ${ENVNAME}
-    if [ ${PYVER} = "3.6" ]; then
-	conda install -y wheel gfortran~=11.2.0
-	pip install build
-	BUILD=pyproject-build
-    elif [ ${PYVER} = "3.9" ]; then
+    if [ ${PYVER} = "3.9" ]; then
 	conda install -y python-build wheel gfortran~=11.2.0 "cython<3"
 	BUILD=python-build
     elif [ ${PYVER} = "3.12" ]; then

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -17,8 +17,6 @@ source ${HOME}/cdf/bin/definitions.B
 # coupled with what's the earliest and latest version of each dep
 # which works with that Python.
 TESTS=(
-       "3.6|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy~=1.15.1|python-dateutil~=2.5.0 scipy~=1.0.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=1.0,<1.1 pandas~=0.18.0|old"
-       "3.6|pip setuptools wheel cython|numpy>=1.19.0,<1.20.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.7|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy>=1.15.1,<1.16.0|python-dateutil~=2.5.0 scipy>=1.0.0,<1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.23.0|old"
        "3.7|pip setuptools wheel cython|numpy>=1.21.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.8|pip~=20.0.0 setuptools~=44.1.0 wheel~=0.34.2 cython<3.0|numpy~=1.18.0|python-dateutil~=2.5.0 scipy~=1.1.0 matplotlib~=3.1.0 h5py~=2.10.0 astropy>=2.0,<2.1 pandas~=0.24.0|old"
@@ -49,7 +47,7 @@ do
     pip install --no-build-isolation ${NUMPY}
     # Don't let it grab a different version of numpy later,
     # and always build against the installed numpy
-    if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.6" -o ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
+    if [ "$DEPSTRAT" = "old" -a \( ${PYVER} = "3.7" -o ${PYVER} = "3.8" \) ]; then
 	# scipy < 1.5 doesn't build on gcc 10+ without this argument
 	FOPT="-fallow-argument-mismatch" pip install --no-build-isolation ${NUMPY} ${PIPLIST}
     else

--- a/developer/scripts/test_linux_wheels.sh
+++ b/developer/scripts/test_linux_wheels.sh
@@ -2,7 +2,7 @@
 
 # Run unit tests on all the wheels, linux version
 
-VERSIONS="3.6 3.7 3.8 3.9 3.10 3.11 3.12"
+VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12"
 
 for PYVER in ${VERSIONS}
 do

--- a/developer/scripts/test_mac_wheels.sh
+++ b/developer/scripts/test_mac_wheels.sh
@@ -2,7 +2,7 @@
 
 # Run unit tests on all the wheels, mac version
 
-VERSIONS="3.6 3.7 3.8 3.9 3.10 3.11 3.12"
+VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12"
 
 for PYVER in ${=VERSIONS}
 do

--- a/developer/scripts/win_build_system_setup.cmd
+++ b/developer/scripts/win_build_system_setup.cmd
@@ -19,7 +19,6 @@ CALL conda create -y -n py310 python=3.10
 CALL conda create -y -n py39 python=3.9
 CALL conda create -y -n py38 python=3.8
 CALL conda create -y -n py37 python=3.7
-CALL conda create -y -n py36 python=3.6
 
 IF "%1"=="build" (
     set ACTION=BUILD
@@ -27,7 +26,7 @@ IF "%1"=="build" (
     set ACTION=TEST
 )
 
-FOR %%P in (36 37 38 39 310 311 312) DO CALL :installs %%P
+FOR %%P in (37 38 39 310 311 312) DO CALL :installs %%P
 
 GOTO :EOF
 
@@ -39,13 +38,7 @@ CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate" py%1
 IF "%ACTION%"=="BUILD" (
     :: Get the compiler
     CALL conda install -y m2w64-gcc-fortran libpython
-    IF "%1"=="36" (
-        :: conda doesn't have build for py3.6
-        CALL pip install build
-	CALL conda install -y wheel
-    ) ELSE (
-        CALL conda install -y python-build wheel
-    )
+    CALL conda install -y python-build wheel
 ) ELSE (
     :: Testing. Get the latest of everything
     CALL conda install -y numpy scipy matplotlib h5py astropy

--- a/developer/scripts/win_build_system_teardown.cmd
+++ b/developer/scripts/win_build_system_teardown.cmd
@@ -1,7 +1,6 @@
 :: Remove the Windows build system
 @ECHO OFF
 
-"%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py36
 "%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py37
 "%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py38
 "%SYSTEMDRIVE%\Miniconda3\Scripts\conda" env remove -y --name py39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "spacepy"
 version = "0.7.0a0"
 description = "SpacePy: Tools for Space Science Applications"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = { "file" = "LICENSE.md" }
 authors = [{ "name" = "SpacePy team", "email" = "spacepy@lanl.gov" }]
 maintainers = [
@@ -46,7 +46,7 @@ dependencies = [
 ]
 
 [tool.distutils.bdist_wheel]
-py-limited-api = "cp36"
+py-limited-api = "cp37"
 
 [tool.setuptools]
 packages = ["spacepy", "spacepy.irbempy", "spacepy.pycdf",

--- a/setup.py
+++ b/setup.py
@@ -583,18 +583,18 @@ setup_kwargs = {
         'python_dateutil>=2.5',
         # AstroPy is only required to convert to/from AstroPy, so either
         # user has it or don't care.
-        #'astropy>=1.0',
+        #'astropy>=2.0',
         # Similar for pandas
         #'pandas>=0.18',
     ],
-    'python_requires': '>=3.6',
+    'python_requires': '>=3.7',
     'cmdclass': {'build': build,
                  'build_ext': build_ext,
                  'install': install,
                  'bdist_wheel': bdist_wheel,
           },
     'zip_safe': False,
-    'options': {'bdist_wheel': {'py_limited_api': 'cp36'}},
+    'options': {'bdist_wheel': {'py_limited_api': 'cp37'}},
 }
 
 if has_editable_wheel:


### PR DESCRIPTION
The latest version of the GitHub runners, even on Ubuntu 20.04, [removes Python 3.6 support](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md#python). This [broke CI](https://github.com/spacepy/spacepy/actions/runs/10697303743). Since we can no longer test it in CI, this PR removes SpacePy support for Python 3.6 and AstroPy 1.0.

Once 3.7 was our oldest version, the documentation CI was grabbing a version of numpydoc that would install but not work on 3.7. So this PR also establishes a minimum version of numpydoc (0.8.0).

Several of our actions were using old versions that had a deprecated node.js, so this PR also updates those runners (as long as we're messing with CI).

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)


