### PR TITLE
test_base: fix test for config file writing with released SpacePy

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -208,7 +208,7 @@ class SpacepyConfigTests(unittest.TestCase):
         configfile = os.path.join(td, 'spacepy.rc')
         expected = ['[spacepy]\n',
                     'some sample text\n',
-                    '#SpacePy UNRELEASED default test entry: value\n',
+                    f'#SpacePy {spacepy.__version__} default test entry: value\n',
                     '#test entry: value\n',
                     '[test section]\n']
         try:


### PR DESCRIPTION
#775 hardcoded the "UNRELEASED" version number in a test, making tests fail when run against a released version of SpacePy. This PR fixes that test.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
