### PR TITLE
Fix Shieldose2 crash when trapped and solar proton spectra differ in length

### DIFF
--- a/Doc/source/release_notes.rst
+++ b/Doc/source/release_notes.rst
@@ -23,6 +23,9 @@ Major bugfixes
 Several small issues in `~spacepy.ae9ap9` were fixed, relating to
 plotting and reading files with non-MJD timestamps.
 
+`~spacepy.irbempy.Shieldose2` no longer requires the trapped and solar
+(untrapped) proton spectra to have the same number of energy points.
+
 Other changes
 *************
 The IGRF provided with SpacePy (used in the default spacepy backend for

--- a/spacepy/irbempy/__init__.py
+++ b/spacepy/irbempy/__init__.py
@@ -1571,7 +1571,9 @@ class Shieldose2:
             argdict['emine'] = argdict['energy_e'].min()
             argdict['emaxe'] = argdict['energy_e'].max()
             argdict['len_p'] = len(argdict['energy_p_un'])
-            argdict['jpmax'] = len(argdict['energy_p_un'])
+            # jpmax sizes the trapped proton spectrum, jsmax the solar
+            # (untrapped) one; they may differ in length
+            argdict['jpmax'] = len(argdict['energy_p_tr'])
             argdict['jsmax'] = len(argdict['energy_p_un'])
             argdict['eminpun'] = argdict['energy_p_un'].min()
             argdict['emaxpun'] = argdict['energy_p_un'].max()

--- a/tests/test_irbempy.py
+++ b/tests/test_irbempy.py
@@ -623,6 +623,19 @@ class IRBEMShieldoseTests(spacepy_testing.TestPlot):
         self.assertRaises(ValueError, self.sd_default.set_flux,
                           jarr, earr, 'e')
 
+    def test_p_tr_un_different_length(self):
+        """Trapped and solar proton spectra may differ in length (regression #808)
+        """
+        sd = self.sd_default
+        en_tr = np.logspace(-1, np.log10(2000), 200)
+        en_un = np.logspace(-1, np.log10(2000), 50)
+        sd.set_flux(1e-9 * np.exp(-en_tr / 20), en_tr, 'p_tr')
+        sd.set_flux(1e-15 * np.exp(-en_un / 20), en_un, 'p_un')
+        sd.get_dose()
+        self.assertEqual(len(en_tr), sd.settings['jpmax'])
+        self.assertEqual(len(en_un), sd.settings['jsmax'])
+        self.assertTrue(sd.results)
+
     def test_plot_e(self):
         """Check for expected outputs in electron dose plot"""
         self.sd_default.get_dose()


### PR DESCRIPTION
Fixes #808.

Shieldose2.get_dose sized jpmax, the number of trapped-proton energy points passed to the Fortran routine, from energy_p_un (the solar/untrapped spectrum) instead of energy_p_tr (the trapped spectrum). The shieldose2.f contract is explicit that JPMAX is the trapped-proton point count and JSMAX the solar count (lines 44-45 and the EPin/ESin array declarations). When the two spectra have different lengths, the wrong count made Fortran either truncate the trapped spectrum or read zero-padding as real energies, producing wrong doses or the crash in the report. The default spectra are equal-length, which is why only custom-spectra users hit it.

The fix is one line, jpmax = len(energy_p_tr). Added a regression test in test_irbempy that runs get_dose with different-length trapped and solar spectra and asserts jpmax/jsmax match their respective arrays, plus a release note.

I verified the correctness against the shieldose2.f contract directly, and reproduced the crash-then-fix on an isolated copy of the expand_dict indexing logic. The unittest exercises the full get_dose path, which needs the compiled IRBEM Fortran extension, so it runs in CI rather than locally; I have noted that boundary.