### PR TITLE
Short MANIFEST.in update

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,7 +13,6 @@ graft spacepy/data
 graft spacepy/irbempy/irbem-lib-*
 include spacepy/libspacepy/*.h
 include spacepy/libspacepy/*.c
-include spacepy/pybats/ctrace2dtest.c
 #Tests
 graft tests
 prune tests/htmlcov


### PR DESCRIPTION
MANIFEST.in referenced ctrace2dtest.c, which was removed in 1a0271f06268f1b0e61bef2efa3dd1c9c9e49b1f (2014!). I checked other MANIFEST.in contents, seem reasonable.

This showed up in the pybats hackathon in August. This wasn't the problem but it confused fixing other issues.

## PR Checklist

- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] (N/A) Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
