### PR TITLE
Test Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,24 @@ jobs:
             cdf-version: "3.9.1"
             cdf-munged-version: "39_1"
             dep-strategy: "newest"
+          - python-version: "3.14"
+            os: ubuntu-22.04
+            build-deps: "pip~=23.1.0 setuptools~=66.1.0 wheel~=0.34.2 cython~=3.0.0 pkgconfig"
+            numpy-version: "~=2.3.0"
+            piplist: "python-dateutil~=2.8.1 scipy~=1.16.0 matplotlib~=3.10.0 h5py~=3.13.0 astropy~=7.1.0 pandas~=2.3.0"
+            cflags: "-Wno-error=format-security"
+            cdf-version: "3.5.1"
+            cdf-munged-version: "35_1"
+            dep-strategy: "oldest"
+          - python-version: "3.14"
+            os: ubuntu-22.04
+            build-deps: "pip setuptools wheel"
+            numpy-version: ">=2.3.0"
+            piplist: "python-dateutil scipy matplotlib h5py astropy pandas"
+            cflags: ""
+            cdf-version: "3.9.1"
+            cdf-munged-version: "39_1"
+            dep-strategy: "newest"
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -246,10 +264,10 @@ jobs:
             cdf-version: "3.5.1"
             cdf-munged-version: "35_1"
             dep-strategy: "oldest"
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: ubuntu-22.04
             build-deps: "pip setuptools wheel cython"
-            numpy-version: ">=2.1.0"
+            numpy-version: ">=2.3.0"
             piplist: "python-dateutil scipy matplotlib h5py astropy sphinx numpydoc"
             cflags: ""
             cdf-version: "3.9.1"

--- a/developer/scripts/test_all.sh
+++ b/developer/scripts/test_all.sh
@@ -31,6 +31,8 @@ TESTS=(
        "3.12|pip setuptools wheel|numpy>=1.26.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
        "3.13|pip~=23.1.0 setuptools~=66.1.0 wheel~=0.34.2 cython~=3.0.0 pkgconfig|numpy~=2.1.0|python-dateutil~=2.8.1 scipy~=1.14.0 matplotlib~=3.6.0 h5py~=3.11.0 astropy~=6.1.0 pandas~=2.2.0|old"
        "3.13|pip setuptools wheel|numpy>=2.1.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
+       "3.14|pip~=23.1.0 setuptools~=66.1.0 wheel~=0.34.2 cython~=3.0.0 pkgconfig|numpy~=2.3.0|python-dateutil~=2.8.1 scipy~=1.16.0 matplotlib~=3.10.0 h5py~=3.13.0 astropy~=7.1.0 pandas~=2.3.0|old"
+       "3.14|pip setuptools wheel|numpy>=2.3.0|python-dateutil scipy matplotlib h5py astropy pandas|new"
       )
 for thisTest in "${TESTS[@]}"
 do

--- a/developer/scripts/test_linux_wheels.sh
+++ b/developer/scripts/test_linux_wheels.sh
@@ -2,7 +2,7 @@
 
 # Run unit tests on all the wheels, linux version
 
-VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12 3.13"
+VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14"
 
 for PYVER in ${VERSIONS}
 do

--- a/developer/scripts/test_mac_wheels.sh
+++ b/developer/scripts/test_mac_wheels.sh
@@ -2,7 +2,7 @@
 
 # Run unit tests on all the wheels, mac version
 
-VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12 3.13"
+VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14"
 
 for PYVER in ${=VERSIONS}
 do

--- a/developer/scripts/test_win_wheels.cmd
+++ b/developer/scripts/test_win_wheels.cmd
@@ -16,6 +16,7 @@ start /wait "" "%USERPROFILE%\Downloads\Miniconda3-latest-Windows-x86_64.exe" /I
 :: base environment needs to be activated
 CALL "%SYSTEMDRIVE%\Miniconda3\Scripts\activate"
 CALL conda update -y conda
+CALL conda create -y -n py314 python=3.14
 CALL conda create -y -n py313 python=3.13
 CALL conda create -y -n py312 python=3.12
 CALL conda create -y -n py311 python=3.11
@@ -25,7 +26,7 @@ CALL conda create -y -n py38 python=3.8
 CALL conda create -y -n py37 python=3.7
 
 
-FOR %%P in (37 38 39 310 311 312 313) DO CALL :installs %%P
+FOR %%P in (37 38 39 310 311 312 313 314) DO CALL :installs %%P
 
 GOTO :EOF
 


### PR DESCRIPTION
This PR updates our workflows and test / build scripts to test against Python 3.14. No changes were made to SpacePy code proper; tests pass.

One note: with the move of several dependencies (numpy, scipy, matplotlib) to more complicated build systems, testing the "oldest" version of dependencies is really "oldest version with binary installers available." Getting the build to run is terrible. Most of them don't go back to release binaries for older package versions when newer versions of Python are released. So this does mean our "oldest" version creeps forward with versions of Python, more aggressively than before. I thought I had a fuller explanation of this when I made that decision but can't find it back (#723 and #790 appear to be after that change).

## PR Checklist
- [X] Pull request has descriptive title
- [X] Pull request gives overview of changes
- [X] (N/A) New code has inline comments where necessary
- [X] (N/A) Any new modules, functions or classes have docstrings consistent with SpacePy style
- [X] (N/A) Added an entry to release notes if fixing a significant bug or providing a new feature
- [X] (N/A) New features and bug fixes should have unit tests
- [X] Relevant issues are linked to (e.g. `See issue #` or `Closes #`)
