### PR TITLE
Changing some integers to 64 bit so numpy >=2.0 can handle large files.

### DIFF
--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -624,10 +624,10 @@ def _scan_bin_header(f, endchar, inttype, floattype):
     # Stash relevant values into the "info" dict:
     vals = readarray(f, dtype=header_fields_dtype, inttype=inttype)[0]
     for v, x in zip(['iter', 'runtime', 'ndim', 'nparam', 'nvar'], vals):
-        info[v] = x
+        info[v] = np.int64(x)
 
     # Dimensionality may be negative to indicate non-uniform grid:
-    info['ndim'] = abs(info['ndim'])
+    info['ndim'] = np.abs(info['ndim'], dtype=np.int64)
 
     # Get gridsize:
     grid = dmarray(readarray(f, inttype, inttype))
@@ -1018,7 +1018,7 @@ class IdlFile(PbData):
     keep_case : bool
         If set to True, the case of variable names will be preserved.  If
         set to False, variable names will be set to all lower case.
-    
+
     Notes
     -----
     PyBats assumes little endian byte ordering because
@@ -1041,7 +1041,7 @@ class IdlFile(PbData):
         :meth:`~spacepy.pybats.bats.Bats2d.extract` and
         :class:`~spacepy.pybats.qotree.QTree` for processing
         adjacent cells. (ASCII data were never sorted.)
-        
+
     '''
 
     def __init__(self, filename, iframe=0, header='units',

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -627,7 +627,7 @@ def _scan_bin_header(f, endchar, inttype, floattype):
         info[v] = x.item()
 
     # Dimensionality may be negative to indicate non-uniform grid:
-    info['ndim'] = np.abs(info['ndim'])
+    info['ndim'] = abs(info['ndim'])
 
     # Get gridsize:
     grid = dmarray(readarray(f, inttype, inttype))

--- a/spacepy/pybats/__init__.py
+++ b/spacepy/pybats/__init__.py
@@ -624,10 +624,10 @@ def _scan_bin_header(f, endchar, inttype, floattype):
     # Stash relevant values into the "info" dict:
     vals = readarray(f, dtype=header_fields_dtype, inttype=inttype)[0]
     for v, x in zip(['iter', 'runtime', 'ndim', 'nparam', 'nvar'], vals):
-        info[v] = np.int64(x)
+        info[v] = x.item()
 
     # Dimensionality may be negative to indicate non-uniform grid:
-    info['ndim'] = np.abs(info['ndim'], dtype=np.int64)
+    info['ndim'] = np.abs(info['ndim'])
 
     # Get gridsize:
     grid = dmarray(readarray(f, inttype, inttype))

--- a/tests/integration_all.py
+++ b/tests/integration_all.py
@@ -15,6 +15,7 @@ import unittest
 import spacepy_testing
 from integration_omni import *
 from integration_toolbox import *
+from integration_pybats import *
 
 
 if __name__ == '__main__':

--- a/tests/integration_pybats.py
+++ b/tests/integration_pybats.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Integration tests for Pybats.
+
+Copyright 2025 SpacePy contributors
+"""
+
+import os
+import unittest
+
+import spacepy_testing
+import spacepy.pybats as pb
+
+
+class PybatsFileIntegration(unittest.TestCase):
+    '''
+    Large and cumbersome tests related to :class:`spacepy.pybats.IdlFile`
+    file types and formats (ascii and binary).
+    '''
+
+    # This single file is 2.4K in size.
+    filebase = os.path.join(spacepy_testing.datadir, 'pybats_test',
+                            'mag_grid_binary.out')
+
+    # Reference values:
+    knownDbnMax = 8.0770346781
+    knownPedMax = 2.783385368
+
+    def testBinaryLarge(self):
+        '''Test ability to open large (>2Gb) file.'''
+
+        # Set location for temporary large file:
+        tempfile = 'testfile_large.outs'
+
+        # Concat small file into a large one (>2gb)
+        with open(tempfile, 'wb') as f_out:
+            with open(self.filebase, 'rb') as f_in:
+                rawbits = f_in.read()
+            for i in range(1000000):
+                f_out.write(rawbits)
+
+        # Read the large file to test for failures:
+        data = pb.IdlFile(tempfile)
+
+        # Switch to final frame and check values:
+        data.switch_frame(-1)
+        self.assertAlmostEqual(self.knownDbnMax, data['dBn'].max())
+        self.assertAlmostEqual(self.knownPedMax, data['dBnPed'].max())
+
+        # Remove temporary test file.
+        os.remove(tempfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -6,10 +6,6 @@ Test suite for SpacePy's PyBats subpackage.
 Copyright 2015 University of Michigan
 """
 
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-
 import datetime as dt
 import glob
 import os
@@ -23,6 +19,10 @@ import spacepy.pybats as pb
 import spacepy.pybats.bats as pbs
 import spacepy.pybats.ram as ram
 import spacepy.pybats.gitm as gitm
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
 
 __all__ = ['TestParseFileTime', 'TestIdlFile', 'TestRim', 'TestBats2d',
            'TestMagGrid', 'TestSatOrbit', 'TestVirtSat', 'TestImfInput',
@@ -347,6 +347,20 @@ class TestIdlFile(unittest.TestCase):
         self.assertEqual(self.knownMhdZlim*-1, mhd['z'].min())
         for v in range(len(self.knownMhdX_unsorted)):
             self.assertEqual(self.knownMhdX_unsorted[v], (mhd['x'])[v])
+
+    def testBinaryLarge(self):
+        '''Test ability to open large (>2Gb) file.'''
+
+        # This single file is 2.4K in size.
+        filebase = os.path.join(spacepy_testing.datadir, 'pybats_test',
+                                'mag_grid_binary.out')
+
+        # Concat small file into a large one.
+        with open('testfile.outs', 'wb') as f_out:
+            with open(filebase, 'rb') as f_in:
+                rawbits = f_in.read()
+            for i in range(1000000):
+                f_out.write(rawbits)
 
     def testAscii(self):
         # Open file:

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -14,15 +14,15 @@ import unittest
 import numpy as np
 import numpy.testing
 
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
 import spacepy_testing
 import spacepy.pybats as pb
 import spacepy.pybats.bats as pbs
 import spacepy.pybats.ram as ram
 import spacepy.pybats.gitm as gitm
-
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
 
 __all__ = ['TestParseFileTime', 'TestIdlFile', 'TestRim', 'TestBats2d',
            'TestMagGrid', 'TestSatOrbit', 'TestVirtSat', 'TestImfInput',

--- a/tests/test_pybats.py
+++ b/tests/test_pybats.py
@@ -348,20 +348,6 @@ class TestIdlFile(unittest.TestCase):
         for v in range(len(self.knownMhdX_unsorted)):
             self.assertEqual(self.knownMhdX_unsorted[v], (mhd['x'])[v])
 
-    def testBinaryLarge(self):
-        '''Test ability to open large (>2Gb) file.'''
-
-        # This single file is 2.4K in size.
-        filebase = os.path.join(spacepy_testing.datadir, 'pybats_test',
-                                'mag_grid_binary.out')
-
-        # Concat small file into a large one.
-        with open('testfile.outs', 'wb') as f_out:
-            with open(filebase, 'rb') as f_in:
-                rawbits = f_in.read()
-            for i in range(1000000):
-                f_out.write(rawbits)
-
     def testAscii(self):
         # Open file:
         mhd = pb.IdlFile(os.path.join(


### PR DESCRIPTION
Closes #810 

Change a few integers that default to numpy int32 to int64 to prevent overflow errors when opening large (>2Gb) files with IdlFile objects in Pybats. 

## PR Checklist

- [ x] Pull request has descriptive title
- [x ] Pull request gives overview of changes
- [ x] New code has inline comments where necessary
- [n/a ] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [ n/a] Added an entry to release notes if fixing a significant bug or providing a new feature
- [ n/a] New features and bug fixes should have unit tests
- [ x] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)

