### PR TITLE
Switch Mac Intel build to Rosetta-on-ARM

### DIFF
--- a/DISTRIBUTE
+++ b/DISTRIBUTE
@@ -134,8 +134,15 @@ sed -i '' 's/LDLIB=-L\$(XCODEDir)/LDLIB?=-L\$(XCODEDir)/' Makefile
 # pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
 # For Apple Silicon
 SDKROOT=/opt/MacOSX11.0.sdk make XCODEVERSION=10.2 LDLIB=-L/opt/MacOSX11.0.sdk/usr/lib OS=macosx ENV=arm64 SHARED=yes CURSES=no FORTRAN=no all
-# For Intel
+# For Intel, built on Intel
 SDKROOT=/opt/MacOSX10.9.sdk make XCODEVERSION=10.2 LDLIB="-L/opt/MacOSX10.9.sdk/usr/lib -L/opt/MacOSX10.9.sdk/usr/lib/system" OS=macosx ENV=x86_64 SHARED=yes CURSES=no FORTRAN=no all
+# To build Intel *on Apple Silicon*
+SDKROOT=/opt/MacOSX10.9.sdk arch -x86_64 make XCODEVERSION=10.2 LDLIB="-L/opt/MacOSX10.9.sdk/usr/lib -L/opt/MacOSX10.9.sdk/usr/lib/system" OS=macosx ENV=x86_64 SHARED=yes CURSES=no FORTRAN=no all
+
+The assumption of the build scripts now is that both the x86 and ARM
+builds will be done on ARM, so the mac_x86_wheels.sh script will call
+Rosetta appropriately. This means both 11.0 and 10.9 SDK must be
+present.
 
 Unzip the spacepy source distribution made above into another directory. Copy
 over the developer/scripts/mac_x86_wheels.sh script into that directory

--- a/Doc/source/install_mac.rst
+++ b/Doc/source/install_mac.rst
@@ -13,9 +13,10 @@ possibility.
 Binary wheels are provided for both x86_64 (Intel) and 64-bit ARM
 (Apple Silicon, e.g. M1/M2/M3). They will install in any of these
 environments; most of the details below are to compile from
-source. x86_64 binaries are built on MacOS 11 (Big Sur) on x86_64 and
-compiled to work on 10.9 (Mavericks). ARM binaries are built on MacOS
-12 (Monterey) on M2 and compiled to work on 11 (Big Sur).
+source. ARM binaries are built on MacOS 12 (Monterey) on M2 and
+compiled to work on 11 (Big Sur). x86_64 binaries are also built and
+tested on MacOS 12 (Monterey) on M2, using Rosetta, and compiled to
+work on 10.9 (Mavericks).
 
 It is *not* recommended to mix environments if building from source,
 e.g. do not use Python from conda and gcc from Homebrew.

--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -12,6 +12,10 @@ This document presents user-visible changes in each release of SpacePy.
 ==========
 0.8.0 (2025-xx-xx)
 ------------------
+Mac binaries for x86_64 (Intel) are now built on ARM (Apple Silicon)
+under Rosetta; please `open a discussion
+<https://github.com/spacepy/spacepy/discussions/new?category=support-and-q-a>`_
+for any difficulties running on Intel Mac.
 
 New features
 ************

--- a/developer/scripts/mac_x86_wheels.sh
+++ b/developer/scripts/mac_x86_wheels.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env zsh
 
 # Get miniconda if you need it
-#wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-#bash ./Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/opt/miniconda
+#wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+#bash ./Miniconda3-latest-MacOSX-arm64.sh -b -p ~/opt/miniconda
 PYVER=3.8
 ENVNAME=spacepy${PYVER//.}
-~/opt/miniconda/bin/conda create -y -n ${ENVNAME} python=${PYVER}
+CONDA_SUBDIR=osx-64 ~/opt/miniconda/bin/conda create -y -n ${ENVNAME} python=${PYVER}
 source ~/opt/miniconda/bin/activate ${ENVNAME}
+conda config --env --set subdir osx-64
 conda install -y python-build wheel gfortran~=11.2.0
 BUILD=python-build
 rm -rf build
@@ -18,4 +19,4 @@ unset $(echo $badvars)
 export $(echo $badvars)
 ~/opt/miniconda/bin/conda env remove -y --name ${ENVNAME}
 #rm -rf ~/opt/miniconda
-#rm ./Miniconda3-latest-MacOSX-x86_64.sh
+#rm ./Miniconda3-latest-MacOSX-arm64.sh


### PR DESCRIPTION
This PR changes our distribution instructions and scripts to do the Mac x86_64 build on ARM. Fortunately this Just Works without any code changes.

It's gotten to be more difficult to keep an Intel Mac around just to do a SpacePy build. But [Apple's still supporting Intel for new OS releases until 2026](https://9to5mac.com/2025/06/09/apple-will-end-support-for-intel-macs/) so probably can't pull the plug just yet.

This _does_ rely on Xcode + Rosetta working, and there are rumors of that support eventually going away, so Intel is definitely on borrowed time.

To test this, I did a build from source on the M2 laptop I normally use for SpacePy distributions and installed the resulting binary wheel into a fresh conda environment, Python 3.10, on the x86 Mac I normally use for SpacePy. All the tests pass.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
