### PR TITLE
Fix `make install` line for cdf install on Linux side

### DIFF
--- a/Doc/source/install_linux.rst
+++ b/Doc/source/install_linux.rst
@@ -83,7 +83,7 @@ distribution-specific directions above will install curses.)
 
 Install::
 
-    sudo make install
+    sudo make INSTALLDIR=/usr/local/cdf install
 
 This will install the library into the default location ``/usr/local/cdf``, where 
 SpacePy can find it. If you choose to install elsewhere, see the CDF documentation, 


### PR DESCRIPTION
The Linux install doc is a little outdated. You need to explicitly target an install directory for `cdf`.

## PR Checklist

- [x] Pull request has descriptive title
- [x] Pull request gives overview of changes
- [x] New code has inline comments where necessary
- [N/A] Any new modules, functions or classes have docstrings consistent with SpacePy style
- [N/A] Added an entry to release notes if fixing a significant bug or providing a new feature
- [N/A] New features and bug fixes should have unit tests
- [N/A] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)